### PR TITLE
8307955: Prefer to PTRACE_GETREGSET instead of PTRACE_GETREGS in method 'ps_proc.c::process_get_lwp_regs'

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -142,18 +142,18 @@ static bool process_get_lwp_regs(struct ps_prochandle* ph, pid_t pid, struct use
 #define PTRACE_GETREGS_REQ PT_GETREGS
 #endif
 
-#ifdef PTRACE_GETREGS_REQ
- if (ptrace_getregs(PTRACE_GETREGS_REQ, pid, user, NULL) < 0) {
-   print_debug("ptrace(PTRACE_GETREGS, ...) failed for lwp %d\n", pid);
-   return false;
- }
- return true;
-#elif defined(PTRACE_GETREGSET)
+#if defined(PTRACE_GETREGSET)
  struct iovec iov;
  iov.iov_base = user;
  iov.iov_len = sizeof(*user);
  if (ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, (void*) &iov) < 0) {
    print_debug("ptrace(PTRACE_GETREGSET, ...) failed for lwp %d\n", pid);
+   return false;
+ }
+ return true;
+#elif defined(PTRACE_GETREGS_REQ)
+ if (ptrace_getregs(PTRACE_GETREGS_REQ, pid, user, NULL) < 0) {
+   print_debug("ptrace(PTRACE_GETREGS, ...) failed for lwp %d\n", pid);
    return false;
  }
  return true;


### PR DESCRIPTION
Hi, This is also needed for riscv-port-jdk11u repo where we have full-reatured linux-riscv port for the same reason as jdk17u backport. The backport is not clean because the sparc architecture related code still exists. Risk is low as this is a small change prefering using `PTRACE_GETREGSET` instead of `PTRACE_GETREGS`. Tested on linux-aarch64 and linux-x86_64 platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307955](https://bugs.openjdk.org/browse/JDK-8307955) needs maintainer approval

### Issue
 * [JDK-8307955](https://bugs.openjdk.org/browse/JDK-8307955): Prefer to PTRACE_GETREGSET instead of PTRACE_GETREGS in method 'ps_proc.c::process_get_lwp_regs' (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2549/head:pull/2549` \
`$ git checkout pull/2549`

Update a local copy of the PR: \
`$ git checkout pull/2549` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2549`

View PR using the GUI difftool: \
`$ git pr show -t 2549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2549.diff">https://git.openjdk.org/jdk11u-dev/pull/2549.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2549#issuecomment-1963406725)