### PR TITLE
8305645: System Tray icons get corrupted when Windows primary monitor changes

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -262,7 +262,7 @@ LRESULT CALLBACK AwtTrayIcon::TrayWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam
                 }
             }
             break;
-        case WM_DPICHANGED:
+        case WM_DISPLAYCHANGE:
             // Set the flag to update icon images, see WmTaskbarCreated
             m_bDPIChanged = true;
             break;

--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,9 @@ public class TrayIconScalingTest {
     private static TrayIcon icon;
 
     private static final String INSTRUCTIONS =
-            "This test checks if the tray icon gets updated when DPI / Scale" +
-            " is changed on the fly.\n\n" +
+            "This test checks if the tray icon gets updated correctly under 2 scenarios:\n\n" +
+            "Case 1: Single Screen - when DPI / Scale is changed on the fly.\n" +
+            "Case 2: Multi Screen - when both screens are set to different scales.\n\n" +
             "STEPS: \n\n" +
             "1. Check the system tray / notification area on Windows" +
             " taskbar, you should see a white icon which displays a" +
@@ -61,11 +62,17 @@ public class TrayIconScalingTest {
             "2. Navigate to Settings > System > Display and change the" +
             " display scale by selecting any value from" +
             " Scale & Layout dropdown.\n\n"+
-            "3. When the scale changes, check the white tray icon," +
+            "3. For Case 1, when the scale changes, check the white tray icon," +
             " there should be no distortion, it should be displayed sharp,\n" +
             " and the displayed number should correspond to the current"+
-            " scale:\n" +
-            " 100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32.\n\n"+
+            " scale.\n\n" +
+            "4. For Case 2, a dual monitor setup is required with 'Multiple Display'" +
+            " option under Display settings set to 'Extend the display'.\n\n" +
+            "5. Have the monitors set to different scales and toggle the" +
+            " 'Make this my main display' option under Display settings.\n\n" +
+            " In both cases, the tray icon should be displayed as a clear image" +
+            " without any distortion with the display number corresponding to the scale.\n" +
+            " 100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32.\n\n" +
             " If the icon is displayed sharp and without any distortion," +
             " press PASS, otherwise press FAIL.\n";
 
@@ -79,7 +86,7 @@ public class TrayIconScalingTest {
             return;
         }
         PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
-                "Test Instructions", INSTRUCTIONS, 8, 18, 85);
+                "Test Instructions", INSTRUCTIONS, 8, 25, 85);
         createAndShowGUI();
         // does not have a test window,
         // hence only the instruction frame is positioned


### PR DESCRIPTION
Backport of [JDK-8305645](https://bugs.openjdk.org/browse/JDK-8305645)

Testing
- Local:
  - Build on MacOS M1 succeeded
  - `TrayIconScalingTest.java` on Windows 11: Test results: passed: 1

```
Processor	12th Gen Intel(R) Core(TM) i7-12800H   2.40 GHz
Installed RAM	64.0 GB (63.7 GB usable)
System type	64-bit operating system, x64-based processor

Edition: Windows 11 Enterprise
Version: 23H2
Installed on: 5/10/2023
OS build: 22631.3155
Experience: Windows Feature Experience Pack 1000.22684.1000.0
```
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-03-13,14,15`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305645](https://bugs.openjdk.org/browse/JDK-8305645) needs maintainer approval

### Issue
 * [JDK-8305645](https://bugs.openjdk.org/browse/JDK-8305645): System Tray icons get corrupted when Windows primary monitor changes (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2589/head:pull/2589` \
`$ git checkout pull/2589`

Update a local copy of the PR: \
`$ git checkout pull/2589` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2589`

View PR using the GUI difftool: \
`$ git pr show -t 2589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2589.diff">https://git.openjdk.org/jdk11u-dev/pull/2589.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2589#issuecomment-1986205723)