### PR TITLE
8306067: Open source AWT Graphics,GridBagLayout related tests

### DIFF
--- a/test/jdk/java/awt/Graphics/DrawNullStringTest.java
+++ b/test/jdk/java/awt/Graphics/DrawNullStringTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 4166809
+ * @summary Make sure NPE is thrown when calling
+ *     Graphics.drawString(null, int, int)
+ * @run main DrawNullStringTest
+ */
+import java.awt.image.BufferedImage;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+
+public class DrawNullStringTest {
+    static String s = null;
+    static boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            BufferedImage img = new BufferedImage(100, 100,
+                                                  BufferedImage.TYPE_INT_RGB);
+            Graphics g = (Graphics)(img.getGraphics());
+            try {
+                g.drawString(s, 30, 30);
+            } catch (NullPointerException npe) {
+                System.out.println("NPE thrown - test passes");
+                passed = true;
+            }
+
+            if (passed == false) {
+                throw new Error("No Exception was thrown - should be an NPE");
+            }
+        });
+    }
+
+ }// class DrawNullStringTest

--- a/test/jdk/java/awt/Graphics/GetGraphicsTest.java
+++ b/test/jdk/java/awt/Graphics/GetGraphicsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4746122
+ * @summary Checks getGraphics doesn't throw NullPointerExcepton for invalid colors and font.
+ * @run main GetGraphicsTest
+*/
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class GetGraphicsTest extends Frame {
+    public Color getBackground() {
+        return null;
+    }
+    public Color getForeground() {
+        return null;
+    }
+    public Font getFont() {
+        return null;
+    }
+
+    public static void main(String[] args) throws Exception {
+        GetGraphicsTest test = new GetGraphicsTest();
+        Graphics g = test.getGraphics();
+    }
+}// class GetGraphicsTest

--- a/test/jdk/java/awt/Graphics/GetGraphicsTest.java
+++ b/test/jdk/java/awt/Graphics/GetGraphicsTest.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 4746122
+ * @key headful
  * @summary Checks getGraphics doesn't throw NullPointerExcepton for invalid colors and font.
  * @run main GetGraphicsTest
 */

--- a/test/jdk/java/awt/GridBagLayout/GridBagLayoutButtonsOverlapTest.java
+++ b/test/jdk/java/awt/GridBagLayout/GridBagLayoutButtonsOverlapTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4930685
+  @summary Test effect of GridBagConstraints on padding / layout
+  @key headful
+  @run main GridBagLayoutButtonsOverlapTest
+*/
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridBagLayout;
+import java.awt.GridBagConstraints;
+
+public class GridBagLayoutButtonsOverlapTest {
+    public static GridBagLayout gridbag;
+    public static GridBagConstraints c;
+    public static Button b1;
+    public static Button b2;
+    public static Button b4;
+    public static Button b5;
+    public static Button b6;
+    public static Button b7;
+    public static Button b8;
+    public static Button b9;
+    public static Button b10;
+    public static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                createUI();
+                test();
+            } finally {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+
+    public static void createUI() {
+        frame = new Frame();
+        gridbag = new GridBagLayout();
+        GridBagConstraints c = new GridBagConstraints();
+        frame.setFont(new Font(Font.DIALOG, Font.PLAIN, 14));
+        frame.setLayout(gridbag);
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1.0;
+        b1 = makeButton("button1", gridbag, c);
+        b2 = makeButton("button2", gridbag, c);
+
+        c.gridwidth = GridBagConstraints.REMAINDER;
+        b4 = makeButton("button4", gridbag, c);
+
+        c.weightx = 0.0;
+        b5 = makeButton("button5", gridbag, c);
+
+        c.gridwidth = GridBagConstraints.RELATIVE;
+        b6 = makeButton("button6", gridbag, c);
+
+        c.gridwidth = GridBagConstraints.REMAINDER;
+        b7 = makeButton("button7", gridbag, c);
+
+        c.gridwidth = 1;
+        c.gridheight = 2;
+        c.weighty = 1.0;
+        b8 = makeButton("button8", gridbag, c);
+
+        c.weighty = 0.0;
+        c.gridwidth = GridBagConstraints.REMAINDER;
+        c.gridheight = 1;
+        b9 = makeButton("button9", gridbag, c);
+        b10 = makeButton("button10", gridbag, c);
+    }
+
+    public static void test() {
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+
+        int b1Corner = b1.getLocation().y + b1.getHeight();
+        int b5Corner = b5.getLocation().y;
+        if (b1Corner > b5Corner) { //they are equals each other in best case
+            throw new RuntimeException("Buttons are overlapped when container is small enough");
+        }
+        System.out.println("Test passed.");
+    }
+
+    protected static Button makeButton(String name,
+                                 GridBagLayout gridbag,
+                                 GridBagConstraints c) {
+        Button button = new Button(name);
+        gridbag.setConstraints(button, c);
+        frame.add(button);
+        return button;
+    }
+
+}// class

--- a/test/jdk/java/awt/GridBagLayout/GridBagLayoutOutOfBoundsTest.java
+++ b/test/jdk/java/awt/GridBagLayout/GridBagLayoutOutOfBoundsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5055696
+  @summary REGRESSION: GridBagLayout throws ArrayIndexOutOfBoundsExceptions
+  @key headful
+  @run main GridBagLayoutOutOfBoundsTest
+*/
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridBagLayout;
+import java.awt.GridBagConstraints;
+import java.awt.Panel;
+
+public class GridBagLayoutOutOfBoundsTest {
+    final static int L=2;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                frame = new Frame("GridBagLayoutOutOfBoundsTestFrame");
+                frame.validate();
+                GridBagLayout layout = new GridBagLayout();
+                frame.setLayout(layout);
+                GridBagConstraints gridBagConstraints;
+
+                Button[] mb = new Button[L];
+                for (int i = 0; i<L; i++){
+                    mb[i] = new Button(""+i);
+                }
+                for (int i = 0; i<mb.length; i++){
+                    gridBagConstraints = new GridBagConstraints();
+                    gridBagConstraints.gridwidth = GridBagConstraints.REMAINDER;
+                    gridBagConstraints.gridheight = GridBagConstraints.REMAINDER;
+                    frame.add(mb[i], gridBagConstraints);
+                }
+                frame.setVisible(true);
+            } finally {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8306067](https://bugs.openjdk.org/browse/JDK-8306067) and [JDK-8306838](https://bugs.openjdk.org/browse/JDK-8306838)

Testing
- Local: Test passed, on MacOS 14.4.1
  - `DrawNullStringTest.java`: Test results: passed: 1
  - `GetGraphicsTest.java`: Test results: passed: 1
  - `GridBagLayoutButtonsOverlapTest.java`: Test results: passed: 1
  - `GridBagLayoutOutOfBoundsTest.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies `GetGraphicsTest.java` skipped on `2024-04-25`
  - `java/awt/Graphics/GetGraphicsTest.java`: **SKIPPED** [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8306838](https://bugs.openjdk.org/browse/JDK-8306838) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306067](https://bugs.openjdk.org/browse/JDK-8306067) needs maintainer approval

### Issues
 * [JDK-8306067](https://bugs.openjdk.org/browse/JDK-8306067): Open source AWT Graphics,GridBagLayout related tests (**Bug** - P4 - Approved)
 * [JDK-8306838](https://bugs.openjdk.org/browse/JDK-8306838): GetGraphicsTest needs to be headful (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2653/head:pull/2653` \
`$ git checkout pull/2653`

Update a local copy of the PR: \
`$ git checkout pull/2653` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2653`

View PR using the GUI difftool: \
`$ git pr show -t 2653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2653.diff">https://git.openjdk.org/jdk11u-dev/pull/2653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2653#issuecomment-2051015306)