### PR TITLE
8326503: [11u] java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fail because of package org.junit.jupiter.api does not exist

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -29,8 +29,8 @@
  * @run junit/othervm HttpURLConnectionExpectContinueTest
  */
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 
 public class HttpURLConnectionExpectContinueTest {
 
-    class Control {
+    private static class Control {
         volatile ServerSocket serverSocket = null;
         volatile boolean stop = false;
         volatile boolean respondWith100Continue = false;
@@ -55,19 +55,19 @@ public class HttpURLConnectionExpectContinueTest {
         volatile String response = null;
     }
 
-    private Thread serverThread = null;
-    private volatile Control control;
+    private static Thread serverThread = null;
+    private static volatile Control control;
     static final Logger logger;
 
     static {
+        control = new Control();
         logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
         logger.setLevel(Level.ALL);
         Logger.getLogger("").getHandlers()[0].setLevel(Level.ALL);
     }
 
-    @Before
-    public void startServerSocket() throws Exception {
-        Control control = this.control = new Control();
+    @BeforeClass
+    public static void startServerSocket() throws Exception {
 
         control.serverSocket = new ServerSocket();
         control.serverSocket.setReuseAddress(true);
@@ -168,9 +168,8 @@ public class HttpURLConnectionExpectContinueTest {
         serverThread.start();
     }
 
-    @After
-    public void stopServerSocket() throws Exception {
-        Control control = this.control;
+    @AfterClass
+    public static void stopServerSocket() throws Exception {
         control.stop = true;
         control.serverSocket.close();
         serverThread.join();
@@ -179,7 +178,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestAndNoExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -205,7 +203,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestWithExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -231,7 +228,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestWithDoubleExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -257,7 +253,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestAndNoExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -284,7 +279,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestWithExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -311,7 +305,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestWithDoubleExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -338,7 +331,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestAndNoExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -365,7 +357,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestWithExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -392,7 +383,6 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestWithDoubleExpect100ContinueResponse";
-        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -29,10 +29,9 @@
  * @run junit/othervm HttpURLConnectionExpectContinueTest
  */
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,9 +43,8 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HttpURLConnectionExpectContinueTest {
 
     class Control {
@@ -67,7 +65,7 @@ public class HttpURLConnectionExpectContinueTest {
         Logger.getLogger("").getHandlers()[0].setLevel(Level.ALL);
     }
 
-    @BeforeAll
+    @Before
     public void startServerSocket() throws Exception {
         Control control = this.control = new Control();
 
@@ -170,7 +168,7 @@ public class HttpURLConnectionExpectContinueTest {
         serverThread.start();
     }
 
-    @AfterAll
+    @After
     public void stopServerSocket() throws Exception {
         Control control = this.control;
         control.stop = true;
@@ -198,10 +196,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -224,10 +222,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -250,10 +248,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -277,10 +275,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -304,10 +302,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -331,10 +329,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -358,10 +356,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -385,10 +383,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     @Test
@@ -412,10 +410,10 @@ public class HttpURLConnectionExpectContinueTest {
         int responseCode = connection.getResponseCode();
         String responseBody = new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
         System.err.println("response body: " + responseBody);
-        assertTrue(responseCode == 200,
-                String.format("Expected 200 response, instead received %s", responseCode));
-        assertTrue(body.equals(responseBody),
-                String.format("Expected response %s, instead received %s", body, responseBody));
+        assertTrue(String.format("Expected 200 response, instead received %s", responseCode),
+                responseCode == 200);
+        assertTrue(String.format("Expected response %s, instead received %s", body, responseBody),
+                body.equals(responseBody));
     }
 
     // Creates a connection with all the common settings used in each test


### PR DESCRIPTION
This patch addresses the test failures described in https://bugs.openjdk.org/browse/JDK-8326503 due to junit 5 package org.junit.jupiter.api which does not exist in older junit 4 that is being used here now for 11u builds by refactoring junit 5 api use to available junit 4 api.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326503](https://bugs.openjdk.org/browse/JDK-8326503) needs maintainer approval

### Issue
 * [JDK-8326503](https://bugs.openjdk.org/browse/JDK-8326503): [11u] java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fail because of package org.junit.jupiter.api does not exist (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2553/head:pull/2553` \
`$ git checkout pull/2553`

Update a local copy of the PR: \
`$ git checkout pull/2553` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2553`

View PR using the GUI difftool: \
`$ git pr show -t 2553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2553.diff">https://git.openjdk.org/jdk11u-dev/pull/2553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2553#issuecomment-1963821842)