### PR TITLE
8323717: Introduce test keyword for tests that need external dependencies

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -29,7 +29,8 @@
 # The list of keywords supported in this test suite
 # randomness:           test uses randomness, test cases differ from run to run
 # cgroups:              test uses cgroups
-keys=cte_test jcmd nmt regression gc stress metaspace headful intermittent randomness cgroups
+# external-dep:         test requires external dependencies to work
+keys=cte_test jcmd nmt regression gc stress metaspace headful intermittent randomness cgroups external-dep
 
 groups=TEST.groups TEST.quick-groups
 

--- a/test/hotspot/jtreg/applications/jcstress/TestGenerator.java
+++ b/test/hotspot/jtreg/applications/jcstress/TestGenerator.java
@@ -96,6 +96,7 @@ public class TestGenerator {
     public static String DESC_FORMAT = "\n"
             + "/**\n"
             + " * @test %1$s\n"
+            + " * @key external-dep\n"
             + " * @library /test/lib /\n"
             + " * @run driver/timeout=21600 " + JcstressRunner.class.getName()
                     // verbose output

--- a/test/hotspot/jtreg/applications/jcstress/accessAtomic.java
+++ b/test/hotspot/jtreg/applications/jcstress/accessAtomic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test accessAtomic
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.accessAtomic\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/acqrel.java
+++ b/test/hotspot/jtreg/applications/jcstress/acqrel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test acqrel
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.acqrel\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/atomicity.java
+++ b/test/hotspot/jtreg/applications/jcstress/atomicity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test atomicity
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.atomicity\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/atomics.java
+++ b/test/hotspot/jtreg/applications/jcstress/atomics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test atomics
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.atomics\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/causality.java
+++ b/test/hotspot/jtreg/applications/jcstress/causality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test causality
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.causality\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/coherence.java
+++ b/test/hotspot/jtreg/applications/jcstress/coherence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test coherence
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.coherence\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/collections.java
+++ b/test/hotspot/jtreg/applications/jcstress/collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test collections
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.collections\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/copy.java
+++ b/test/hotspot/jtreg/applications/jcstress/copy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test copy
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.copy\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/countdownlatch.java
+++ b/test/hotspot/jtreg/applications/jcstress/countdownlatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test countdownlatch
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.countdownlatch\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/defaultValues.java
+++ b/test/hotspot/jtreg/applications/jcstress/defaultValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test defaultValues
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.defaultValues\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/executors.java
+++ b/test/hotspot/jtreg/applications/jcstress/executors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test executors
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.executors\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/fences.java
+++ b/test/hotspot/jtreg/applications/jcstress/fences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test fences
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.fences\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/future.java
+++ b/test/hotspot/jtreg/applications/jcstress/future.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test future
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.future\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/init.java
+++ b/test/hotspot/jtreg/applications/jcstress/init.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test init
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.init\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/initClass.java
+++ b/test/hotspot/jtreg/applications/jcstress/initClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test initClass
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.initClass\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/initLen.java
+++ b/test/hotspot/jtreg/applications/jcstress/initLen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test initLen
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.initLen\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/interrupt.java
+++ b/test/hotspot/jtreg/applications/jcstress/interrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test interrupt
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.interrupt\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/locks.java
+++ b/test/hotspot/jtreg/applications/jcstress/locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test locks
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.locks\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/memeffects.java
+++ b/test/hotspot/jtreg/applications/jcstress/memeffects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test memeffects
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.memeffects\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/mxbeans.java
+++ b/test/hotspot/jtreg/applications/jcstress/mxbeans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test mxbeans
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.mxbeans\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/oota.java
+++ b/test/hotspot/jtreg/applications/jcstress/oota.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test oota
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.oota\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/seqcst.java
+++ b/test/hotspot/jtreg/applications/jcstress/seqcst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test seqcst
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.seqcst\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/singletons.java
+++ b/test/hotspot/jtreg/applications/jcstress/singletons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test singletons
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.singletons\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/strings.java
+++ b/test/hotspot/jtreg/applications/jcstress/strings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test strings
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.strings\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/tearing.java
+++ b/test/hotspot/jtreg/applications/jcstress/tearing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test tearing
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.tearing\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/threadlocal.java
+++ b/test/hotspot/jtreg/applications/jcstress/threadlocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test threadlocal
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.threadlocal\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/unsafe.java
+++ b/test/hotspot/jtreg/applications/jcstress/unsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test unsafe
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.unsafe\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/varhandles.java
+++ b/test/hotspot/jtreg/applications/jcstress/varhandles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test varhandles
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.varhandles\.
  */

--- a/test/hotspot/jtreg/applications/jcstress/volatiles.java
+++ b/test/hotspot/jtreg/applications/jcstress/volatiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /**
  * @test volatiles
+ * @key external-dep
  * @library /test/lib /
  * @run driver/timeout=21600 applications.jcstress.JcstressRunner -v -t org.openjdk.jcstress.tests.volatiles\.
  */

--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key external-dep
  * @library /test/lib
  * @run driver Scimark
  */


### PR DESCRIPTION
Semi-clean backport to allow running all tests cleanly. There was a contextual conflict in `TEST.ROOT` due to the absence of many keyword clean up patches, which I think can be backported and resolved later.

Additional testing:
 - [x] `applications/jcstress applications/scimark` are now properly skipped with `JTREG_KEYWORDS=\!external-dep`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323717](https://bugs.openjdk.org/browse/JDK-8323717) needs maintainer approval

### Issue
 * [JDK-8323717](https://bugs.openjdk.org/browse/JDK-8323717): Introduce test keyword for tests that need external dependencies (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2569/head:pull/2569` \
`$ git checkout pull/2569`

Update a local copy of the PR: \
`$ git checkout pull/2569` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2569`

View PR using the GUI difftool: \
`$ git pr show -t 2569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2569.diff">https://git.openjdk.org/jdk11u-dev/pull/2569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2569#issuecomment-1968457964)