### PR TITLE
8323994: gtest runner repeats test name for every single gtest assertion

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestResultParser.java
+++ b/test/hotspot/jtreg/gtest/GTestResultParser.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class GTestResultParser {
+    private final List<String> _failedTests;
+
+    public GTestResultParser(Path file) {
+        List<String> failedTests = new ArrayList<>();
+        try (Reader r = Files.newBufferedReader(file)) {
+            XMLInputFactory factory = XMLInputFactory.newInstance();
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            XMLStreamReader xmlReader = factory.createXMLStreamReader(r);
+            String testSuite = null;
+            String testCase = null;
+            while (xmlReader.hasNext()) {
+                int code = xmlReader.next();
+                if (code == XMLStreamConstants.START_ELEMENT) {
+                    switch (xmlReader.getLocalName()) {
+                        case "testsuite":
+                            testSuite = xmlReader.getAttributeValue("", "name");
+                            break;
+                        case "testcase":
+                            testCase = xmlReader.getAttributeValue("", "name");
+                            break;
+                        case "failure":
+                            String failedStr = testSuite + "::" + testCase;
+                            if (!failedTests.contains(failedStr)) {
+                                failedTests.add(failedStr);
+                            }
+                            break;
+                        default:
+                            // ignore
+                    }
+                }
+            }
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException("can't open parse xml " + file, e);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("can't open result file " + file, e);
+        }
+        _failedTests = Collections.unmodifiableList(failedTests);
+    }
+
+    public List<String> failedTests() {
+        return _failedTests;
+    }
+}

--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,24 +25,22 @@
  * @summary a jtreg wrapper for gtest tests
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.xml
  * @requires vm.flagless
  * @run main/native GTestWrapper
  */
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-import java.util.stream.Collectors;
-
-import java.io.File;
-import java.nio.file.Paths;
-import java.nio.file.Path;
-
 import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class GTestWrapper {
     public static void main(String[] args) throws Throwable {
@@ -77,13 +75,33 @@ public class GTestWrapper {
             env.put(pathVar, path + File.pathSeparator + ldLibraryPath);
         }
 
-        pb.command(new String[] {
-            execPath.toString(),
-            "-jdk",
-            System.getProperty("test.jdk"),
-            "--gtest_catch_exceptions=0"
-        });
-        ProcessTools.executeCommand(pb).shouldHaveExitValue(0);
+        Path resultFile = Paths.get("test_result.xml");
+        pb.command(execPath.toAbsolutePath().toString(),
+                "-jdk", Utils.TEST_JDK,
+                "--gtest_output=xml:" + resultFile);
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
+        if (exitCode != 0) {
+            List<String> failedTests = failedTests(resultFile);
+            String message = "gtest execution failed; exit code = " + exitCode + ".";
+            if (!failedTests.isEmpty()) {
+                message += " the failed tests: " + failedTests;
+            }
+            throw new AssertionError(message);
+        }
+    }
+
+    private static List<String> failedTests(Path xml) {
+        if (!Files.exists(xml)) {
+            System.err.println("WARNING: test result file (" + xml + ") hasn't been found");
+        }
+
+        try {
+            return new GTestResultParser(xml).failedTests();
+        } catch (Throwable t) {
+            System.err.println("WARNING: failed to parse result file (" + xml + ") " + t);
+            t.printStackTrace();
+        }
+        return Collections.emptyList();
     }
 
     private static String getJVMVariantSubDir() {


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

test/hotspot/jtreg/gtest/GTestResultParser.java
due to the file was added by JDK-8158048, so backport with JDK-8158048 and JDK-8263659 together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8158048](https://bugs.openjdk.org/browse/JDK-8158048) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8263659](https://bugs.openjdk.org/browse/JDK-8263659) needs maintainer approval
- [x] [JDK-8323994](https://bugs.openjdk.org/browse/JDK-8323994) needs maintainer approval

### Issues
 * [JDK-8323994](https://bugs.openjdk.org/browse/JDK-8323994): gtest runner repeats test name for every single gtest assertion (**Bug** - P4 - Approved)
 * [JDK-8158048](https://bugs.openjdk.org/browse/JDK-8158048): Fix failure message from jtreg gtest wrapper (**Bug** - P3 - Approved)
 * [JDK-8263659](https://bugs.openjdk.org/browse/JDK-8263659): Reflow GTestResultParser for better readability (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2633/head:pull/2633` \
`$ git checkout pull/2633`

Update a local copy of the PR: \
`$ git checkout pull/2633` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2633`

View PR using the GUI difftool: \
`$ git pr show -t 2633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2633.diff">https://git.openjdk.org/jdk11u-dev/pull/2633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2633#issuecomment-2024611919)