### PR TITLE
8314830: runtime/ErrorHandling/ tests ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.test.lib.process.ProcessTools;
  * @bug 8194652
  * @summary Printing native stack shows an "error occurred during error reporting".
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @library /test/lib
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023，Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023，Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
  * @summary Test ErrorFileToStderr and ErrorFileToStdout
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @bug 8167108
  * @summary Nested ThreadsListHandle info should be in error handling output.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ProblematicFrameTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ProblematicFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @requires vm.flagless
  * @run driver ProblematicFrameTest
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary SafeFetch32 and SafeFetchN do not work in error handling
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @author Thomas Stuefe (SAP)
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @bug 8065896
  * @summary Synchronous signals during error reporting may terminate or hang VM process
  * @library /test/lib
+ * @requires vm.flagless
  * @author Thomas Stuefe (SAP)
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -27,6 +27,7 @@
  * @bug 8191101
  * @summary Show Registers on assert/guarantee
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family == "linux")
  * @author Thomas Stuefe (SAP)
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -26,6 +26,7 @@
  * @summary Test using -XX:+CrashOnOutOfMemoryError
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestCrashOnOutOfMemoryError
  * @bug 8138745
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary Test using -XX:ExitOnOutOfMemoryError
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestExitOnOutOfMemoryError
  * @bug 8138745
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test TestHeapDumpOnOutOfMemoryError
  * @summary Test verifies that -XX:HeapDumpOnOutOfMemoryError dump heap when OutOfMemory is thrown in heap
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestHeapDumpOnOutOfMemoryError run heap
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpPath.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test TestHeapDumpPath
  * @summary Test verifies that -XX:HeapDumpPath= supports directory as a parameter.
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestHeapDumpPath
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test using -XX:OnError=<cmd>
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @run main TestOnError
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary Test using single and multiple -XX:OnOutOfMemoryError=<cmd>
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run main TestOnOutOfMemoryError
  * @bug 8078470 8177522
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary ThreadsListHandle info should be in error handling output.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableThreadSMRStatistics ThreadsListHandleInErrorHandlingTest
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Hanging Error Reporting steps may lead to torn error logs
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family != "windows")
  * @author Thomas Stuefe (SAP)
  */
@@ -51,6 +52,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Error handling step timeouts should never be blocked by OnError etc.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family != "windows")
  * @run driver TimeoutInErrorHandlingTest with-on-error
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
  * @summary No hs-err file if fatal error is raised during dynamic initialization.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @requires os.family == "linux"
  */
@@ -48,8 +49,7 @@ public class VeryEarlyAssertTest {
   public static void main(String[] args) throws Exception {
 
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-version");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-version");
     Map<String, String> env = pb.environment();
     env.put("HOTSPOT_FATAL_ERROR_DURING_DYNAMIC_INITIALIZATION", "1");
 


### PR DESCRIPTION
I backport this for from 17u-dev.
test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileOverwriteTest.java
test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
test/hotspot/jtreg/runtime/ErrorHandling/TestGZippedHeapDumpOnOutOfMemoryError.java
these tests are not in 11, skipped, others are clean except Copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314830](https://bugs.openjdk.org/browse/JDK-8314830) needs maintainer approval

### Issue
 * [JDK-8314830](https://bugs.openjdk.org/browse/JDK-8314830): runtime/ErrorHandling/ tests ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2544/head:pull/2544` \
`$ git checkout pull/2544`

Update a local copy of the PR: \
`$ git checkout pull/2544` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2544`

View PR using the GUI difftool: \
`$ git pr show -t 2544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2544.diff">https://git.openjdk.org/jdk11u-dev/pull/2544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2544#issuecomment-1960801193)