### PR TITLE
8263940: NPE when creating default file system when default file system provider is packaged as JAR file on class path

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -66,6 +66,7 @@ import jdk.internal.perf.PerfCounter;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.UTF_8;
+import sun.nio.fs.DefaultFileSystemProvider;
 import sun.security.action.GetPropertyAction;
 import java.security.AccessController;
 
@@ -1405,13 +1406,19 @@ class ZipFile implements ZipConstants, Closeable {
             }
         }
         private static final HashMap<Key, Source> files = new HashMap<>();
-
+        /**
+         * Use the platform's default file system to avoid
+         * issues when the VM is configured to use a custom file system provider.
+         */
+        private static final java.nio.file.FileSystem builtInFS =
+                DefaultFileSystemProvider.theFileSystem();
 
         static Source get(File file, boolean toDelete, ZipCoder zc) throws IOException {
             final Key key;
             try {
                 key = new Key(file,
-                        Files.readAttributes(file.toPath(), BasicFileAttributes.class));
+                        Files.readAttributes(builtInFS.getPath(file.getPath()),
+                                BasicFileAttributes.class), zc);
             } catch (InvalidPathException ipe) {
                 throw new IOException(ipe);
             }

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -104,7 +104,7 @@ public class SetDefaultProvider {
             List<String> paths = stream
                     .map(path -> path.getFileName().toString())
                     .filter(f -> f.startsWith("TestProvider"))
-                    .toList();
+                    .collect(Collectors.toList());
             for(var p : paths) {
                 args.add("-C");
                 args.add(dir.toString());

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940
  * @modules jdk.jartool
  * @library /test/lib
  * @build SetDefaultProvider TestProvider m/* jdk.test.lib.process.ProcessTools
@@ -36,11 +37,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.spi.ToolProvider;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.lib.process.ProcessTools;
 
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
@@ -70,6 +74,45 @@ public class SetDefaultProvider {
         String classpath = moduleClasses + File.pathSeparator + testClasses;
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
         assertTrue(exitValue == 0);
+    }
+
+    /**
+     * Test override of default FileSystemProvider with a
+     * FileSystemProvider jar and the main application on the class path.
+     */
+    public void testClassPathWithFileSystemProviderJar() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        Path jar = Path.of("testFileSystemProvider.jar");
+        Files.deleteIfExists(jar);
+        createFileSystemProviderJar(jar, Path.of(testClasses));
+        String classpath = jar + File.pathSeparator + testClasses
+                + File.separator + "modules" + File.separator + "m";
+        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
+        assertTrue(exitValue == 0);
+    }
+
+    /**
+     * Creates a JAR containing the FileSystemProvider used to override the
+     * default FileSystemProvider
+     */
+    private void createFileSystemProviderJar(Path jar, Path dir) throws IOException {
+
+        List<String>  args = new ArrayList<>();
+        args.add("--create");
+        args.add("--file=" + jar);
+        try (Stream<Path> stream = Files.list(dir)) {
+            List<String> paths = stream
+                    .map(path -> path.getFileName().toString())
+                    .filter(f -> f.startsWith("TestProvider"))
+                    .toList();
+            for(var p : paths) {
+                args.add("-C");
+                args.add(dir.toString());
+                args.add(p);
+            }
+        }
+        int ret = JAR_TOOL.run(System.out, System.out, args.toArray(new String[0]));
+        assertTrue(ret == 0);
     }
 
     /**


### PR DESCRIPTION
Backport of [JDK-8263940](https://bugs.openjdk.org/browse/JDK-8263940)
- This PR contains 2 commits
  - commit 1 - is the changed from `git apply`
  - commit 2 - is the manual merge based on the `ZipFile.java.rej` and `SetDefaultProvider.java.rej` files
    - We respect all the changes of the `.rej` files, 
    - In `ZipFile.java` - Added missing parameter `ZipCoder zc` in `private static class Key`
    - In `SetDefaultProvider.java` - Fixed Java 11 compile errors

- `git apply` log
```
github.com/dev-8263940-11
branch 'backport-8263940' set up to track 'origin/backport-8263940'.
Switched to a new branch 'backport-8263940'

patching file 'src/java.base/share/classes/java/util/zip/ZipFile.java'
Reversed (or previously applied) patch detected!  Assume -R? [y] y
2 out of 3 hunks failed--saving rejects to 'src/java.base/share/classes/java/util/zip/ZipFile.java.rej'
patching file 'test/jdk/java/nio/file/spi/SetDefaultProvider.java'
1 out of 3 hunks failed--saving rejects to 'test/jdk/java/nio/file/spi/SetDefaultProvider.java.rej'
```

- `git status` log

```
modified:   src/java.base/share/classes/java/util/zip/ZipFile.java
modified:   test/jdk/java/nio/file/spi/SetDefaultProvider.java

Untracked files:
  src/java.base/share/classes/java/util/zip/ZipFile.java.rej
  test/jdk/java/nio/file/spi/SetDefaultProvider.java.rej
```

- `src/java.base/share/classes/java/util/zip/ZipFile.java.rej` content

```diff
@@ -68,7 +69,6 @@
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.UTF_8;
-import sun.nio.fs.DefaultFileSystemProvider;
 import sun.security.util.SignatureFileVerifier;
 
 import static java.util.zip.ZipConstants64.*;
@@ -1255,19 +1255,14 @@
             }
         }
         private static final HashMap<Key, Source> files = new HashMap<>();
-        /**
-         * Use the platform's default file system to avoid
-         * issues when the VM is configured to use a custom file system provider.
-         */
-        private static final java.nio.file.FileSystem builtInFS =
-                DefaultFileSystemProvider.theFileSystem();
+
 
         static Source get(File file, boolean toDelete, ZipCoder zc) throws IOException {
             final Key key;
             try {
                 key = new Key(file,
-                        Files.readAttributes(builtInFS.getPath(file.getPath()),
-                                BasicFileAttributes.class), zc);
+                        Files.readAttributes(file.toPath(), BasicFileAttributes.class),
+                        zc);
             } catch (InvalidPathException ipe) {
                 throw new IOException(ipe);
             }
```

- `test/jdk/java/nio/file/spi/SetDefaultProvider.java.rej`  content

```diff
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8266345
+ * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940
  * @modules jdk.jartool
  * @library /test/lib
  * @build SetDefaultProvider TestProvider m/* jdk.test.lib.process.ProcessTools
```


Testing
- Local: `SetDefaultProvider.java` - Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-29`
  - Automated jtreg test: jtreg_jdk_tier2
  - java/nio/file/spi/SetDefaultProvider.java: SUCCESSFUL GitHub 📊⏲ - [14,363 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8263940](https://bugs.openjdk.org/browse/JDK-8263940) needs maintainer approval

### Issue
 * [JDK-8263940](https://bugs.openjdk.org/browse/JDK-8263940): NPE when creating default file system when default file system provider is packaged as JAR file on class path (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [33bd99de](https://git.openjdk.org/jdk11u-dev/pull/2647/files/33bd99de32f603f712de6c0039faa4e8ac25cdb4)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2647/head:pull/2647` \
`$ git checkout pull/2647`

Update a local copy of the PR: \
`$ git checkout pull/2647` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2647`

View PR using the GUI difftool: \
`$ git pr show -t 2647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2647.diff">https://git.openjdk.org/jdk11u-dev/pull/2647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2647#issuecomment-2049048336)