### PR TITLE
8326938: [11u] JDK-8214908 broke two CTW tests

### DIFF
--- a/test/hotspot/jtreg/applications/ctw/modules/jdk_jfr.java
+++ b/test/hotspot/jtreg/applications/ctw/modules/jdk_jfr.java
@@ -26,8 +26,7 @@
  * @summary run CTW for all classes from jdk.jfr module
  *
  * @library /test/lib / /testlibrary/ctw/src
- * @modules java.base/jdk.internal.access
- *          java.base/jdk.internal.jimage
+ * @modules java.base/jdk.internal.jimage
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.reflect
  * @modules jdk.jfr

--- a/test/hotspot/jtreg/applications/ctw/modules/jdk_management_jfr.java
+++ b/test/hotspot/jtreg/applications/ctw/modules/jdk_management_jfr.java
@@ -26,8 +26,7 @@
  * @summary run CTW for all classes from jdk.management.jfr module
  *
  * @library /test/lib / /testlibrary/ctw/src
- * @modules java.base/jdk.internal.access
- *          java.base/jdk.internal.jimage
+ * @modules java.base/jdk.internal.jimage
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.reflect
  * @modules jdk.management.jfr


### PR DESCRIPTION
This is a 11u-specific test bug. Not sure how the original backport passed testing, because the failure reproduces reliably. See more investigation in the bug itself. This PR reverts the entire https://github.com/openjdk/jdk11u-dev/commit/9d4da7c1dfb829ef5973857c2707b0feadeaa8c7 commit.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `applications/ctw/modules` now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326938](https://bugs.openjdk.org/browse/JDK-8326938) needs maintainer approval

### Issue
 * [JDK-8326938](https://bugs.openjdk.org/browse/JDK-8326938): [11u] JDK-8214908 broke two CTW tests (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2570/head:pull/2570` \
`$ git checkout pull/2570`

Update a local copy of the PR: \
`$ git checkout pull/2570` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2570`

View PR using the GUI difftool: \
`$ git pr show -t 2570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2570.diff">https://git.openjdk.org/jdk11u-dev/pull/2570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2570#issuecomment-1968653041)