### PR TITLE
8326594: Exclude test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -540,6 +540,8 @@ javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java 8042215 
 
 # jdk_net
 
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java 8326549 generic-all
+
 java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
 java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
 


### PR DESCRIPTION
This new test introduced by #2523 fails with JTreg 6.1, as currently used by 11u. As we won't be able to move to JTreg 7 until the 11.0.24 timeframe, we should exclude this test for 11.0.23.  The test will still be present for those who want to manually run the test using a later JTreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8326594](https://bugs.openjdk.org/browse/JDK-8326594) needs maintainer approval

### Issue
 * [JDK-8326594](https://bugs.openjdk.org/browse/JDK-8326594): Exclude test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2547/head:pull/2547` \
`$ git checkout pull/2547`

Update a local copy of the PR: \
`$ git checkout pull/2547` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2547`

View PR using the GUI difftool: \
`$ git pr show -t 2547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2547.diff">https://git.openjdk.org/jdk11u-dev/pull/2547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2547#issuecomment-1961735681)