### PR TITLE
8218917: KeyEvent.getModifiers() returns inconsistent values for ALT keys

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,7 +318,6 @@ const nsKeyToJavaModifierTable[] =
 };
 
 static BOOL leftAltKeyPressed;
-static BOOL altGRPressed = NO;
 
 /*
  * Almost all unicode characters just go from NS to Java with no translation.
@@ -566,19 +565,13 @@ jint NsKeyModifiersToJavaModifiers(NSUInteger nsFlags, BOOL isExtMods)
 
     for (cur = nsKeyToJavaModifierTable; cur->nsMask != 0; ++cur) {
         if ((cur->nsMask & nsFlags) != 0) {
-
-            if (cur->nsMask == NSAlternateKeyMask) {
-                if (leftAltKeyPressed == YES) {
-                    javaModifiers |= isExtMods? cur->javaExtMask : cur->javaMask;
-                    if (altGRPressed == NO)
-                        break;
-                    } else {
-                        leftAltKeyPressed = YES;
-                        altGRPressed = YES;
-                        continue;
-                    }
-                }
+            //This code will consider the mask value for left alt as well as
+            //right alt, but that should be ok, since right alt contains left alt
+            //mask value.
             javaModifiers |= isExtMods ? cur->javaExtMask : cur->javaMask;
+            if (cur->nsMask == NSAlternateKeyMask && leftAltKeyPressed) {
+                    break; //since right alt key struct is defined last, break out of the loop                }
+            }
         }
     }
 

--- a/test/jdk/java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java
@@ -25,7 +25,6 @@
  @test
  @bug 8041928 8158616
  @summary Confirm that the Alt-Gr Modifier bit is set correctly.
- @requires (os.family != "windows" & os.family != "mac")
  @run main/manual AltGraphModifierTest
  */
 

--- a/test/jdk/java/awt/keyboard/8218917/AltKeyBug.java
+++ b/test/jdk/java/awt/keyboard/8218917/AltKeyBug.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8218917
+ * @summary Tests whether sending an ALT_GRAPH key once, will result in the
+ * system reporting only ALT_GRAPH even if an ALT was sent and vice versa.
+ * @run main AltKeyBug
+ */
+import javax.swing.JTextField;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import java.awt.Robot;
+import java.awt.event.KeyListener;
+import java.awt.event.KeyEvent;
+
+public class AltKeyBug {
+    private static JFrame f;
+    private static boolean rightAltPressed = false;
+    private static boolean throwException = false;
+    private static String errorString;
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+
+            SwingUtilities.invokeAndWait(() -> {
+                JTextField comp = new JTextField();
+                comp.addKeyListener(new KeyListener() {
+                    @Override public void keyTyped(KeyEvent e) {}
+                    @Override public void keyPressed(KeyEvent e) {
+                        System.out.println("ModEx : " +e.getModifiersEx());
+                        System.out.println("Mod : " +e.getModifiers());
+                        System.out.println("ALT_DOWN : " + e.isAltDown());
+                        System.out.println("ALT_GR_DOWN: " + e.isAltGraphDown());
+                        System.out.println("-----------");
+                        if (rightAltPressed && !e.isAltGraphDown()) {
+                            throwException = true;
+                            errorString = "Right Alt press was sent but not received back.";
+                        } else if (!rightAltPressed && e.isAltGraphDown()) {
+                            throwException = true;
+                            errorString = "Left Alt press was sent, but received Right Alt";
+                        }
+                    }
+                    @Override public void keyReleased(KeyEvent e) {}
+                });
+                f = new JFrame();
+                f.add(comp);
+                f.setSize(100,100);
+                f.setVisible(true);
+            });
+
+            for(int i = 0; i < 20; i++) {
+                rightAltPressed = true;
+                robot.keyPress(KeyEvent.VK_ALT_GRAPH);
+                robot.keyRelease(KeyEvent.VK_ALT_GRAPH);
+
+                robot.waitForIdle();
+
+                if (throwException) {
+                    throw new RuntimeException(errorString);
+                }
+                rightAltPressed = false;
+                robot.keyPress(KeyEvent.VK_ALT);
+                robot.keyRelease(KeyEvent.VK_ALT);
+
+                robot.waitForIdle();
+
+                if (throwException) {
+                    throw new RuntimeException(errorString);
+                }
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(()-> {
+                if (f != null)
+                    f.dispose();
+            });
+        }
+
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8218917](https://bugs.openjdk.org/browse/JDK-8218917)

Testing
- Local: Test passed
  - `AltGraphModifierTest.java`: Test results: no tests selected
  - `AltKeyBug.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-03-13,14,15`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8218917](https://bugs.openjdk.org/browse/JDK-8218917) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218917](https://bugs.openjdk.org/browse/JDK-8218917): KeyEvent.getModifiers() returns inconsistent values for ALT keys (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2587/head:pull/2587` \
`$ git checkout pull/2587`

Update a local copy of the PR: \
`$ git checkout pull/2587` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2587`

View PR using the GUI difftool: \
`$ git pr show -t 2587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2587.diff">https://git.openjdk.org/jdk11u-dev/pull/2587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2587#issuecomment-1984931508)