### PR TITLE
8326487: ZipFileSystem.getPath("").getFileName() returns null instead of an empty string

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
@@ -416,7 +416,7 @@ final class ZipPath implements Path {
             index = 0;
             if (path.length == 0) {
                 // empty path has one name
-                count = 1;
+                count = 0;
             } else {
                 while (index < path.length) {
                     byte c = path[index++];


### PR DESCRIPTION
In the scenario of using ZipFileSystem, when getPath("").getFileName() returns null, change getPath("").getNameCount() to 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8326487](https://bugs.openjdk.org/browse/JDK-8326487) needs maintainer approval

### Issue
 * [JDK-8326487](https://bugs.openjdk.org/browse/JDK-8326487): ZipFileSystem.getPath("").getFileName() returns null instead of an empty string (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2560/head:pull/2560` \
`$ git checkout pull/2560`

Update a local copy of the PR: \
`$ git checkout pull/2560` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2560`

View PR using the GUI difftool: \
`$ git pr show -t 2560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2560.diff">https://git.openjdk.org/jdk11u-dev/pull/2560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2560#issuecomment-1966069421)