### PR TITLE
8281507: Two javac tests have bad jtreg `@clean` tags

### DIFF
--- a/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
+++ b/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
@@ -27,10 +27,10 @@
  * @summary NULLCHK is emitted as Object.getClass
  * @compile -source 6 -target 6 TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 6
- * @clean TestSyntheticNullChecks*
+ * @clean *
  * @compile -source 7 -target 7 TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 7
- * @clean TestSyntheticNullChecks*
+ * @clean *
  * @compile TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 9
  */

--- a/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
+++ b/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
@@ -34,27 +34,27 @@ import java.io.File;
  * @summary Test that StringConcat is working for JDK >= 9
  * @modules jdk.jdeps/com.sun.tools.classfile
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -source 6 -target 6 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -source 7 -target 7 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -source 8 -target 8 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=inline -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=indy -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=indyWithConstants -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  */


### PR DESCRIPTION
Semi-clean backport on the way to jtreg update. Both files still have source/target=6 blocks, which need to be handled as well.

Additional testing:
 - [x] Affected tests now pass with jtreg 7.3.1+1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8281507](https://bugs.openjdk.org/browse/JDK-8281507) needs maintainer approval

### Issue
 * [JDK-8281507](https://bugs.openjdk.org/browse/JDK-8281507): Two javac tests have bad jtreg `@<!---->clean` tags (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2556/head:pull/2556` \
`$ git checkout pull/2556`

Update a local copy of the PR: \
`$ git checkout pull/2556` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2556`

View PR using the GUI difftool: \
`$ git pr show -t 2556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2556.diff">https://git.openjdk.org/jdk11u-dev/pull/2556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2556#issuecomment-1963946633)