### PR TITLE
8326564: Problem list HttpURLConnectionExpectContinueTest.java due to 8326503

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -549,7 +549,7 @@ java/net/DatagramSocket/SendDatagramToBadAddress.java           7143960 macosx-a
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326503 generic-all
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326564 generic-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -549,7 +549,7 @@ java/net/DatagramSocket/SendDatagramToBadAddress.java           7143960 macosx-a
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326564 generic-all
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326503 generic-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -549,6 +549,8 @@ java/net/DatagramSocket/SendDatagramToBadAddress.java           7143960 macosx-a
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326503 generic-all
+
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
The testcase java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java was newly added, it's backport from jdk23.

This testcase rely on jtreg-7, and it will fail run by jtreg-6: error: package org.junit.jupiter.api does not exist

If I use jtreg7 instead of jtreg6 to run all the testcases of jdk11u-dev, there are 424 testcases fail.
There are a total of 2 types failure:
1.javax/xml/jaxp testcases fail because of `java.security.AccessControlException: access denied (“java.util.PropertyPermission” “testng.thread.affinity” “read”)`
2. 5 tools/javac testcases fails, such as tools/javac/6257443/T6257443.java, the fail message is: `Error. Parse Exception: Bad classname provided for `clean’: foo.package-info`

So, the solution that use jtreg-7 instead of jtreg-6 is unacctable. Util we found a good solution to run this testcase success, this testcase should be excluded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8326564](https://bugs.openjdk.org/browse/JDK-8326564) needs maintainer approval

### Issue
 * [JDK-8326564](https://bugs.openjdk.org/browse/JDK-8326564): Problem list HttpURLConnectionExpectContinueTest.java due to 8326503 (**Sub-task** - P4 - Requested)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2545/head:pull/2545` \
`$ git checkout pull/2545`

Update a local copy of the PR: \
`$ git checkout pull/2545` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2545`

View PR using the GUI difftool: \
`$ git pr show -t 2545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2545.diff">https://git.openjdk.org/jdk11u-dev/pull/2545.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2545#issuecomment-1960898695)