### PR TITLE
8292182: [TESTLIB] Enhance JAXPPolicyManager to setup required permissions for jtreg version 7 jar

### DIFF
--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPPolicyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,9 @@
 package jaxp.library;
 
 
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -161,7 +163,7 @@ public class JAXPPolicyManager {
  */
 class TestPolicy extends Policy {
     private final static Set<String> TEST_JARS =
-         Set.of("jtreg.jar", "javatest.jar", "testng.jar", "jcommander.jar");
+         Set.of("jtreg.*jar", "javatest.*jar", "testng.*jar", "jcommander.*jar");
     private final PermissionCollection permissions = new Permissions();
 
     private ThreadLocal<Map<Integer, Permission>> transientPermissions = new ThreadLocal<>();
@@ -213,9 +215,10 @@ class TestPolicy extends Policy {
     private boolean isTestMachineryDomain(ProtectionDomain domain) {
         CodeSource cs = (domain == null) ? null : domain.getCodeSource();
         URL loc = (cs == null) ? null : cs.getLocation();
-        String path = (loc == null) ? null : loc.getPath();
-        return path != null && TEST_JARS.stream()
-                                .filter(path::endsWith)
+        URI uri = (loc == null) ? null : URI.create(loc.toString());
+        String name = (uri == null) ? null : Path.of(uri).getFileName().toString();
+        return name != null && TEST_JARS.stream()
+                                .filter(name::matches)
                                 .findAny()
                                 .isPresent();
     }


### PR DESCRIPTION
Clean backport to enable jtreg 7 for jaxp tests.

Additional testing:
 - [x] `jaxp:all` still passes with jtreg-6.2
 - [x] `jaxp:all` now fully passes with jtreg-7.3.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8292182](https://bugs.openjdk.org/browse/JDK-8292182) needs maintainer approval

### Issue
 * [JDK-8292182](https://bugs.openjdk.org/browse/JDK-8292182): [TESTLIB] Enhance JAXPPolicyManager to setup required permissions for jtreg version 7 jar (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2558/head:pull/2558` \
`$ git checkout pull/2558`

Update a local copy of the PR: \
`$ git checkout pull/2558` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2558`

View PR using the GUI difftool: \
`$ git pr show -t 2558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2558.diff">https://git.openjdk.org/jdk11u-dev/pull/2558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2558#issuecomment-1964594854)