### PR TITLE
8327036: [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0

### DIFF
--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -595,6 +595,7 @@ extern "C" {                                                         \
 #define JVM_ENTRY_FROM_LEAF(env, result_type, header)                \
   { {                                                                \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE_FROM_LEAF(result_type, header, thread)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f38add6f](https://github.com/openjdk/jdk17u-dev/commit/f38add6f8d9c07442e5f6bb5c280a2d907b38b24) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

[WIP]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036) needs maintainer approval

### Issue
 * [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036): [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2595/head:pull/2595` \
`$ git checkout pull/2595`

Update a local copy of the PR: \
`$ git checkout pull/2595` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2595`

View PR using the GUI difftool: \
`$ git pr show -t 2595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2595.diff">https://git.openjdk.org/jdk11u-dev/pull/2595.diff</a>

</details>
