### PR TITLE
8299858: [Metrics] Swap memory limit reported incorrectly when too large

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -122,9 +122,11 @@ public class CgroupMetrics implements Metrics {
     @Override
     public long getMemoryLimit() {
         long subsMem = subsystem.getMemoryLimit();
+        long systemTotal = getTotalMemorySize0();
+        assert(systemTotal > 0);
         // Catch the cgroup memory limit exceeding host physical memory.
         // Treat this as unlimited.
-        if (subsMem >= getTotalMemorySize0()) {
+        if (subsMem >= systemTotal) {
             return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
         }
         return subsMem;
@@ -142,7 +144,15 @@ public class CgroupMetrics implements Metrics {
 
     @Override
     public long getMemoryAndSwapLimit() {
-        return subsystem.getMemoryAndSwapLimit();
+        long totalSystemMemSwap = getTotalMemorySize0() + getTotalSwapSize0();
+        assert(totalSystemMemSwap > 0);
+        // Catch the cgroup memory and swap limit exceeding host physical swap
+        // and memory. Treat this case as unlimited.
+        long subsSwapMem = subsystem.getMemoryAndSwapLimit();
+        if (subsSwapMem >= totalSystemMemSwap) {
+            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
+        }
+        return subsSwapMem;
     }
 
     @Override
@@ -185,5 +195,6 @@ public class CgroupMetrics implements Metrics {
 
     private static native boolean isUseContainerSupport();
     private static native long getTotalMemorySize0();
+    private static native long getTotalSwapSize0();
 
 }

--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -23,6 +23,7 @@
  * questions.
  */
 #include <unistd.h>
+#include <sys/sysinfo.h>
 
 #include "jni.h"
 #include "jvm.h"
@@ -42,4 +43,16 @@ Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
     jlong pages = sysconf(_SC_PHYS_PAGES);
     jlong page_size = sysconf(_SC_PAGESIZE);
     return pages * page_size;
+}
+
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_platform_CgroupMetrics_getTotalSwapSize0
+  (JNIEnv *env, jclass ignored)
+{
+    struct sysinfo si;
+    int retval = sysinfo(&si);
+    if (retval < 0) {
+         return 0; // syinfo failed, treat as no swap
+    }
+    return (jlong)si.totalswap;
 }

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -37,6 +37,7 @@
  * @run driver ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:whitebox.jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestMemoryAwareness
  */
+import java.util.function.Consumer;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
@@ -96,7 +97,9 @@ public class TestMemoryAwareness {
                 true /* additional cgroup fs mounts */
             );
             testOSMXBeanIgnoresMemLimitExceedingPhysicalMemory();
+            testOSMXBeanIgnoresSwapLimitExceedingPhysical();
             testMetricsExceedingPhysicalMemory();
+            testMetricsSwapExceedingPhysical();
             testContainerMemExceedsPhysical();
         } finally {
             if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
@@ -183,6 +186,13 @@ public class TestMemoryAwareness {
 
     private static void testOperatingSystemMXBeanAwareness(String memoryAllocation, String expectedMemory,
             String swapAllocation, String expectedSwap, boolean addCgroupMounts) throws Exception {
+        Consumer<OutputAnalyzer> noOp = o -> {};
+        testOperatingSystemMXBeanAwareness(memoryAllocation, expectedMemory, swapAllocation, expectedSwap, false, noOp);
+    }
+
+    private static void testOperatingSystemMXBeanAwareness(String memoryAllocation, String expectedMemory,
+            String swapAllocation, String expectedSwap, boolean addCgroupMounts,
+            Consumer<OutputAnalyzer> additionalMatch) throws Exception {
 
         Common.logNewTestCase("Check OperatingSystemMXBean");
 
@@ -191,6 +201,7 @@ public class TestMemoryAwareness {
                 "--memory", memoryAllocation,
                 "--memory-swap", swapAllocation
             )
+            .addJavaOpts("-esa")
             // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
             // diagnostics
             .addJavaOpts("--add-exports")
@@ -224,8 +235,8 @@ public class TestMemoryAwareness {
         } catch(RuntimeException ex) {
             out.shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: 0");
         }
+        additionalMatch.accept(out);
     }
-
 
     // JDK-8292541: Ensure OperatingSystemMXBean ignores container memory limits above the host's physical memory.
     private static void testOSMXBeanIgnoresMemLimitExceedingPhysicalMemory()
@@ -233,6 +244,35 @@ public class TestMemoryAwareness {
         String hostMaxMem = getHostMaxMemory();
         String badMem = hostMaxMem + "0";
         testOperatingSystemMXBeanAwareness(badMem, hostMaxMem, badMem, hostMaxMem);
+    }
+
+    private static void testOSMXBeanIgnoresSwapLimitExceedingPhysical()
+            throws Exception {
+        long totalSwap = wb.hostPhysicalSwap() + wb.hostPhysicalMemory();
+        String expectedSwap = Long.valueOf(totalSwap).toString();
+        String hostMaxMem = getHostMaxMemory();
+        String badMem = hostMaxMem + "0";
+        final String badSwap = expectedSwap + "0";
+        testOperatingSystemMXBeanAwareness(badMem, hostMaxMem, badSwap, expectedSwap, false, o -> {
+            o.shouldNotContain("Metrics.getMemoryAndSwapLimit() == " + badSwap);
+        });
+    }
+
+    private static void testMetricsSwapExceedingPhysical()
+            throws Exception {
+        Common.logNewTestCase("Metrics ignore container swap memory limit exceeding physical");
+        long totalSwap = wb.hostPhysicalSwap() + wb.hostPhysicalMemory();
+        String expectedSwap = Long.valueOf(totalSwap).toString();
+        final String badSwap = expectedSwap + "0";
+        String badMem = getHostMaxMemory() + "0";
+        DockerRunOptions opts = Common.newOpts(imageName)
+            .addJavaOpts("-XshowSettings:system")
+            .addDockerOpts("--memory", badMem)
+            .addDockerOpts("--memory-swap", badSwap);
+
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        out.shouldContain("Memory Limit: Unlimited");
+        out.shouldContain("Memory & Swap Limit: Unlimited");
     }
 
     // JDK-8292541: Ensure Metrics ignores container memory limits above the host's physical memory.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299858](https://bugs.openjdk.org/browse/JDK-8299858) needs maintainer approval

### Issue
 * [JDK-8299858](https://bugs.openjdk.org/browse/JDK-8299858): [Metrics] Swap memory limit reported incorrectly when too large (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2644/head:pull/2644` \
`$ git checkout pull/2644`

Update a local copy of the PR: \
`$ git checkout pull/2644` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2644`

View PR using the GUI difftool: \
`$ git pr show -t 2644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2644.diff">https://git.openjdk.org/jdk11u-dev/pull/2644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2644#issuecomment-2047719644)