### PR TITLE
8248667: Need support for building native libraries located in the test/lib directory

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -554,6 +554,18 @@ test-image-jdk-jtreg-native:
 	+($(CD) $(TOPDIR)/make/test && $(MAKE) $(MAKE_ARGS) -f JtregNativeJdk.gmk \
 	    test-image-jdk-jtreg-native)
 
+# Native files needed by the testlib
+build-test-lib-native:
+	+($(CD) $(TOPDIR)/make/test && $(MAKE) $(MAKE_ARGS) -f BuildTestLibNative.gmk \
+	    build-test-lib-native)
+
+test-image-lib-native:
+	+($(CD) $(TOPDIR)/make/test && $(MAKE) $(MAKE_ARGS) -f BuildTestLibNative.gmk \
+	    test-image-lib-native)
+
+# Native files needed when testing the testlib itself
+# ... build-test-libtest-jtreg-native etc not yet backported
+
 build-test-hotspot-jtreg-graal:
 	+($(CD) $(TOPDIR)/make/test && $(MAKE) $(MAKE_ARGS) -f JtregGraalUnit.gmk \
 	     build-test-hotspot-jtreg-graal)
@@ -596,7 +608,8 @@ endif
 
 ALL_TARGETS += prepare-test-image build-test-hotspot-jtreg-native \
     test-image-hotspot-jtreg-native build-test-jdk-jtreg-native \
-    test-image-jdk-jtreg-native build-test-lib build-test-failure-handler \
+    test-image-jdk-jtreg-native build-test-lib-native test-image-lib-native \
+    build-test-lib build-test-failure-handler \
     test-failure-handler test-image-failure-handler test-image-hotspot-gtest \
     test-image-hotspot-jtreg-graal build-test-hotspot-jtreg-graal \
     run-test exploded-run-test
@@ -976,11 +989,15 @@ else
 
   build-test-jdk-jtreg-native: buildtools-jdk java.base-libs
 
+  build-test-lib-native: buildtools-jdk java.base-libs
+
   build-test-hotspot-jtreg-graal: exploded-image-optimize
 
   test-image-hotspot-jtreg-native: build-test-hotspot-jtreg-native
 
   test-image-jdk-jtreg-native: build-test-jdk-jtreg-native
+
+  test-image-lib-native: build-test-lib-native
 
   test-image-hotspot-jtreg-graal: build-test-hotspot-jtreg-graal
 
@@ -1141,7 +1158,8 @@ endif
 
 # This target builds the test image
 test-image: prepare-test-image \
-    test-image-jdk-jtreg-native test-image-failure-handler \
+    test-image-jdk-jtreg-native test-image-lib-native \
+    test-image-failure-handler \
     test-image-demos-jdk $(JVM_TEST_IMAGE_TARGETS)
 
 ################################################################################

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -45,12 +45,14 @@ $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
 
 TARGETS += $(BUILD_WB_JAR)
 
-# test-lib.jar will contain only hprof classes until JDK-8081381 is resolved
 $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     SETUP := GENERATE_USINGJDKBYTECODE, \
-    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/lib/hprof, \
+    SRC := $(TEST_LIB_SOURCE_DIR), \
+    EXCLUDES := jdk/test/lib/containers jdk/test/lib/security, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
+    HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/make/test/BuildTestLibNative.gmk
+++ b/make/test/BuildTestLibNative.gmk
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+################################################################################
+# This file builds the native component of testlib.
+# It also covers the test-image part, where the built files are copied to the
+# test image.
+################################################################################
+
+default: all
+
+include $(SPEC)
+include MakeBase.gmk
+include TestFilesCompilation.gmk
+
+################################################################################
+# Targets for building the native tests themselves.
+################################################################################
+
+BUILD_LIBTEST_NATIVE_SRC := $(TOPDIR)/test/lib
+
+BUILD_LIBTEST_OUTPUT_DIR := $(OUTPUTDIR)/support/test/lib/native
+
+BUILD_LIBTEST_IMAGE_DIR := $(TEST_IMAGE_DIR)/lib
+
+# This evaluation is expensive and should only be done if this target was
+# explicitly called.
+ifneq ($(filter build-test-lib-native, $(MAKECMDGOALS)), )
+  $(eval $(call SetupTestFilesCompilation, BUILD_LIBTEST_LIBRARIES, \
+      TYPE := LIBRARY, \
+      SOURCE_DIRS := $(BUILD_LIBTEST_NATIVE_SRC), \
+      OUTPUT_DIR := $(BUILD_LIBTEST_OUTPUT_DIR), \
+  ))
+endif
+
+build-test-lib-native: $(BUILD_LIBTEST_LIBRARIES)
+
+################################################################################
+# Targets for building test-image.
+################################################################################
+
+# Copy to testlib test image. We need it in both hotspot and jdk.
+$(eval $(call SetupCopyFiles, COPY_LIBTEST_NATIVE_TO_HOTSPOT, \
+    SRC := $(BUILD_LIBTEST_OUTPUT_DIR), \
+    DEST := $(TEST_IMAGE_DIR)/hotspot/jtreg/native, \
+    FILES := $(wildcard $(addprefix $(BUILD_LIBTEST_OUTPUT_DIR), /lib/*)), \
+    FLATTEN := true, \
+))
+
+$(eval $(call SetupCopyFiles, COPY_LIBTEST_NATIVE_TO_JDK, \
+    SRC := $(BUILD_LIBTEST_OUTPUT_DIR), \
+    DEST := $(TEST_IMAGE_DIR)/jdk/jtreg/native, \
+    FILES := $(wildcard $(addprefix $(BUILD_LIBTEST_OUTPUT_DIR), /lib/*)), \
+    FLATTEN := true, \
+))
+
+test-image-lib-native: $(COPY_LIBTEST_NATIVE_TO_HOTSPOT) $(COPY_LIBTEST_NATIVE_TO_JDK)
+
+all: build-test-lib-native
+
+.PHONY: default all build-test-lib-native test-image-lib-native

--- a/test/lib/jdk/test/lib/apps/libLingeredApp.c
+++ b/test/lib/jdk/test/lib/apps/libLingeredApp.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+
+// Borrowed from hotspot vmError.cpp.
+// Returns an address which is guaranteed to generate a SIGSEGV on read,
+// which is not NULL and contains bits in every word
+void* get_segfault_address() {
+  return (void*)
+#ifdef _LP64
+    0xABC0000000000ABCULL;
+#else
+    0x00000ABC;
+#endif
+}
+
+JNIEXPORT jint JNICALL
+Java_jdk_test_lib_apps_LingeredApp_crash(JNIEnv *env, jclass clss)
+{
+    return *(jint *)get_segfault_address();
+}


### PR DESCRIPTION
Backport for  JDK-8248667
As make/Main.gmk still use the old format, make some change. Others are clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8248667](https://bugs.openjdk.org/browse/JDK-8248667) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248667](https://bugs.openjdk.org/browse/JDK-8248667): Need support for building native libraries located in the test/lib directory (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2590/head:pull/2590` \
`$ git checkout pull/2590`

Update a local copy of the PR: \
`$ git checkout pull/2590` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2590`

View PR using the GUI difftool: \
`$ git pr show -t 2590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2590.diff">https://git.openjdk.org/jdk11u-dev/pull/2590.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2590#issuecomment-1987645595)