### PR TITLE
8314552: Fix javadoc tests to work with jtreg 7

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,8 @@ public class TestSerialVersionUID extends JavadocTester {
 
     @Test
     void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 testSrc("C.java"));
         checkExit(Exit.OK);
 

--- a/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ public class TestTagMisuse extends JavadocTester {
 
     @Test
     void test() {
-        javadoc("-Xdoclint:none",
+        javadoc("-encoding", "UTF-8",
+                "-Xdoclint:none",
                 "-d", "out",
                 testSrc("TestTagMisuse.java"));
         checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ public class TestThrowsHead extends JavadocTester {
 
     @Test
     void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 testSrc("C.java"));
         checkExit(Exit.OK);
 

--- a/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,8 @@ public class TestUnnamedPackage extends JavadocTester {
 
     @Test
     void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 "-sourcepath", testSrc,
                 testSrc("C.java"));
         checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
+++ b/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ public class Test {
     public static void main(String... args) throws Exception {
         File testSrc = new File(System.getProperty("test.src"));
         String[] jdoc_args = {
+            "-encoding", "UTF-8",
             "-d", "out",
             new File(testSrc, Test.class.getSimpleName() + ".java").getPath()
         };


### PR DESCRIPTION
This is a variant of the fix for JDK 11u, required for jtreg upgrade.

Additional testing:
 - [x] `langtools:all` passes with jtreg-7.3.1+1 (some known failures fixed by other PRs)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314552](https://bugs.openjdk.org/browse/JDK-8314552) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314552](https://bugs.openjdk.org/browse/JDK-8314552): Fix javadoc tests to work with jtreg 7 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2557/head:pull/2557` \
`$ git checkout pull/2557`

Update a local copy of the PR: \
`$ git checkout pull/2557` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2557`

View PR using the GUI difftool: \
`$ git pr show -t 2557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2557.diff">https://git.openjdk.org/jdk11u-dev/pull/2557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2557#issuecomment-1964099746)