### PR TITLE
8317507: C2 compilation fails with "Exceeded _node_regs array"

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3040,6 +3040,9 @@ static void define_fill_new_machnode(bool used, FILE *fp_cpp) {
     fprintf(fp_cpp, "    if( i != cisc_operand() ) \n");
     fprintf(fp_cpp, "      to[i] = _opnds[i]->clone();\n");
     fprintf(fp_cpp, "  }\n");
+    fprintf(fp_cpp, "  // Do not increment node index counter, since node reuses my index\n");
+    fprintf(fp_cpp, "  Compile* C = Compile::current();\n");
+    fprintf(fp_cpp, "  C->set_unique(C->unique() - 1);\n");
     fprintf(fp_cpp, "}\n");
   }
   fprintf(fp_cpp, "\n");

--- a/test/hotspot/jtreg/compiler/regalloc/TestNodeRegArrayOverflow.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestNodeRegArrayOverflow.java
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.regalloc;
+
+/**
+ * @test
+ * @bug 8317507
+ * @summary Test that C2's PhaseRegAlloc::_node_regs (a post-register-allocation
+ *          mapping from machine nodes to assigned registers) does not overflow
+ *          in the face of a program with a high-density of CISC spilling
+ *          candidate nodes.
+ * @run main/othervm -Xcomp -XX:CompileOnly=compiler.regalloc.TestNodeRegArrayOverflow::testWithCompilerUnrolling
+                     -XX:CompileCommand=dontinline,compiler.regalloc.TestNodeRegArrayOverflow::dontInline
+                     compiler.regalloc.TestNodeRegArrayOverflow compiler
+ * @run main/othervm -Xcomp -XX:CompileOnly=compiler.regalloc.TestNodeRegArrayOverflow::testWithManualUnrolling
+                     -XX:CompileCommand=dontinline,compiler.regalloc.TestNodeRegArrayOverflow::dontInline
+                     compiler.regalloc.TestNodeRegArrayOverflow manual
+ */
+
+public class TestNodeRegArrayOverflow {
+
+    static int dontInline() {
+        return 0;
+    }
+
+    static float testWithCompilerUnrolling(float inc) {
+        int i = 0, j = 0;
+        // This non-inlined method call causes 'inc' to be spilled.
+        float f = dontInline();
+        // This two-level reduction loop is unrolled 512 times, which is
+        // requested by the SLP-specific unrolling analysis, but not vectorized.
+        // Because 'inc' is spilled, each of the unrolled AddF nodes is
+        // CISC-spill converted (PhaseChaitin::fixup_spills()). Before the fix,
+        // this causes the unique node index counter (Compile::_unique) to grow
+        // beyond the size of the node register array
+        // (PhaseRegAlloc::_node_regs), and leads to overflow when accessed for
+        // nodes that are created later (e.g. during the peephole phase).
+        while (i++ < 128) {
+            for (j = 0; j < 16; j++) {
+                f += inc;
+            }
+        }
+        return f;
+    }
+
+    // This test reproduces the same failure as 'testWithCompilerUnrolling'
+    // without relying on loop transformations.
+    static float testWithManualUnrolling(float inc) {
+        int i = 0, j = 0;
+        float f = dontInline();
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        f += inc;
+        return f;
+    }
+
+    public static void main(String[] args) {
+        switch (args[0]) {
+        case "compiler":
+            testWithCompilerUnrolling(0);
+            break;
+        case "manual":
+            testWithManualUnrolling(0);
+            break;
+        default:
+            throw new IllegalArgumentException("Invalid mode: " + args[0]);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I'd like to propose this backport to 11u-dev. The 17u fix applies cleanly. I ran and debugged the test to make sure that it is triggering the faulty behavior.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317507](https://bugs.openjdk.org/browse/JDK-8317507) needs maintainer approval

### Issue
 * [JDK-8317507](https://bugs.openjdk.org/browse/JDK-8317507): C2 compilation fails with "Exceeded _node_regs array" (**Bug** - P2 - Approved)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2617/head:pull/2617` \
`$ git checkout pull/2617`

Update a local copy of the PR: \
`$ git checkout pull/2617` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2617`

View PR using the GUI difftool: \
`$ git pr show -t 2617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2617.diff">https://git.openjdk.org/jdk11u-dev/pull/2617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2617#issuecomment-2014124906)