### PR TITLE
Backport 87516e29dc5015c4cab2c07c5539ad30f2768667

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -23,10 +23,11 @@
 
 /* @test
  * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171
+ * @library /test/lib
  * @modules java.base/jdk.internal.util
  * @summary Unit test for probeContentType method
  * @library ../..
- * @build Basic SimpleFileTypeDetector
+ * @build jdk.test.lib.OSVersion jdk.test.lib.Platform Basic SimpleFileTypeDetector
  * @run main/othervm Basic
  */
 
@@ -37,8 +38,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import jdk.internal.util.OperatingSystem;
-import jdk.internal.util.OSVersion;
+import jdk.test.lib.Platform;
+import jdk.test.lib.OSVersion;
 
 /**
  * Uses Files.probeContentType to probe html file, custom file type, and minimal
@@ -80,7 +81,7 @@ public class Basic {
         assert actual != null;
 
         if (!expected.equals(actual)) {
-            if (!OperatingSystem.isWindows()) {
+            if (!Platform.isWindows()) {
                 Path userMimeTypes =
                     Paths.get(System.getProperty("user.home"), ".mime.types");
                 checkMimeTypesFile(userMimeTypes);
@@ -185,10 +186,10 @@ public class Basic {
         exTypes.add(new ExType("webp", List.of("image/webp")));
         exTypes.add(new ExType("xls", List.of("application/vnd.ms-excel")));
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
-        exTypes.add(new ExType("wasm", List.of("application/wasm")));
+        // exTypes.add(new ExType("wasm", List.of("application/wasm")));
 
         // extensions with content type that differs on Windows 11+
-        if (OperatingSystem.isWindows() &&
+        if (Platform.isWindows() &&
             (System.getProperty("os.name").endsWith("11") ||
                 new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
             System.out.println("Windows 11+ detected: using different types");

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171
+ * @modules java.base/jdk.internal.util
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector
@@ -31,18 +32,19 @@
 
 import java.io.*;
 import java.nio.file.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.internal.util.OSVersion;
 
 /**
  * Uses Files.probeContentType to probe html file, custom file type, and minimal
  * set of file extension to content type mappings.
  */
 public class Basic {
-    private static final boolean IS_UNIX =
-        ! System.getProperty("os.name").startsWith("Windows");
-
     static Path createHtmlFile() throws IOException {
         Path file = Files.createTempFile("foo", ".html");
         try (OutputStream out = Files.newOutputStream(file)) {
@@ -78,7 +80,7 @@ public class Basic {
         assert actual != null;
 
         if (!expected.equals(actual)) {
-            if (IS_UNIX) {
+            if (!OperatingSystem.isWindows()) {
                 Path userMimeTypes =
                     Paths.get(System.getProperty("user.home"), ".mime.types");
                 checkMimeTypesFile(userMimeTypes);
@@ -97,12 +99,12 @@ public class Basic {
         return 0;
     }
 
-    static int checkContentTypes(ExType[] exTypes)
+    static int checkContentTypes(List<ExType> exTypes)
         throws IOException {
         int failures = 0;
-        for (int i = 0; i < exTypes.length; i++) {
-            String extension = exTypes[i].extension();
-            List<String> expectedTypes = exTypes[i].expectedTypes();
+        for (ExType exType : exTypes) {
+            String extension = exType.extension();
+            List<String> expectedTypes = exType.expectedTypes();
             Path file = Files.createTempFile("foo", "." + extension);
             try {
                 String type = Files.probeContentType(file);
@@ -154,39 +156,55 @@ public class Basic {
         }
 
         // Verify that certain extensions are mapped to the correct type.
-        var exTypes = new ExType[] {
-                new ExType("adoc", List.of("text/plain")),
-                new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")),
-                new ExType("css", List.of("text/css")),
-                new ExType("csv", List.of("text/csv")),
-                new ExType("doc", List.of("application/msword")),
-                new ExType("docx", List.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")),
-                new ExType("gz", List.of("application/gzip", "application/x-gzip")),
-                new ExType("jar", List.of("application/java-archive", "application/x-java-archive", "application/jar")),
-                new ExType("jpg", List.of("image/jpeg")),
-                new ExType("js", List.of("text/javascript", "application/javascript")),
-                new ExType("json", List.of("application/json")),
-                new ExType("markdown", List.of("text/markdown")),
-                new ExType("md", List.of("text/markdown", "application/x-genesis-rom")),
-                new ExType("mp3", List.of("audio/mpeg")),
-                new ExType("mp4", List.of("video/mp4")),
-                new ExType("odp", List.of("application/vnd.oasis.opendocument.presentation")),
-                new ExType("ods", List.of("application/vnd.oasis.opendocument.spreadsheet")),
-                new ExType("odt", List.of("application/vnd.oasis.opendocument.text")),
-                new ExType("pdf", List.of("application/pdf")),
-                new ExType("php", List.of("text/plain", "text/php", "application/x-php")),
-                new ExType("png", List.of("image/png")),
-                new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
-                new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
-                new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")),
-                new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")),
-                new ExType("rtf", List.of("application/rtf", "text/rtf")),
-                new ExType("webm", List.of("video/webm")),
-                new ExType("webp", List.of("image/webp")),
-                new ExType("xls", List.of("application/vnd.ms-excel")),
-                new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")),
-                new ExType("7z", List.of("application/x-7z-compressed")),
-        };
+        List<ExType> exTypes = new ArrayList<ExType>();
+
+        // extensions with consistent content type
+        exTypes.add(new ExType("adoc", List.of("text/plain")));
+        exTypes.add(new ExType("css", List.of("text/css")));
+        exTypes.add(new ExType("doc", List.of("application/msword")));
+        exTypes.add(new ExType("docx", List.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")));
+        exTypes.add(new ExType("gz", List.of("application/gzip", "application/x-gzip")));
+        exTypes.add(new ExType("jar", List.of("application/java-archive", "application/x-java-archive", "application/jar")));
+        exTypes.add(new ExType("jpg", List.of("image/jpeg")));
+        exTypes.add(new ExType("js", List.of("text/plain", "text/javascript", "application/javascript")));
+        exTypes.add(new ExType("json", List.of("application/json")));
+        exTypes.add(new ExType("markdown", List.of("text/markdown")));
+        exTypes.add(new ExType("md", List.of("text/markdown", "application/x-genesis-rom")));
+        exTypes.add(new ExType("mp3", List.of("audio/mpeg")));
+        exTypes.add(new ExType("mp4", List.of("video/mp4")));
+        exTypes.add(new ExType("odp", List.of("application/vnd.oasis.opendocument.presentation")));
+        exTypes.add(new ExType("ods", List.of("application/vnd.oasis.opendocument.spreadsheet")));
+        exTypes.add(new ExType("odt", List.of("application/vnd.oasis.opendocument.text")));
+        exTypes.add(new ExType("pdf", List.of("application/pdf")));
+        exTypes.add(new ExType("php", List.of("text/plain", "text/php", "application/x-php")));
+        exTypes.add(new ExType("png", List.of("image/png")));
+        exTypes.add(new ExType("ppt", List.of("application/vnd.ms-powerpoint")));
+        exTypes.add(new ExType("pptx", List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")));
+        exTypes.add(new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")));
+        exTypes.add(new ExType("webm", List.of("video/webm")));
+        exTypes.add(new ExType("webp", List.of("image/webp")));
+        exTypes.add(new ExType("xls", List.of("application/vnd.ms-excel")));
+        exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
+        exTypes.add(new ExType("wasm", List.of("application/wasm")));
+
+        // extensions with content type that differs on Windows 11+
+        if (OperatingSystem.isWindows() &&
+            (System.getProperty("os.name").endsWith("11") ||
+                new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
+            System.out.println("Windows 11+ detected: using different types");
+            exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));
+            exTypes.add(new ExType("csv", List.of("text/csv", "application/vnd.ms-excel")));
+            exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed", "application/x-compressed")));
+            exTypes.add(new ExType("rtf", List.of("application/rtf", "text/rtf", "application/msword")));
+            exTypes.add(new ExType("7z", List.of("application/x-7z-compressed", "application/x-compressed")));
+        } else {
+            exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")));
+            exTypes.add(new ExType("csv", List.of("text/csv")));
+            exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")));
+            exTypes.add(new ExType("rtf", List.of("application/rtf", "text/rtf")));
+            exTypes.add(new ExType("7z", List.of("application/x-7z-compressed")));
+        }
+
         failures += checkContentTypes(exTypes);
 
         if (failures > 0) {


### PR DESCRIPTION
Backport of [JDK-8320943](https://bugs.openjdk.org/browse/JDK-8320943)
- This PR has two commits
  - commit 1 is the backport of the original [commit](https://github.com/openjdk/jdk/commit/87516e29dc5015c4cab2c07c5539ad30f2768667)
  - commit 2 is fixing the compile and runtime issue on Java 17.
    - Compile issue fixed: on Java 17 the class is `jdk.test.lib.Platform` and `jdk.test.lib.OSVersion`
    - Runtime issue fixed: on Java 17 there is no mime `wasm`, so we comment it out
      - `wasm` exists in Java 21: https://github.com/openjdk/jdk21u-dev/blob/master/src/java.base/windows/classes/sun/net/www/content-types.properties
      - `wasm` does not exists in Java 11: https://github.com/openjdk/jdk11u-dev/blob/master/src/java.base/windows/classes/sun/net/www/content-types.properties 
- So this is an unclean back port

Testing
- Local: Test passed on Mac
  - `Basic.java` - Test results: passed: 1

Mac machine

```
MacBook Pro
16-inch, 2021
Chip: Apple M1 Max
MacOS: 14.3.1 (23D60)
```

Windows machine: (to test)

- Pipeline: 
- Testing Machine:
