### PR TITLE
8318580: "javax/swing/MultiMonitor/MultimonVImage.java failing with Error. Can't find library: /open/test/jdk/java/awt/regtesthelpers" after JDK-8316053

### DIFF
--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -28,7 +28,8 @@
  * @summary displays an animating fps (frames per second)
  *  counter.  When the window is dragged from monitor to monitor,
  *  the speed of the animation should not change too greatly.
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual MultimonVImage
  */
 
@@ -181,3 +182,4 @@ class AnimatingFrame extends JFrame implements Runnable {
         }
     }
 }
+


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318580](https://bugs.openjdk.org/browse/JDK-8318580) needs maintainer approval

### Issue
 * [JDK-8318580](https://bugs.openjdk.org/browse/JDK-8318580): "javax/swing/MultiMonitor/MultimonVImage.java failing with Error. Can't find library: /open/test/jdk/java/awt/regtesthelpers" after JDK-8316053 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2567/head:pull/2567` \
`$ git checkout pull/2567`

Update a local copy of the PR: \
`$ git checkout pull/2567` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2567`

View PR using the GUI difftool: \
`$ git pr show -t 2567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2567.diff">https://git.openjdk.org/jdk11u-dev/pull/2567.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2567#issuecomment-1968388553)