### PR TITLE
8261302: NMT: Improve malloc site table hashing

### DIFF
--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,8 +93,7 @@ public:
     return _stack[index];
   }
 
-  // Hash code. Any better algorithm?
-  unsigned int hash() const;
+  unsigned int hash() const { return _hash_value; }
 
   void print_on(outputStream* out) const;
   void print_on(outputStream* out, int indent) const;


### PR DESCRIPTION
This is the same fix that was applied in https://github.com/openjdk/jdk/commit/a3d6e371 for https://bugs.openjdk.org/browse/JDK-8261302

It simplifies the way of calculating the hash of a stack.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8261302](https://bugs.openjdk.org/browse/JDK-8261302) needs maintainer approval

### Issue
 * [JDK-8261302](https://bugs.openjdk.org/browse/JDK-8261302): NMT: Improve malloc site table hashing (**Enhancement** - P4 - Rejected)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2608/head:pull/2608` \
`$ git checkout pull/2608`

Update a local copy of the PR: \
`$ git checkout pull/2608` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2608`

View PR using the GUI difftool: \
`$ git pr show -t 2608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2608.diff">https://git.openjdk.org/jdk11u-dev/pull/2608.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2608#issuecomment-2004352856)