### PR TITLE
8316053: Open some swing tests 3

### DIFF
--- a/test/jdk/javax/swing/JDialog/bug4859570.java
+++ b/test/jdk/javax/swing/JDialog/bug4859570.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4859570
+ * @summary SwingUtilities.sharedOwnerFrame is never disposed
+ * @key headful
+ */
+
+import java.awt.Robot;
+import java.awt.Window;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+
+public class bug4859570 {
+    static Window owner;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JDialog dialog = new JDialog();
+            dialog.setTitle("bug4859570");
+            dialog.setBounds(100, 100, 100, 100);
+            dialog.setVisible(true);
+
+            owner = dialog.getOwner();
+            dialog.dispose();
+        });
+
+        Robot r = new Robot();
+        r.waitForIdle();
+        r.delay(1000);
+
+        SwingUtilities.invokeAndWait(() -> {
+            if (owner.isDisplayable()) {
+                throw new RuntimeException("The shared owner frame should be disposed.");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JDialog/bug4936652.java
+++ b/test/jdk/javax/swing/JDialog/bug4936652.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4936652
+ * @key headful
+ * @summary JDialog.setVisible, JDialog.dispose works incorrectly
+ */
+
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+
+public class bug4936652 {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            for (int i = 0 ; i < 100; i++) {
+                System.out.println("i: " + i);
+                JDialog o = new JDialog();
+                o.setTitle("bug4936652");
+                o.setVisible(true);
+                o.setVisible(false);
+                o.dispose();
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JLabel/bug4768127.java
+++ b/test/jdk/javax/swing/JLabel/bug4768127.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4768127
+ * @summary ToolTipManager not removed from components
+ * @key headful
+ */
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseMotionListener;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+public class bug4768127 {
+    static JFrame fr;
+    static volatile Point p;
+    static volatile JLabel[] label = new JLabel[2];
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("bug4768127");
+
+                JDesktopPane jdp = new JDesktopPane();
+                JInternalFrame jif1 = new JInternalFrame("jif 1");
+                JInternalFrame jif2 = new JInternalFrame("jif 2");
+                label[0] = new JLabel("Label 1");
+                label[1] = new JLabel("Label 2");
+
+                label[0].setToolTipText("tooltip 1");
+                jif1.getContentPane().add(label[0]);
+                jif1.setBounds(0, 0, 130, 160);
+                jif1.setVisible(true);
+                jdp.add(jif1);
+
+                label[1].setToolTipText("tooltip 2");
+                jif2.getContentPane().add(label[1]);
+                jif2.setBounds(210, 0, 130, 220);
+                jif2.setVisible(true);
+                jdp.add(jif2);
+
+                fr.getContentPane().add(jdp);
+                fr.setLocationRelativeTo(null);
+
+                fr.setSize(400, 300);
+                fr.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(10);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            clickLabel(0, robot);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            clickLabel(1, robot);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            clickLabel(0, robot);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            clickLabel(1, robot);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            MouseMotionListener[] mml = label[0].getMouseMotionListeners();
+            if (mml.length > 0 && mml[0] instanceof ToolTipManager) {
+                throw new RuntimeException("Extra MouseMotionListeners were added to the label \"Label 1\" by ToolTipManager");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    static void clickLabel(int i, Robot robot) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            p = label[i].getLocationOnScreen();
+        });
+        final Rectangle rect = label[i].getBounds();
+        robot.mouseMove(p.x + rect.width / 2, p.y + rect.height / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        //Generate mouseMotionEvent
+        robot.mouseMove(p.x + rect.width / 2 + 3, p.y + rect.height / 2 + 3);
+        robot.mouseMove(p.x + rect.width / 2, p.y + rect.height / 2);
+    }
+}

--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4371134
+ * @key headful
+ * @summary displays an animating fps (frames per second)
+ *  counter.  When the window is dragged from monitor to monitor,
+ *  the speed of the animation should not change too greatly.
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @run main/manual MultimonVImage
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JViewport;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class MultimonVImage {
+    private static final String instructionsText =
+            "This test should be run on any Windows platform that\n" +
+            "supports multiple monitors.\n" +
+            "You will see an animating fps (frames per second) counter at\n" +
+            "the bottom of the window.  Drag the window into the other monitor\n" +
+            "and that counter should not change drastically.  If the counter\n" +
+            "is much lower on one monitor than the other (barring situations\n" +
+            "described below) then the back buffer may not be accelerated\n" +
+            "on the second monitor and the test fails.\n" +
+            "Situations in which performance will differ even though there\n" +
+            "is acceleration on both monitors include:\n" +
+            "  - different bit depths on each monitor.  The higher the bits\n" +
+            "    per pixel, the more data to push and the lower the fps number.\n" +
+            "    Set the bit depths to be the same on both monitors to work\n" +
+            "    around this issue.\n" +
+            "  - the amount of acceleration available on each video card differs,\n" +
+            "    so if your system uses different video cards then you should\n" +
+            "    expect some difference between the cards.  To work around this\n" +
+            "    issue, try to use the same or similar video cards for each monitor.";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("MultimonVImage Instructions")
+                .instructions(instructionsText)
+                .testTimeOut(5)
+                .rows(25)
+                .columns(50)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AnimatingFrame af = new AnimatingFrame();
+            af.test();
+            af.run();
+
+            PassFailJFrame.addTestWindow(af);
+            PassFailJFrame.positionTestWindow(af,
+                    PassFailJFrame.Position.HORIZONTAL);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class FrameCounter {
+
+    String fpsString = "Calculating...";
+    long startTime, endTime;
+    int numFrames;
+
+    public FrameCounter() {
+        startTime = System.currentTimeMillis();
+    }
+
+    public String addFrame() {
+        ++numFrames;
+        return calculateFPS();
+    }
+
+    String calculateFPS() {
+        endTime = System.currentTimeMillis();
+        double seconds = ((double) endTime - (double) startTime) / 1000;
+        if (seconds > 1) {
+            int fps = (int) (numFrames / seconds);
+            fpsString = fps + " fps";
+            startTime = endTime;
+            numFrames = 0;
+        }
+        return fpsString;
+    }
+}
+
+class AnimatingComponent extends JViewport {
+
+    FrameCounter frameCounter;
+    int boxX, boxY;
+    int boxW, boxH;
+    int xStep = 1;
+
+    public AnimatingComponent() {
+        frameCounter = new FrameCounter();
+        boxX = 0;
+        boxY = 0;
+        boxW = 100;
+        boxH = 100;
+    }
+
+    public void paintComponent(Graphics g) {
+        boxX += xStep;
+        if (boxX <= 0 || (boxX + boxW) > getWidth()) {
+            xStep = -xStep;
+            boxX += (2 * xStep);
+        }
+        g.setColor(Color.white);
+        g.fillRect(0, 0, getWidth(), getHeight());
+        g.setColor(Color.green);
+        for (int i = 0; i < 100; ++i) {
+            g.fillRect(boxX, boxY, 100, 100);
+        }
+        g.setColor(Color.black);
+        g.drawString(frameCounter.addFrame(), 200, getHeight() - 30);
+    }
+}
+
+class AnimatingFrame extends JFrame implements Runnable {
+    JViewport component;
+    Thread thread;
+
+    public AnimatingFrame() {
+        setSize(500, 500);
+        setTitle("MultimonVImage Demo");
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                System.exit(0);
+            }
+        });
+
+        component = new AnimatingComponent();
+        component.setPreferredSize(new Dimension(500, 500));
+        setContentPane(component);
+        component.setVisible(true);
+
+        setLocationRelativeTo(null);
+        pack();
+        setVisible(true);
+    }
+
+    public void test() {
+        thread = new Thread(this);
+        thread.setPriority(Thread.MIN_PRIORITY);
+        thread.start();
+    }
+
+    public void run() {
+        Thread me = Thread.currentThread();
+        while (thread == me) {
+            component.repaint();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.
test/jdk/javax/swing/MultiMonitor/MultimonVImage.java error as expected, will backport for JDK-8318580 to fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316053](https://bugs.openjdk.org/browse/JDK-8316053) needs maintainer approval

### Issue
 * [JDK-8316053](https://bugs.openjdk.org/browse/JDK-8316053): Open some swing tests 3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2550/head:pull/2550` \
`$ git checkout pull/2550`

Update a local copy of the PR: \
`$ git checkout pull/2550` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2550`

View PR using the GUI difftool: \
`$ git pr show -t 2550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2550.diff">https://git.openjdk.org/jdk11u-dev/pull/2550.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2550#issuecomment-1963433011)