### PR TITLE
8273831: PrintServiceLookup spawns 2 threads in the current classloader, getting orphaned

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -26,10 +26,8 @@
 package sun.print;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Vector;
 import java.security.AccessController;
@@ -53,6 +51,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.nio.file.Files;
+
+import sun.awt.util.ThreadGroupUtils;
 
 /*
  * Remind: This class uses solaris commands. We also need a linux
@@ -207,14 +207,18 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
         return BSD_LPD;
     }
 
-
+    @SuppressWarnings("removal")
     public PrintServiceLookupProvider() {
         // start the printer listener thread
         if (pollServices) {
-            Thread thr = new Thread(null, new PrinterChangeListener(),
-                                    "PrinterListener", 0, false);
-            thr.setDaemon(true);
-            thr.start();
+            AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread thr = new Thread(ThreadGroupUtils.getRootThreadGroup(),
+                                        new PrinterChangeListener(),
+                                        "PrinterListener", 0, false);
+                thr.setContextClassLoader(null);
+                thr.setDaemon(true);
+                return thr;
+            }).start();
             IPPPrintService.debug_println(debugPrefix+"polling turned on");
         }
     }

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -25,6 +25,8 @@
 
 package sun.print;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 
 import javax.print.DocFlavor;
@@ -40,6 +42,8 @@ import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.PrintServiceAttribute;
 import javax.print.attribute.PrintServiceAttributeSet;
 import javax.print.attribute.standard.PrinterName;
+
+import sun.awt.util.ThreadGroupUtils;
 
 public class PrintServiceLookupProvider extends PrintServiceLookup {
 
@@ -78,22 +82,31 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
         return win32PrintLUS;
     }
 
+    @SuppressWarnings("removal")
     public PrintServiceLookupProvider() {
 
         if (win32PrintLUS == null) {
             win32PrintLUS = this;
 
             // start the local printer listener thread
-            Thread thr = new Thread(null, new PrinterChangeListener(),
-                                    "PrinterListener", 0, false);
-            thr.setDaemon(true);
-            thr.start();
+            AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread thr = new Thread(ThreadGroupUtils.getRootThreadGroup(),
+                                        new PrinterChangeListener(),
+                                        "PrinterListener", 0, false);
+                thr.setContextClassLoader(null);
+                thr.setDaemon(true);
+                return thr;
+            }).start();
 
             // start the remote printer listener thread
-            Thread remThr = new Thread(null, new RemotePrinterChangeListener(),
-                                       "RemotePrinterListener", 0, false);
-            remThr.setDaemon(true);
-            remThr.start();
+            AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread thr = new Thread(ThreadGroupUtils.getRootThreadGroup(),
+                                        new RemotePrinterChangeListener(),
+                                        "RemotePrinterListener", 0, false);
+                thr.setContextClassLoader(null);
+                thr.setDaemon(true);
+                return thr;
+            }).start();
         } /* else condition ought to never happen! */
     }
 

--- a/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
+++ b/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import javax.print.DocFlavor;
+import javax.print.PrintServiceLookup;
+
+/**
+ * @test
+ * @bug 8273831
+ * @summary Tests custom class loader cleanup
+ */
+public final class FlushCustomClassLoader {
+
+    public static void main(String[] args) throws Exception {
+        Reference<ClassLoader> loader = getLoader("testMethod");
+
+        int attempt = 0;
+        while (loader.get() != null) {
+            if (++attempt > 10) {
+                throw new RuntimeException("Too many attempts: " + attempt);
+            }
+            System.gc();
+            Thread.sleep(1000);
+            System.out.println("Not freed, attempt: " + attempt);
+        }
+    }
+
+    public static void testMethod() {
+        DocFlavor flavor = DocFlavor.SERVICE_FORMATTED.PRINTABLE;
+        PrintServiceLookup.lookupPrintServices(flavor, null);
+    }
+
+    private static Reference<ClassLoader> getLoader(String m) throws Exception {
+        /*
+         * The print services are stored per the AppContext, and each AppContext
+         * caches the "current" class loader during creation.
+         * see javax.print.PrintServiceLookup.
+         *
+         * To prevent AppContext from cache our test loader we force AppContext
+         * creation early by the invokeAndWait.
+         * The "EventQueue.invokeAndWait(() -> {});" can be removed when the
+         * AppContext usage will be deleted in the PrintServiceLookup
+         */
+        EventQueue.invokeAndWait(() -> {});
+
+        URL url = FlushCustomClassLoader.class.getProtectionDomain()
+                                              .getCodeSource().getLocation();
+        URLClassLoader loader = new URLClassLoader(new URL[]{url}, null);
+
+        Thread ct = Thread.currentThread();
+        ct.setContextClassLoader(loader);
+        Class<?> cls = Class.forName("FlushCustomClassLoader", true, loader);
+        cls.getDeclaredMethod(m).invoke(null);
+        ct.setContextClassLoader(null);
+        loader.close();
+        return new WeakReference<>(loader);
+    }
+}


### PR DESCRIPTION
Clean backport of JDK-8273831 to fix a regression that can leave an orphaned thread. Verified with included test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273831](https://bugs.openjdk.org/browse/JDK-8273831) needs maintainer approval

### Issue
 * [JDK-8273831](https://bugs.openjdk.org/browse/JDK-8273831): PrintServiceLookup spawns 2 threads in the current classloader, getting orphaned (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2623/head:pull/2623` \
`$ git checkout pull/2623`

Update a local copy of the PR: \
`$ git checkout pull/2623` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2623`

View PR using the GUI difftool: \
`$ git pr show -t 2623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2623.diff">https://git.openjdk.org/jdk11u-dev/pull/2623.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2623#issuecomment-2019108553)