### PR TITLE
Backport 4dd6c44cbdb0b5957414fa87b6c559fa4d6f2fa8

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
@@ -50,6 +50,7 @@ import sun.hotspot.WhiteBox;
  *     sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerCompile::dummyMethod,jdk.jfr.event.compiler.TestCompilerCompile::doTest
  *     jdk.jfr.event.compiler.TestCompilerCompile
  */
 public class TestCompilerCompile {


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jdk/commit/4dd6c44cbdb0b5957414fa87b6c559fa4d6f2fa8

This backport limits compilation only to the test methods [TestCompileCompile](https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java) cares about. It should help resolve some test failures for Adoptium (see https://github.com/adoptium/aqa-tests/issues/3046).