### PR TITLE
8280546: Remove hard-coded 127.0.0.1 loopback address

### DIFF
--- a/test/jdk/javax/net/ssl/TLS/TestJSSE.java
+++ b/test/jdk/javax/net/ssl/TLS/TestJSSE.java
@@ -21,12 +21,13 @@
  * questions.
  */
 
+import java.net.InetAddress;
 import java.security.Provider;
 import java.security.Security;
 
 public class TestJSSE {
 
-    private static final String LOCAL_IP = "127.0.0.1";
+    private static final String LOCAL_IP = InetAddress.getLoopbackAddress().getHostAddress();
 
     public static void main(String... args) throws Exception {
         // reset the security property to make sure that the algorithms

--- a/test/jdk/javax/net/ssl/sanity/interop/JSSEClient.java
+++ b/test/jdk/javax/net/ssl/sanity/interop/JSSEClient.java
@@ -23,6 +23,7 @@
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.security.cert.Certificate;
 
 import javax.net.ssl.KeyManager;
@@ -52,7 +53,8 @@ class JSSEClient extends CipherTest.Client {
                     new TrustManager[] { CipherTest.trustManager },
                     CipherTest.secureRandom);
             SSLSocketFactory factory = (SSLSocketFactory)sslContext.getSocketFactory();
-            socket = (SSLSocket)factory.createSocket("127.0.0.1", CipherTest.serverPort);
+            socket = (SSLSocket)factory.createSocket(
+                    InetAddress.getLoopbackAddress().getHostAddress(), CipherTest.serverPort);
             socket.setSoTimeout(CipherTest.TIMEOUT);
             socket.setEnabledCipherSuites(new String[] { params.cipherSuite.name() });
             socket.setEnabledProtocols(new String[] { params.protocol.name });


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280546](https://bugs.openjdk.org/browse/JDK-8280546) needs maintainer approval

### Issue
 * [JDK-8280546](https://bugs.openjdk.org/browse/JDK-8280546): Remove hard-coded 127.0.0.1 loopback address (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2634/head:pull/2634` \
`$ git checkout pull/2634`

Update a local copy of the PR: \
`$ git checkout pull/2634` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2634`

View PR using the GUI difftool: \
`$ git pr show -t 2634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2634.diff">https://git.openjdk.org/jdk11u-dev/pull/2634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2634#issuecomment-2025181391)