### PR TITLE
8325972: Add -x to bash for building with LOG=debug

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -151,6 +151,10 @@ define SetupLogging
                 flock $$(FLOCK) \
                 $$(OUTPUTDIR)/build-profile.log $$(SHELL)
     endif
+  endif
+
+  ifneq ($$(findstring $$(LOG_LEVEL), debug trace),)
+    SHELL := $$(SHELL) -x
   endif
 
   ifeq ($$(LOG_LEVEL), trace)


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325972](https://bugs.openjdk.org/browse/JDK-8325972) needs maintainer approval

### Issue
 * [JDK-8325972](https://bugs.openjdk.org/browse/JDK-8325972): Add -x to bash for building with LOG=debug (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2579/head:pull/2579` \
`$ git checkout pull/2579`

Update a local copy of the PR: \
`$ git checkout pull/2579` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2579`

View PR using the GUI difftool: \
`$ git pr show -t 2579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2579.diff">https://git.openjdk.org/jdk11u-dev/pull/2579.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2579#issuecomment-1975778378)