### PR TITLE
8326638: Crash in PhaseIdealLoop::remix_address_expressions due to unexpected Region instead of Loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -492,8 +492,8 @@ Node *PhaseIdealLoop::remix_address_expressions( Node *n ) {
   }
 
   // Replace ((I1 +p V) +p I2) with ((I1 +p I2) +p V),
-  // but not if I2 is a constant.
-  if( n_op == Op_AddP ) {
+  // but not if I2 is a constant. Skip for irreducible loops.
+  if (n_op == Op_AddP && n_loop->_head->is_Loop()) {
     if( n2_loop == n_loop && n3_loop != n_loop ) {
       if( n->in(2)->Opcode() == Op_AddP && !n->in(3)->is_Con() ) {
         Node *n22_ctrl = get_ctrl(n->in(2)->in(2));

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8326638
+ * @summary Test handling of irreducible loops in PhaseIdealLoop::remix_address_expressions.
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *                   -XX:CompileCommand=compileonly,TestRemixAddressExpressionsWithIrreducibleLoop::test
+ *                   TestRemixAddressExpressionsWithIrreducibleLoop
+ */
+
+public class TestRemixAddressExpressionsWithIrreducibleLoop {
+
+    public static void main(String[] args) {
+        test("4");
+    }
+
+    public static void test(String arg) {
+        for (int i = 0; i < 100_000; ++i) {
+            int j = 0;
+            while (true) {
+                boolean tmp = "1\ufff0".startsWith(arg, 2 - arg.length());
+                if (j++ > 100)
+                    break;
+            }
+        loop:
+            while (i >= 100) {
+                for (int i2 = 0; i2 < 1; i2 = 1)
+                    if (j > 300)
+                        break loop;
+                j++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.
No code change, only code line change in src/hotspot/share/opto/loopopts.cpp, so make it clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326638](https://bugs.openjdk.org/browse/JDK-8326638) needs maintainer approval

### Issue
 * [JDK-8326638](https://bugs.openjdk.org/browse/JDK-8326638): Crash in PhaseIdealLoop::remix_address_expressions due to unexpected Region instead of Loop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2581/head:pull/2581` \
`$ git checkout pull/2581`

Update a local copy of the PR: \
`$ git checkout pull/2581` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2581`

View PR using the GUI difftool: \
`$ git pr show -t 2581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2581.diff">https://git.openjdk.org/jdk11u-dev/pull/2581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2581#issuecomment-1976161050)