### PR TITLE
8306714: Open source few Swing event and AbstractAction tests

### DIFF
--- a/test/jdk/javax/swing/Action/bug4186951.java
+++ b/test/jdk/javax/swing/Action/bug4186951.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4186951
+   @summary Bulletproofing for AbstractAction.ArrayTable Serialization.
+   @run main bug4186951
+*/
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.SwingUtilities;
+
+public class bug4186951 {
+    public static void main(String[] args) throws Exception {
+        AbstractAction ma = new MyAction();
+        MyClassSer mcs = new MyClassSer();
+        ma.putValue("serializable",mcs);
+        MyClassNonSer mcn = new MyClassNonSer();
+        ma.putValue("non-serializable",mcn);
+        FileOutputStream fos = new FileOutputStream("file.test");
+        ObjectOutputStream oos = new ObjectOutputStream(fos);
+        oos.writeObject(ma);
+        FileInputStream fis = new FileInputStream("file.test");
+        ObjectInputStream ois = new ObjectInputStream(fis);
+        ma = (MyAction)ois.readObject();
+        File fil = new File("file.test");
+        if (fil!=null) {
+            fil.delete();
+        }
+        if (!((MyClassSer)ma.getValue("serializable")).equals(mcs)) {
+            throw new RuntimeException("Serialisable class " +
+                                        " wasn't serialized...");
+        }
+        if ((MyClassNonSer)ma.getValue("non-serializable") != null) {
+            throw new RuntimeException("Serialisation occurs for " +
+                                        " non-serialisable class...");
+        }
+    }
+
+    static class MyAction extends AbstractAction {
+        public void actionPerformed(ActionEvent e) {}
+    }
+
+    static class MyClassSer implements Serializable {
+        String str = "default_string";
+        public boolean equals(MyClassSer s) {
+          return str.equals(s.str);
+        }
+    }
+
+    static class MyClassNonSer {
+        String str = "default_string";
+    }
+
+}

--- a/test/jdk/javax/swing/Action/bug4211425.java
+++ b/test/jdk/javax/swing/Action/bug4211425.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4211425
+   @summary Verifies ClassCastException in AbstractAction
+   @run main bug4211425
+*/
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+
+public class bug4211425 {
+
+    public static void main(String[] args) {
+        AbstractAction at = new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                System.out.println("Action!");
+            }
+        };
+        for (int i = 0; i < 10; i++) {
+            at.putValue("key " + i, "name");
+            at.putValue("key " + i, "name");  // Adding another with same key
+                                              // tickles this bug
+        }
+    }
+}

--- a/test/jdk/javax/swing/Action/bug4211454.java
+++ b/test/jdk/javax/swing/Action/bug4211454.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4211454
+   @summary Verifies ClassCastException in AbstractAction
+   @run main bug4211454
+*/
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+
+public class bug4211454 {
+
+    public static void main(String[] args) {
+        AbstractAction at = new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                System.out.println("Action!");
+            }
+        };
+        for (int i = 0; i<9; i++) {
+            at.putValue("key " + i, "name");
+        }
+        for (int i = 9; i>3; i--) {
+            at.putValue("key " + i, null);
+            at.putValue("Not a key " + i, null);
+        }
+    }
+}

--- a/test/jdk/javax/swing/Action/bug4244034.java
+++ b/test/jdk/javax/swing/Action/bug4244034.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4244034
+   @summary Tests that AbstractAction has method getKeys()
+   @run main bug4244034
+*/
+
+import java.util.Arrays;
+import java.util.List;
+import java.awt.event.ActionEvent;
+import javax.swing.Action;
+import javax.swing.AbstractAction;
+
+public class bug4244034 {
+
+    /** Auxilliary class extending AbstractAction
+     */
+    static class NullAction extends AbstractAction {
+        public void actionPerformed(ActionEvent e) {}
+    }
+
+    public static void main(String[] args) {
+        AbstractAction action = new NullAction();
+        action.putValue(Action.SHORT_DESCRIPTION, "my short descr");
+        action.putValue(Action.LONG_DESCRIPTION, "my long descr");
+        action.putValue(Action.NAME, "my name");
+
+        Object[] keys = action.getKeys();
+        List keysList = Arrays.asList(keys);
+        if (! keysList.contains(Action.SHORT_DESCRIPTION) ||
+            ! keysList.contains(Action.LONG_DESCRIPTION) ||
+            ! keysList.contains(Action.NAME)) {
+
+            throw new Error("Failed: getKeys() works improperly");
+        }
+    }
+}

--- a/test/jdk/javax/swing/event/bug4143690.java
+++ b/test/jdk/javax/swing/event/bug4143690.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4143690
+   @summary Tests that TreeSelectionEvent has isAddedPath(int) method
+   @run main bug4143690
+*/
+
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.tree.TreePath;
+
+public class bug4143690 {
+
+    public static void main(String[] argv) throws Exception {
+        bug4143690 test = new bug4143690();
+        TreePath p = new TreePath("");
+        TreeSelectionEvent e = new TreeSelectionEvent(test, p, true, p, p);
+
+        TreePath[] paths = e.getPaths();
+        for(int i = 0; i < paths.length; i++) {
+            TreePath path = paths[i];
+            if (e.isAddedPath(i) != true) {
+                throw new RuntimeException("Incorrect isAddedPath(int)...");
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/event/bug4160240.java
+++ b/test/jdk/javax/swing/event/bug4160240.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4160240
+   @summary InternalFrameEvent has getInternalFrame() method.
+   @run main bug4160240
+*/
+
+import javax.swing.JInternalFrame;
+import javax.swing.event.InternalFrameEvent;
+
+public class bug4160240 {
+
+    public static void main(String[] argv) throws Exception {
+        JInternalFrame jif = new JInternalFrame();
+        InternalFrameEvent ife = new InternalFrameEvent(jif,
+                                    InternalFrameEvent.INTERNAL_FRAME_OPENED);
+        if (ife.getInternalFrame() != jif) {
+            throw new RuntimeException("JInternalFrame.getInternalFrame " +
+                                        " doesn't work correctly...");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8306714](https://bugs.openjdk.org/browse/JDK-8306714) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306714](https://bugs.openjdk.org/browse/JDK-8306714): Open source few Swing event and AbstractAction tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2636/head:pull/2636` \
`$ git checkout pull/2636`

Update a local copy of the PR: \
`$ git checkout pull/2636` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2636`

View PR using the GUI difftool: \
`$ git pr show -t 2636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2636.diff">https://git.openjdk.org/jdk11u-dev/pull/2636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2636#issuecomment-2026662443)