### PR TITLE
8292716: Configure should check that jtreg is of the required version

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -61,6 +61,9 @@ TOOLCHAIN_MINIMUM_VERSION_xlc=""
 # Minimum supported linker versions, empty means unspecified
 TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.18"
 
+# Minimum supported version
+JTREG_MINIMUM_VERSION=6.1
+
 # Prepare the system so that TOOLCHAIN_CHECK_COMPILER_VERSION can be called.
 # Must have CC_VERSION_NUMBER and CXX_VERSION_NUMBER.
 # $1 - optional variable prefix for compiler and version variables (BUILD_)
@@ -1144,6 +1147,24 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_JTREG],
   UTIL_FIXUP_EXECUTABLE(JTREGEXE)
   UTIL_FIXUP_PATH(JT_HOME)
   AC_SUBST(JT_HOME)
+
+  # Verify jtreg version
+  if test "x$JT_HOME" != x; then
+    AC_MSG_CHECKING([jtreg version number])
+    # jtreg -version looks like this: "jtreg 6.1+1-19"
+    # Extract actual version part ("6.1" in this case)
+    jtreg_version_full=`$JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2`
+    jtreg_version=${jtreg_version_full/%+*}
+    AC_MSG_RESULT([$jtreg_version])
+
+    # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
+    comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$jtreg_version"`
+    comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$JTREG_MINIMUM_VERSION"`
+    if test $comparable_actual_version -lt $comparable_minimum_version ; then
+      AC_MSG_ERROR([jtreg version is too old, at least version $JTREG_MINIMUM_VERSION is required])
+    fi
+  fi
+
   AC_SUBST(JTREGEXE)
 ])
 


### PR DESCRIPTION
I backport this as prereq to raise the jtreg version.

I had to resolve one hunk due to context.  This is based on the commit to 17 including a follow up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8292763](https://bugs.openjdk.org/browse/JDK-8292763) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8292716](https://bugs.openjdk.org/browse/JDK-8292716) needs maintainer approval

### Issues
 * [JDK-8292716](https://bugs.openjdk.org/browse/JDK-8292716): Configure should check that jtreg is of the required version (**Bug** - P3 - Approved)
 * [JDK-8292763](https://bugs.openjdk.org/browse/JDK-8292763): JDK-8292716 breaks configure without jtreg (**Bug** - P1 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2585/head:pull/2585` \
`$ git checkout pull/2585`

Update a local copy of the PR: \
`$ git checkout pull/2585` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2585`

View PR using the GUI difftool: \
`$ git pr show -t 2585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2585.diff">https://git.openjdk.org/jdk11u-dev/pull/2585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2585#issuecomment-1984057315)