### PR TITLE
8324598: use mem_unit when working with sysinfo memory and swap related information

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -368,7 +368,7 @@ pid_t os::Linux::gettid() {
 julong os::Linux::host_swap() {
   struct sysinfo si;
   sysinfo(&si);
-  return (julong)si.totalswap;
+  return (julong)(si.totalswap * si.mem_unit);
 }
 
 // Most versions of linux have a bug where the number of processors are


### PR DESCRIPTION
Backport of 8324598 ; this backport does not change [src/java.base/linux/native/libjava/CgroupMetrics.c](https://github.com/openjdk/jdk/commit/7a798d3cebea0915f8a73af57333b3488c2091af#diff-e8dee60b11f369a261076ab88cda5bf76ecb720b3937b2e27a1ed64aff2b1729)

because the adjusted coding in this file is not in jdk11u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324598](https://bugs.openjdk.org/browse/JDK-8324598) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324598](https://bugs.openjdk.org/browse/JDK-8324598): use mem_unit when working with sysinfo memory and swap related information (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2642/head:pull/2642` \
`$ git checkout pull/2642`

Update a local copy of the PR: \
`$ git checkout pull/2642` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2642`

View PR using the GUI difftool: \
`$ git pr show -t 2642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2642.diff">https://git.openjdk.org/jdk11u-dev/pull/2642.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2642#issuecomment-2039725413)