### PR TITLE
8322239: [macos] a11y : java.lang.NullPointerException is thrown when focus is moved on the JTabbedPane

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package javax.swing;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.IllegalComponentStateException;
 import java.beans.JavaBean;
 import java.beans.BeanProperty;
 import java.beans.Transient;
@@ -2255,15 +2256,23 @@ public class JTabbedPane extends JComponent
         }
 
         public Point getLocationOnScreen() {
-             Point parentLocation = parent.getLocationOnScreen();
+             Point parentLocation;
+             try {
+                 parentLocation = parent.getLocationOnScreen();
+             } catch (IllegalComponentStateException icse) {
+                 return null;
+             }
              Point componentLocation = getLocation();
+             if (parentLocation == null || componentLocation == null) {
+                 return null;
+             }
              componentLocation.translate(parentLocation.x, parentLocation.y);
              return componentLocation;
         }
 
         public Point getLocation() {
              Rectangle r = getBounds();
-             return new Point(r.x, r.y);
+             return r == null ? null : new Point(r.x, r.y);
         }
 
         public void setLocation(Point p) {
@@ -2280,7 +2289,7 @@ public class JTabbedPane extends JComponent
 
         public Dimension getSize() {
             Rectangle r = getBounds();
-            return new Dimension(r.width, r.height);
+            return r == null ? null : new Dimension(r.width, r.height);
         }
 
         public void setSize(Dimension d) {

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322239
+ * @summary [macos] a11y : java.lang.NullPointerException is thrown when
+ *          focus is moved on the JTabbedPane
+ * @key headful
+ * @run main TabbedPaneNPECheck
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.lang.reflect.InvocationTargetException;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class TabbedPaneNPECheck {
+    JTabbedPane pane;
+    JFrame mainFrame;
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        TabbedPaneNPECheck me = new TabbedPaneNPECheck();
+        SwingUtilities.invokeAndWait(me::setupGUI);
+        try {
+            SwingUtilities.invokeAndWait(me::test);
+        } finally {
+            SwingUtilities.invokeAndWait(me::shutdownGUI);
+        }
+    }
+
+    public void setupGUI() {
+        mainFrame = new JFrame("TabbedPaneNPECheck");
+        pane = new JTabbedPane();
+        Dimension panelSize = new Dimension(200, 200);
+        for (int i = 0; i < 25; i++) {
+            JPanel p = new JPanel();
+            p.setMinimumSize(panelSize);
+            p.setMaximumSize(panelSize);
+            p.setSize(panelSize);
+            pane.addTab("Tab no." + i, p);
+        }
+        mainFrame.setLayout(new BorderLayout());
+        mainFrame.add(pane, BorderLayout.CENTER);
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.setSize(250, 250);
+        mainFrame.setVisible(true);
+    }
+
+    public void test() {
+        AccessibleContext context = pane.getAccessibleContext();
+        int nChild = context.getAccessibleChildrenCount();
+        for (int i = 0; i < nChild; i++) {
+            Accessible accessible = context.getAccessibleChild(i);
+            if (accessible instanceof AccessibleComponent) {
+                try {
+                    AccessibleComponent component = (AccessibleComponent) accessible;
+                    Point p = component.getLocationOnScreen();
+                    Rectangle r = component.getBounds();
+                } catch (NullPointerException npe) {
+                    throw new RuntimeException("Unexpected NullPointerException " +
+                            "while getting accessible component bounds: ", npe);
+                }
+            }
+        }
+    }
+
+    public void shutdownGUI() {
+        if (mainFrame != null) {
+            mainFrame.setVisible(false);
+            mainFrame.dispose();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

I resolved Copyright and import (actually unneeded) in JTabbedPane.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322239](https://bugs.openjdk.org/browse/JDK-8322239) needs maintainer approval

### Issue
 * [JDK-8322239](https://bugs.openjdk.org/browse/JDK-8322239): [macos] a11y : java.lang.NullPointerException is thrown when focus is moved on the JTabbedPane (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2601/head:pull/2601` \
`$ git checkout pull/2601`

Update a local copy of the PR: \
`$ git checkout pull/2601` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2601`

View PR using the GUI difftool: \
`$ git pr show -t 2601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2601.diff">https://git.openjdk.org/jdk11u-dev/pull/2601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2601#issuecomment-1994228865)