### PR TITLE
8219901: Noto fonts for East Asian countries cannot belong to CompositeFont

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/FcFontManager.java
+++ b/src/java.desktop/unix/classes/sun/awt/FcFontManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class FcFontManager extends SunFontManager {
             for (int i=0; i<fontConfigFonts.length; i++) {
                 if ("sans".equals(fontConfigFonts[i].fcFamily) &&
                     0 == fontConfigFonts[i].style) {
-                    info[0] = fontConfigFonts[i].firstFont.familyName;
+                    info[0] = fontConfigFonts[i].firstFont.fullName;
                     info[1] = fontConfigFonts[i].firstFont.fontFile;
                     break;
                 }
@@ -90,7 +90,7 @@ public class FcFontManager extends SunFontManager {
         if (info[0] == null) {
             if (fontConfigFonts != null && fontConfigFonts.length > 0 &&
                 fontConfigFonts[0].firstFont.fontFile != null) {
-                info[0] = fontConfigFonts[0].firstFont.familyName;
+                info[0] = fontConfigFonts[0].firstFont.fullName;
                 info[1] = fontConfigFonts[0].firstFont.fontFile;
             } else {
                 info[0] = "Dialog";

--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Scanner;
 import sun.awt.FcFontManager;
@@ -264,7 +265,7 @@ public class FcFontConfiguration extends FontConfiguration {
                 int index;
                 for (index = 0; index < fcFonts.length; index++) {
                     fileNames[index] = fcFonts[index].fontFile;
-                    faceNames[index] = fcFonts[index].familyName;
+                    faceNames[index] = fcFonts[index].fullName;
                 }
 
                 if (installedFallbackFontFiles != null) {
@@ -357,9 +358,11 @@ public class FcFontConfiguration extends FontConfiguration {
             String version = System.getProperty("java.version");
             String fs = File.separator;
             String dir = userDir+fs+".java"+fs+"fonts"+fs+version;
-            String lang = SunToolkit.getStartupLocale().getLanguage();
+            Locale locale = SunToolkit.getStartupLocale();
+            String lang = locale.getLanguage();
+            String country = locale.getCountry();
             String name = "fcinfo-"+fileVersion+"-"+hostname+"-"+
-                osName+"-"+osVersion+"-"+lang+".properties";
+                osName+"-"+osVersion+"-"+lang+"-"+country+".properties";
             fcInfoFileName = dir+fs+name;
         }
         return new File(fcInfoFileName);
@@ -385,10 +388,12 @@ public class FcFontConfiguration extends FontConfiguration {
             props.setProperty(styleKey+".length",
                               Integer.toString(fci.allFonts.length));
             for (int j=0; j<fci.allFonts.length; j++) {
-                props.setProperty(styleKey+"."+j+".family",
-                                  fci.allFonts[j].familyName);
                 props.setProperty(styleKey+"."+j+".file",
                                   fci.allFonts[j].fontFile);
+                if (fci.allFonts[j].fullName != null) {
+                    props.setProperty(styleKey+"."+j+".fullName",
+                                      fci.allFonts[j].fullName);
+                }
             }
         }
         try {
@@ -503,9 +508,9 @@ public class FcFontConfiguration extends FontConfiguration {
                     fci[index].allFonts = new FontConfigFont[nfonts];
                     for (int f=0; f<nfonts; f++) {
                         fci[index].allFonts[f] = new FontConfigFont();
-                        String fkey = key+"."+f+".family";
-                        String family = (String)props.get(fkey);
-                        fci[index].allFonts[f].familyName = family;
+                        String fkey = key+"."+f+".fullName";
+                        String fullName = (String)props.get(fkey);
+                        fci[index].allFonts[f].fullName = fullName;
                         fkey = key+"."+f+".file";
                         String file = (String)props.get(fkey);
                         if (file == null) {

--- a/test/jdk/java/awt/font/FontNames/FCCompositeTest.java
+++ b/test/jdk/java/awt/font/FontNames/FCCompositeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8219901
+ * @modules java.desktop/sun.font
+ * @requires (os.family == "linux")
+ * @summary Verifies if the first fonts of CompositeFont and fc-match are same.
+ */
+
+import java.awt.Font;
+import java.util.Locale;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import sun.font.FontUtilities;
+import sun.font.Font2D;
+import sun.font.CompositeFont;
+import sun.font.PhysicalFont;
+
+public class FCCompositeTest {
+
+    final static String[] names =
+        new String[]{"Monospaced","SansSerif","Serif"};
+    final static String[] fcnames =
+        new String[]{"monospace","sans","serif"};
+
+    public static void main(String args[]) {
+        for(int i = 0; i < names.length; i++) {
+            test(i);
+        }
+    }
+
+    private static void test(int index) {
+        boolean matched = false;
+        String fullName = "";
+        String fcFullName = "";
+        try {
+            Font2D f2d = FontUtilities.getFont2D(
+                             new Font(names[index], Font.PLAIN, 12));
+            if (!(f2d instanceof CompositeFont)) {
+                System.out.println("WARNING: Not CompositeFont");
+                return;
+            }
+            PhysicalFont pf = ((CompositeFont)f2d).getSlotFont(0);
+            fullName = pf.getFontName(Locale.ENGLISH);
+            System.out.println("PF="+fullName);
+
+            String[] command = {"fc-match",
+                                fcnames[index],
+                                "fullname"};
+            Runtime runtime = Runtime.getRuntime();
+            Process p = runtime.exec(command, null, null);
+            p.waitFor();
+            InputStream is = p.getInputStream();
+            InputStream es = p.getErrorStream();
+            BufferedReader br =
+                new BufferedReader(new InputStreamReader(is));
+            BufferedReader errorBr =
+                new BufferedReader(new InputStreamReader(es));
+            String line;
+            while ((line = errorBr.readLine()) != null) {
+                if (line.contains("warning") && line.contains("language")) {
+                    System.out.println("Skip test by fc-match warning");
+                    return;
+                }
+            }
+            while (!matched) {
+                String fcname = br.readLine();
+                if (fcname == null) break;
+                fcFullName = fcname;
+                if (fcname.equals("")) {
+                    System.out.println("Skip if no fullname");
+                    return;
+                }
+                fcname = fcname.replaceAll("\\\\", "");
+                String[] list = fcname.split("=|,", 0);
+                for (int i = 1; i < list.length; i++) {
+                    // skip header
+                    if (fullName.equals(list[i])) {
+                        matched = true;
+                        break;
+                    }
+                }
+            }
+            br.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Method invocation exception");
+        }
+        if (!matched) {
+            throw new RuntimeException("FullName mismatch: "+fullName+"|"+
+                                           fcFullName);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [189e938d](https://github.com/openjdk/jdk/commit/189e938d3ab6984581c83a5996281ec436e0ac2e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Toshio Nakamura on 2 Jun 2019 and was reviewed by Phil Race and Jayathirth D V.

Testing: original issue test case passes, all tests in ```test/jdk/java/awt/font/``` pass and tier 1 with GHA. 


Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8219901](https://bugs.openjdk.org/browse/JDK-8219901) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219901](https://bugs.openjdk.org/browse/JDK-8219901): Noto fonts for East Asian countries cannot belong to CompositeFont (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2586/head:pull/2586` \
`$ git checkout pull/2586`

Update a local copy of the PR: \
`$ git checkout pull/2586` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2586`

View PR using the GUI difftool: \
`$ git pr show -t 2586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2586.diff">https://git.openjdk.org/jdk11u-dev/pull/2586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2586#issuecomment-1985939681)