### PR TITLE
8320129: "top" command during jtreg failure handler does not display CPU usage on OSX

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -99,7 +99,7 @@ system.sysctl.args=-a
 process.ps.app=ps
 process.ps.args=-Meo pid,pcpu,cputime,start,pmem,vsz,rss,state,wchan,user,args
 process.top.app=top
-process.top.args=-l 1
+process.top.args=-l 2
 
 memory.vmstat.app=vm_stat
 memory.vmstat.args=-c 3 3


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320129](https://bugs.openjdk.org/browse/JDK-8320129) needs maintainer approval

### Issue
 * [JDK-8320129](https://bugs.openjdk.org/browse/JDK-8320129): "top" command during jtreg failure handler does not display CPU usage on OSX (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2597/head:pull/2597` \
`$ git checkout pull/2597`

Update a local copy of the PR: \
`$ git checkout pull/2597` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2597`

View PR using the GUI difftool: \
`$ git pr show -t 2597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2597.diff">https://git.openjdk.org/jdk11u-dev/pull/2597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2597#issuecomment-1989992347)