### PR TITLE
8315834: Open source several Swing JSpinner related tests

### DIFF
--- a/test/jdk/javax/swing/JSpinner/bug4522737.java
+++ b/test/jdk/javax/swing/JSpinner/bug4522737.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JComponent;
+import javax.swing.JSpinner;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+/*
+ * @test
+ * @bug 4522737
+ * @summary Cannot serialize JSpinner twice.
+ * @run main bug4522737
+ */
+
+public class bug4522737 {
+    public static void main(String[] args) throws Exception {
+        final JComponent originalComponent = new JSpinner();
+
+        ByteArrayOutputStream byteArrayOutputStream =
+                new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream =
+                new ObjectOutputStream(byteArrayOutputStream);
+        objectOutputStream.writeObject(originalComponent);
+
+        objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+        objectOutputStream.writeObject(originalComponent);
+
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JSpinner/bug4656590.java
+++ b/test/jdk/javax/swing/JSpinner/bug4656590.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerDateModel;
+import javax.swing.SpinnerListModel;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4656590
+ * @summary JSpinner.setFont() does nothing
+ * @key headful
+ * @run main bug4656590
+ */
+
+public class bug4656590 {
+    private static JSpinner[] spinner = new JSpinner[6];
+    private static Font font = new Font("Arial", Font.BOLD, 24);
+    private static volatile boolean failed = false;
+    private static JFrame frame;
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.getContentPane().setLayout(new GridLayout(3, 2));
+                spinner[0] = new JSpinner();
+                spinner[0].setModel(new SpinnerNumberModel());
+                spinner[0].setFont(font);
+                frame.getContentPane().add(spinner[0]);
+
+                spinner[1] = new JSpinner();
+                spinner[1].setModel(new SpinnerDateModel());
+                spinner[1].setFont(font);
+                frame.getContentPane().add(spinner[1]);
+
+                spinner[2] = new JSpinner();
+                spinner[2].setModel(new SpinnerListModel
+                        (new Object[]{"one", "two", "three"}));
+                spinner[2].setFont(font);
+                frame.getContentPane().add(spinner[2]);
+
+                spinner[3] = new JSpinner();
+                spinner[3].setFont(font);
+                spinner[3].setModel(new SpinnerNumberModel());
+                frame.getContentPane().add(spinner[3]);
+
+                spinner[4] = new JSpinner();
+                spinner[4].setFont(font);
+                spinner[4].setModel(new SpinnerDateModel());
+                frame.getContentPane().add(spinner[4]);
+
+                spinner[5] = new JSpinner();
+                spinner[5].setFont(font);
+                spinner[5].setModel(new SpinnerListModel
+                        (new Object[]{"one", "two", "three"}));
+                frame.getContentPane().add(spinner[5]);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                JFormattedTextField ftf;
+                for (int i = 1; i < 6; i++) {
+                    ftf = ((JSpinner.DefaultEditor)
+                            spinner[i].getEditor()).getTextField();
+                    if (!ftf.getFont().equals(font)) {
+                        failed = true;
+                    }
+                }
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (failed) {
+                throw new RuntimeException("JSpinner.setFont() " +
+                        "doesn't set the font properly");
+            }
+            System.out.println("Test Passed!");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JSpinner/bug4680204.java
+++ b/test/jdk/javax/swing/JSpinner/bug4680204.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4680204
+ * @summary JSpinner shows ToolTipText only on it's border
+ * @key headful
+ * @run main bug4680204
+ */
+
+public class bug4680204 {
+
+    private static JSpinner sp1, sp2;
+    private static final String TOOL_TIP_TEXT = "ToolTipText";
+    private static JFrame frame;
+    private static Robot robot;
+    private static volatile boolean failed = false;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.getContentPane().setLayout(new FlowLayout());
+
+                sp1 = new JSpinner(new SpinnerNumberModel(1, 1, 100, 1));
+                sp1.setToolTipText(TOOL_TIP_TEXT);
+                frame.getContentPane().add(sp1);
+
+                sp2 = new JSpinner();
+                sp2.setToolTipText(TOOL_TIP_TEXT);
+                frame.getContentPane().add(sp2);
+                sp2.setModel(new SpinnerNumberModel(1, 1, 100, 1));
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                Component[] children = sp1.getComponents();
+                for (int i = 0; i < children.length; i++) {
+                    if (children[i] instanceof JSpinner.DefaultEditor) {
+                        JTextField tf = ((JSpinner.DefaultEditor) children[i]).getTextField();
+                        if (!TOOL_TIP_TEXT.equals(tf.getToolTipText())) {
+                            failed = true;
+                        }
+                    } else if (children[i] instanceof JComponent) {
+                        String text = ((JComponent) children[i]).getToolTipText();
+                        if (!TOOL_TIP_TEXT.equals(text)) {
+                            failed = true;
+                        }
+                    }
+                }
+
+                children = sp2.getComponents();
+                for (int i = 0; i < children.length; i++) {
+                    if (children[i] instanceof JSpinner.DefaultEditor) {
+                        JTextField tf = ((JSpinner.DefaultEditor) children[i]).getTextField();
+                        if (!TOOL_TIP_TEXT.equals(tf.getToolTipText())) {
+                            failed = true;
+                        }
+                    } else if (children[i] instanceof JComponent) {
+                        String text = ((JComponent) children[i]).getToolTipText();
+                        if (!TOOL_TIP_TEXT.equals(text)) {
+                            failed = true;
+                        }
+                    }
+                }
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (failed) {
+                throw new RuntimeException("The tooltip text is not correctly set for JSpinner");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JSpinner/bug4862257.java
+++ b/test/jdk/javax/swing/JSpinner/bug4862257.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JSpinner;
+
+/*
+ * @test
+ * @bug 4862257
+ * @summary Class cast Exception occurred when JButton is set to JSpinner
+ * @run main bug4862257
+ */
+
+public class bug4862257 {
+    public static void main(String[] argv) {
+        JSpinner spinner = new JSpinner();
+        spinner.setEditor(new JButton("JButton"));
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JSpinner/bug5104421.java
+++ b/test/jdk/javax/swing/JSpinner/bug5104421.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.SpinnerDateModel;
+
+/*
+ * @test
+ * @bug 5104421
+ * @summary SpinnerDateModel.setValue(Object) throws exception with incorrect message
+ * @run main bug5104421
+ */
+
+public class bug5104421 {
+    public static void main(String[] args) {
+        SpinnerDateModel model = new SpinnerDateModel();
+        try {
+            model.setValue(Integer.valueOf(42));
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().toLowerCase().indexOf("null value") != -1) {
+                throw new RuntimeException("SpinnerDateModel.setValue(Object) throws " +
+                        "exception with incorrect message");
+            }
+        }
+        System.out.println("Test Passed!");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8315834](https://bugs.openjdk.org/browse/JDK-8315834)

Testing
- Local: Test passed
  - `bug4522737.java` - Test results: passed: 1
  - `bug4656590.java` - Test results: passed: 1
  - `bug4680204.java` - Test results: passed: 1
  - `bug4862257.java` - Test results: passed: 1
  - `bug5104421.java` - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-03-01,03`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315834](https://bugs.openjdk.org/browse/JDK-8315834) needs maintainer approval

### Issue
 * [JDK-8315834](https://bugs.openjdk.org/browse/JDK-8315834): Open source several Swing JSpinner related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2572/head:pull/2572` \
`$ git checkout pull/2572`

Update a local copy of the PR: \
`$ git checkout pull/2572` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2572`

View PR using the GUI difftool: \
`$ git pr show -t 2572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2572.diff">https://git.openjdk.org/jdk11u-dev/pull/2572.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2572#issuecomment-1969802211)