### PR TITLE
      Backport 905b7639424a0fa80f81f734f6fdae1b5018a14a 

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3506,12 +3506,13 @@ public final class Class<T> implements java.io.Serializable,
 
     // Fetches the factory for reflective objects
     private static ReflectionFactory getReflectionFactory() {
-        if (reflectionFactory == null) {
-            reflectionFactory =
-                java.security.AccessController.doPrivileged
-                    (new ReflectionFactory.GetReflectionFactoryAction());
+        var factory = reflectionFactory;
+        if (factory != null) {
+            return factory;
         }
-        return reflectionFactory;
+        return reflectionFactory =
+                java.security.AccessController.doPrivileged
+                        (new ReflectionFactory.GetReflectionFactoryAction());
     }
     private static ReflectionFactory reflectionFactory;
 


### PR DESCRIPTION
This is a backport of https://bugs.openjdk.org/browse/JDK-8261404
8261404: Class.getReflectionFactory() is not thread-safe

Original commit https://github.com/openjdk/jdk/commit/905b7639424a0fa80f81f734f6fdae1b5018a14a