### PR TITLE
8271142: package help is not displayed for missing X11/extensions/Xrandr.h

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,21 +40,21 @@ AC_DEFUN([HELP_MSG_MISSING_DEPENDENCY],
     PKGHANDLER_COMMAND=
 
     case $PKGHANDLER in
-      apt-get)
+      *apt-get)
         apt_help     $MISSING_DEPENDENCY ;;
-      yum)
+      *yum)
         yum_help     $MISSING_DEPENDENCY ;;
-      brew)
+      *brew)
         brew_help    $MISSING_DEPENDENCY ;;
-      port)
+      *port)
         port_help    $MISSING_DEPENDENCY ;;
-      pkgutil)
+      *pkgutil)
         pkgutil_help $MISSING_DEPENDENCY ;;
-      pkgadd)
+      *pkgadd)
         pkgadd_help  $MISSING_DEPENDENCY ;;
-      pacman)
+      *pacman)
         pacman_help  $MISSING_DEPENDENCY ;;
-      apk)
+      *apk)
         apk_help     $MISSING_DEPENDENCY ;;
     esac
 

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Compared with the origin commit in JDK-17, this backport is no clean for two reasons:
1. JDK11 doesn't have package handler `zypper`
2. JDK11 has the extra package handler `apk`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271142](https://bugs.openjdk.org/browse/JDK-8271142) needs maintainer approval

### Issue
 * [JDK-8271142](https://bugs.openjdk.org/browse/JDK-8271142): package help is not displayed for missing X11/extensions/Xrandr.h (**Bug** - P4 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2538/head:pull/2538` \
`$ git checkout pull/2538`

Update a local copy of the PR: \
`$ git checkout pull/2538` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2538`

View PR using the GUI difftool: \
`$ git pr show -t 2538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2538.diff">https://git.openjdk.org/jdk11u-dev/pull/2538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2538#issuecomment-1958590545)