### PR TITLE
8293965: Code signing warnings after JDK-8293550

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1219,11 +1219,15 @@ define SetupNativeCompilationBody
 		    $$($1_MT) -nologo -manifest $$($1_MANIFEST) -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" -outputresource:$$@;#1
                   endif
                 endif
-                # On macosx, optionally run codesign on every binary
+                # On macosx, optionally run codesign on every binary.
+                # Remove signature explicitly first to avoid warnings if the linker
+                # added a default adhoc signature.
                 ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+		  $(CODESIGN) --remove-signature $$@
 		  $(CODESIGN) -f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime \
 		      --entitlements $$(call GetEntitlementsFile, $$@) $$@
                 else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+		  $(CODESIGN) --remove-signature $$@
 		  $(CODESIGN) -f -s - --entitlements $$(call GetEntitlementsFile, $$@) $$@
                 endif
   endif


### PR DESCRIPTION
Backport of [JDK-8293965](https://bugs.openjdk.org/browse/JDK-8293965)

Testing
- Local: make jdk succeeded in local macOS `14.4.1 (23E224)`
```
dev-8293965-11/build/macosx-aarch64-normal-server-slowdebug/images/jdk/bin % ./java -version
openjdk version "11.0.24-internal" 2024-07-16
OpenJDK Runtime Environment (slowdebug build 11.0.24-internal+0-adhoc.I048686.dev-8293965-11)
OpenJDK 64-Bit Server VM (slowdebug build 11.0.24-internal+0-adhoc.I048686.dev-8293965-11, mixed mode)
```
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8293965](https://bugs.openjdk.org/browse/JDK-8293965) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293965](https://bugs.openjdk.org/browse/JDK-8293965): Code signing warnings after JDK-8293550 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2648/head:pull/2648` \
`$ git checkout pull/2648`

Update a local copy of the PR: \
`$ git checkout pull/2648` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2648`

View PR using the GUI difftool: \
`$ git pr show -t 2648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2648.diff">https://git.openjdk.org/jdk11u-dev/pull/2648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2648#issuecomment-2049109171)