### PR TITLE
8318854: [macos14] Running any AWT app prints Secure coding warning

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -811,7 +811,7 @@ AWT_ASSERT_APPKIT_THREAD;
         isDisabled = !awtWindow.isEnabled;
     }
 
-    if (menuBar == nil) {
+    if (menuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
         menuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         isDisabled = NO;
     }
@@ -1180,7 +1180,7 @@ JNI_COCOA_ENTER(env);
         window.javaMenuBar = menuBar;
 
         CMenuBar* actualMenuBar = menuBar;
-        if (actualMenuBar == nil) {
+        if (actualMenuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
             actualMenuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -210,9 +210,11 @@ static BOOL sSetupHelpMenu = NO;
         // In theory, this might cause flickering if the window gaining focus
         // has its own menu. However, I couldn't reproduce it on practice, so
         // perhaps this is a non issue.
-        CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
-        if (defaultMenu != nil) {
-            [CMenuBar activate:defaultMenu modallyDisabled:NO];
+        if ([ApplicationDelegate sharedDelegate] != nil) {
+            CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
+            if (defaultMenu != nil) {
+                [CMenuBar activate:defaultMenu modallyDisabled:NO];
+            }
         }
     }
 }

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -200,6 +200,21 @@
     } copy]];
 }
 
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    static BOOL checked = NO;
+    static BOOL supportsSecureState = YES;
+
+    if (checked == NO) {
+        checked = YES;
+        if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+            supportsSecureState = NO;
+        }
+    }
+    return supportsSecureState;
+}
+
 - (void)processQueuedEventsWithTargetDelegate:(id <NSApplicationDelegate>)delegate
 {
     self.realDelegate = delegate;


### PR DESCRIPTION
Backport of [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854)

Testing in Local: Passed on `MacOS 14.4.1 (23E224)`
- Before the Change, the message is shown
  - `WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.`

```
SwingSet2 % pwd
SAPDevelop/github.com/dev-8318854-11/build/macosx-aarch64-normal-server-slowdebug/images/jdk/demo/jfc/SwingSet2

SwingSet2 % ~/SAPDevelop/tools/java-11/Contents/Home/bin/java -version                                                                       
openjdk version "11.0.19" 2023-04-18 LTS
OpenJDK Runtime Environment SapMachine (build 11.0.19+7-LTS-sapmachine)
OpenJDK 64-Bit Server VM SapMachine (build 11.0.19+7-LTS-sapmachine, mixed mode)

SwingSet2 % ~/SAPDevelop/tools/java-11/Contents/Home/bin/java -jar SwingSet2.jar                                                             
2024-04-23 14:26:21.290 java[61586:391167] WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.
```

- After the Change, the message is gone

```
SwingSet2 % pwd
SAPDevelop/github.com/dev-8318854-11/build/macosx-aarch64-normal-server-slowdebug/images/jdk/demo/jfc/SwingSet2

SwingSet2 % ~/SAPDevelop/github.com/dev-8318854-11/build/macosx-aarch64-normal-server-slowdebug/images/jdk/bin/java -version  
openjdk version "11.0.24-internal" 2024-07-16
OpenJDK Runtime Environment (slowdebug build 11.0.24-internal+0-adhoc.I048686.dev-8318854-11)
OpenJDK 64-Bit Server VM (slowdebug build 11.0.24-internal+0-adhoc.I048686.dev-8318854-11, mixed mode)

SwingSet2 % ~/SAPDevelop/github.com/dev-8318854-11/build/macosx-aarch64-normal-server-slowdebug/images/jdk/bin/java -jar SwingSet2.jar 
2024-04-23 14:28:58.784 java[62205:395610] name is : .SFNS-Regular
2024-04-23 14:28:58.784 java[62205:395610] family is : .AppleSystemUIFont
2024-04-23 14:28:58.784 java[62205:395610] name is : .SFNS-Bold
2024-04-23 14:28:58.784 java[62205:395610] family is : .AppleSystemUIFont
2024-04-23 14:28:58.967 java[62205:395610] nsFont-name is : .AppleSystemUIFont
```

Testing on Servers
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854) needs maintainer approval

### Issue
 * [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854): [macos14] Running any AWT app prints Secure coding warning (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2649/head:pull/2649` \
`$ git checkout pull/2649`

Update a local copy of the PR: \
`$ git checkout pull/2649` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2649`

View PR using the GUI difftool: \
`$ git pr show -t 2649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2649.diff">https://git.openjdk.org/jdk11u-dev/pull/2649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2649#issuecomment-2049171589)