### PR TITLE
8266242: java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #define DEFAULT_DEVICE_HEIGHT 768
 #define DEFAULT_DEVICE_DPI 72
 
+static NSInteger architecture = -1;
 /*
  * Convert the mode string to the more convinient bits per pixel value
  */
@@ -58,7 +59,17 @@ static int getBPPFromModeString(CFStringRef mode)
     return 0;
 }
 
-static BOOL isValidDisplayMode(CGDisplayModeRef mode){
+static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
+    // Workaround for apple bug FB13261205, since it only affects arm based macs
+    // and arm support started with macOS 11 ignore the workaround for previous versions
+    if (@available(macOS 11, *)) {
+        if (architecture == -1) {
+            architecture = [[NSRunningApplication currentApplication] executableArchitecture];
+        }
+        if (architecture == NSBundleExecutableArchitectureARM64) {
+            return (CGDisplayModeGetPixelWidth(mode) >= 800);
+        }
+    }
     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
 }
 


### PR DESCRIPTION
Backport of [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242)
- `src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m` - clean backport
- `test/jdk/ProblemList.txt` - this file has been ignored because the line does not exist

Testing
- Local: Test `failed`
  - `CheckDisplayModes.java`:

```
MacBook Pro
16-inch, 2021
Chip Apple M1 Max
Memory: 32 GB
MacOS: 14.5 (23F79)
```

```
----------System.err:(15/991)----------
java.lang.IllegalArgumentException: Invalid display mode
	at java.desktop/sun.awt.CGraphicsDevice.nativeSetDisplayMode(Native Method)
	at java.desktop/sun.awt.CGraphicsDevice.setDisplayMode(CGraphicsDevice.java:254)
	at CheckDisplayModes.main(CheckDisplayModes.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:829)

JavaTest Message: Test threw exception: java.lang.IllegalArgumentException: Invalid display mode
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.IllegalArgumentException: Invalid display mode
```

- Pipeline: 
- Testing Machine: On the SAP Testing machine this test is skipped
  - Automated jtreg test: `jtreg_jdk_tier4`
  - java/awt/GraphicsDevice/CheckDisplayModes.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242): java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2576/head:pull/2576` \
`$ git checkout pull/2576`

Update a local copy of the PR: \
`$ git checkout pull/2576` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2576`

View PR using the GUI difftool: \
`$ git pr show -t 2576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2576.diff">https://git.openjdk.org/jdk11u-dev/pull/2576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2576#issuecomment-1970235590)