### PR TITLE
8282017: sun/net/www/protocol/https/HttpsURLConnection/B6216082.java fails with "SocketException: Unexpected end of file from server"

### DIFF
--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
@@ -263,9 +263,9 @@ public class TunnelProxy {
             boolean res;
             try {
                 InputStream is = new BufferedInputStream (new NioInputStream (chan));
-                String requestline = readLine (is);
-                HttpHeaderParser mhead = new HttpHeaderParser (is);
-                String[] req = requestline.split (" ");
+                HttpHeaderParser mHead = new HttpHeaderParser (is);
+                String requestLine = mHead.getRequestDetails();
+                String[] req = requestLine.split (" ");
                 if (req.length < 2) {
                     /* invalid request line */
                     return false;


### PR DESCRIPTION
Backport of [JDK-8282017](https://bugs.openjdk.org/browse/JDK-8282017)
- This PR can be `considered as clean`, because 
  - We only miss the changed in the `test/jdk/ProblemList.txt` file due to the line removed does not exist
  - Well the changes of file `TunnelProxy.java` in [original commit](https://github.com/openjdk/jdk/commit/cd9a3cf05b2c200709103e2e8596414a62a1c441) is clean.
- `git apply` log

```
github.com/dev-8282017-11
branch 'backport-8282017' set up to track 'origin/backport-8282017'.
Switched to a new branch 'backport-8282017'
patching file 'test/jdk/ProblemList.txt'
Reversed (or previously applied) patch detected!  Assume -R? [y] y
patching file 'test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java'
```


Testing
- Local: Test passed on `MacOS 14.4.1`
  - Not a test or directory containing tests: `sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java`
  - `test/jdk/sun/net/www/protocol/https/HttpsURLConnection/B6216082.java` - Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8282017](https://bugs.openjdk.org/browse/JDK-8282017) needs maintainer approval

### Issue
 * [JDK-8282017](https://bugs.openjdk.org/browse/JDK-8282017): sun/net/www/protocol/https/HttpsURLConnection/B6216082.java fails with "SocketException: Unexpected end of file from server" (**Bug** - P2 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2650/head:pull/2650` \
`$ git checkout pull/2650`

Update a local copy of the PR: \
`$ git checkout pull/2650` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2650`

View PR using the GUI difftool: \
`$ git pr show -t 2650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2650.diff">https://git.openjdk.org/jdk11u-dev/pull/2650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2650#issuecomment-2050557022)