### PR TITLE
8163921: HttpURLConnection default Accept header is malformed according to HTTP/1.1 RFC

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,8 +285,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
     }
 
     static final String httpVersion = "HTTP/1.1";
-    static final String acceptString =
-        "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2";
+    static final String acceptString = "*/*";
 
     // the following http request headers should NOT have their values
     // returned for security reasons.

--- a/test/jdk/sun/net/www/B8185898.java
+++ b/test/jdk/sun/net/www/B8185898.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8185898
+ * @bug 8185898 8163921
  * @modules java.base/sun.net.www
  * @library /test/lib
  * @run main/othervm B8185898
@@ -143,32 +143,32 @@ public class B8185898 {
         // {{inputString1, expectedToString1, expectedPrint1}, {...}}
         String[][] strings = {
                 {"HTTP/1.1 200 OK\r\n"
-                        + "Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2\r\n"
+                        + "Accept: */*\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n\r\nfoooo",
                 "pairs: {null: HTTP/1.1 200 OK}"
-                        + "{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}"
+                        + "{Accept: */*}"
                         + "{Connection: keep-alive}"
                         + "{Host: 127.0.0.1:12345}"
                         + "{User-agent: Java/12}",
-                "Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2\r\n"
+                "Accept: */*\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n\r\n"},
                 {"HTTP/1.1 200 OK\r\n"
-                        + "Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2\r\n"
+                        + "Accept: */*\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n"
                         + "X-Header:\r\n\r\n",
                 "pairs: {null: HTTP/1.1 200 OK}"
-                        + "{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}"
+                        + "{Accept: */*}"
                         + "{Connection: keep-alive}"
                         + "{Host: 127.0.0.1:12345}"
                         + "{User-agent: Java/12}"
                         + "{X-Header: }",
-                "Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2\r\n"
+                "Accept: */*\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n"


### PR DESCRIPTION
Backport of [JDK-8163921](https://bugs.openjdk.org/browse/JDK-8163921)

Testing
- Local: Test passed
  - `B8185898.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8163921](https://bugs.openjdk.org/browse/JDK-8163921) needs maintainer approval

### Issue
 * [JDK-8163921](https://bugs.openjdk.org/browse/JDK-8163921): HttpURLConnection default Accept header is malformed according to HTTP/1.1 RFC (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2645/head:pull/2645` \
`$ git checkout pull/2645`

Update a local copy of the PR: \
`$ git checkout pull/2645` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2645`

View PR using the GUI difftool: \
`$ git pr show -t 2645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2645.diff">https://git.openjdk.org/jdk11u-dev/pull/2645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2645#issuecomment-2048850387)