### PR TITLE
8304761: Update IANA Language Subtag Registry to Version 2023-03-22

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2022-08-08
+File-Date: 2023-03-22
 %%
 Type: language
 Subtag: aa
@@ -2143,6 +2143,8 @@ Type: language
 Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: apc
 Macrolanguage: ar
 %%
 Type: language
@@ -2790,7 +2792,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: apc
-Description: North Levantine Arabic
+Description: Levantine Arabic
 Added: 2009-07-29
 Macrolanguage: ar
 %%
@@ -8910,6 +8912,11 @@ Description: Kuwaataay
 Added: 2009-07-29
 %%
 Type: language
+Subtag: cxh
+Description: Cha'ari
+Added: 2023-03-17
+%%
+Type: language
 Subtag: cya
 Description: Nopala Chatino
 Added: 2009-07-29
@@ -10176,6 +10183,11 @@ Description: Disa
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dsk
+Description: Dokshi
+Added: 2023-03-17
+%%
+Type: language
 Subtag: dsl
 Description: Danish Sign Language
 Added: 2009-07-29
@@ -10503,6 +10515,11 @@ Description: Jola-Fonyi
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dyr
+Description: Dyarim
+Added: 2023-03-17
+%%
+Type: language
 Subtag: dyu
 Description: Dyula
 Added: 2005-10-16
@@ -10522,7 +10539,6 @@ Type: language
 Subtag: dzd
 Description: Daza
 Added: 2009-07-29
-Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: dze
@@ -11144,6 +11160,11 @@ Type: language
 Subtag: etz
 Description: Semimi
 Added: 2009-07-29
+%%
+Type: language
+Subtag: eud
+Description: Eudeve
+Added: 2023-03-17
 %%
 Type: language
 Subtag: euq
@@ -14805,6 +14826,11 @@ Added: 2009-07-29
 Macrolanguage: iu
 %%
 Type: language
+Subtag: ikh
+Description: Ikhin-Arokho
+Added: 2023-03-17
+%%
+Type: language
 Subtag: iki
 Description: Iko
 Added: 2009-07-29
@@ -15378,6 +15404,11 @@ Description: Izi-Ezaa-Ikwo-Mgbo
 Added: 2009-07-29
 Deprecated: 2013-09-10
 Comments: see eza, gmz, iqw, izz
+%%
+Type: language
+Subtag: izm
+Description: Kizamani
+Added: 2023-03-17
 %%
 Type: language
 Subtag: izr
@@ -16922,6 +16953,8 @@ Type: language
 Subtag: kgm
 Description: Karipúna
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: plu
 %%
 Type: language
 Subtag: kgn
@@ -18339,7 +18372,7 @@ Scope: collection
 %%
 Type: language
 Subtag: krp
-Description: Korop
+Description: Durop
 Added: 2009-07-29
 %%
 Type: language
@@ -18392,6 +18425,8 @@ Type: language
 Subtag: ksa
 Description: Shuwa-Zamani
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see izm, rsw
 %%
 Type: language
 Subtag: ksb
@@ -19476,7 +19511,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: lag
-Description: Langi
+Description: Rangi
 Added: 2009-07-29
 %%
 Type: language
@@ -20009,6 +20044,12 @@ Type: language
 Subtag: lgr
 Description: Lengo
 Added: 2009-07-29
+%%
+Type: language
+Subtag: lgs
+Description: Guinea-Bissau Sign Language
+Description: Língua Gestual Guineense
+Added: 2023-03-17
 %%
 Type: language
 Subtag: lgt
@@ -20655,6 +20696,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: loh
+Description: Laarim
 Description: Narim
 Added: 2009-07-29
 %%
@@ -21127,6 +21169,11 @@ Type: language
 Subtag: lvk
 Description: Lavukaleve
 Added: 2009-07-29
+%%
+Type: language
+Subtag: lvl
+Description: Lwel
+Added: 2023-03-17
 %%
 Type: language
 Subtag: lvs
@@ -26188,6 +26235,8 @@ Type: language
 Subtag: nom
 Description: Nocamán
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: cbr
 %%
 Type: language
 Subtag: non
@@ -27085,6 +27134,11 @@ Type: language
 Subtag: nzm
 Description: Zeme Naga
 Added: 2009-07-29
+%%
+Type: language
+Subtag: nzr
+Description: Dir-Nyamzak-Mbarimi
+Added: 2023-03-17
 %%
 Type: language
 Subtag: nzs
@@ -28845,6 +28899,8 @@ Type: language
 Subtag: plj
 Description: Polci
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see nzr, pze, uly, zlu
 %%
 Type: language
 Subtag: plk
@@ -28970,6 +29026,8 @@ Type: language
 Subtag: pmk
 Description: Pamlico
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: crr
 %%
 Type: language
 Subtag: pml
@@ -29446,6 +29504,8 @@ Type: language
 Subtag: prp
 Description: Parsi
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: gu
 %%
 Type: language
 Subtag: prq
@@ -29855,6 +29915,11 @@ Type: language
 Subtag: pyy
 Description: Pyen
 Added: 2009-07-29
+%%
+Type: language
+Subtag: pze
+Description: Pesse
+Added: 2023-03-17
 %%
 Type: language
 Subtag: pzh
@@ -30873,7 +30938,7 @@ Deprecated: 2017-02-23
 Type: language
 Subtag: rsk
 Description: Ruthenian
-Description: Rusyn
+Description: Rusnak
 Added: 2022-02-25
 %%
 Type: language
@@ -30890,6 +30955,11 @@ Type: language
 Subtag: rsn
 Description: Rwandan Sign Language
 Added: 2022-02-25
+%%
+Type: language
+Subtag: rsw
+Description: Rishiwa
+Added: 2023-03-17
 %%
 Type: language
 Subtag: rtc
@@ -32328,6 +32398,7 @@ Type: language
 Subtag: slq
 Description: Salchuq
 Added: 2009-07-29
+Deprecated: 2023-03-17
 %%
 Type: language
 Subtag: slr
@@ -33685,6 +33756,8 @@ Type: language
 Subtag: szd
 Description: Seru
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: umi
 %%
 Type: language
 Subtag: sze
@@ -35065,6 +35138,8 @@ Type: language
 Subtag: tmk
 Description: Northwestern Tamang
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: tdg
 %%
 Type: language
 Subtag: tml
@@ -35481,6 +35556,8 @@ Type: language
 Subtag: tpw
 Description: Tupí
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: tpn
 %%
 Type: language
 Subtag: tpx
@@ -36074,6 +36151,11 @@ Type: language
 Subtag: tve
 Description: Te'un
 Added: 2009-07-29
+%%
+Type: language
+Subtag: tvi
+Description: Tulai
+Added: 2023-03-17
 %%
 Type: language
 Subtag: tvk
@@ -36727,6 +36809,11 @@ Description: Ulwa
 Added: 2010-03-11
 %%
 Type: language
+Subtag: uly
+Description: Buli
+Added: 2023-03-17
+%%
+Type: language
 Subtag: uma
 Description: Umatilla
 Added: 2009-07-29
@@ -37316,6 +37403,11 @@ Type: language
 Subtag: viv
 Description: Iduna
 Added: 2009-07-29
+%%
+Type: language
+Subtag: vjk
+Description: Bajjika
+Added: 2023-03-17
 %%
 Type: language
 Subtag: vka
@@ -38316,7 +38408,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: wnb
-Description: Wanambre
+Description: Mokati
 Added: 2009-07-29
 %%
 Type: language
@@ -38617,6 +38709,11 @@ Type: language
 Subtag: wsv
 Description: Wotapuri-Katarqalai
 Added: 2009-07-29
+%%
+Type: language
+Subtag: wtb
+Description: Matambwe
+Added: 2023-03-17
 %%
 Type: language
 Subtag: wtf
@@ -40085,6 +40182,8 @@ Type: language
 Subtag: xss
 Description: Assan
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: zko
 %%
 Type: language
 Subtag: xsu
@@ -40668,6 +40767,11 @@ Description: Chepya
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ycr
+Description: Yilan Creole
+Added: 2023-03-17
+%%
+Type: language
 Subtag: yda
 Description: Yanda
 Added: 2013-09-10
@@ -40945,6 +41049,11 @@ Type: language
 Subtag: ykg
 Description: Northern Yukaghir
 Added: 2009-07-29
+%%
+Type: language
+Subtag: ykh
+Description: Khamnigan Mongol
+Added: 2023-03-17
 %%
 Type: language
 Subtag: yki
@@ -41921,6 +42030,11 @@ Added: 2009-07-29
 Macrolanguage: za
 %%
 Type: language
+Subtag: zem
+Description: Zeem
+Added: 2023-03-17
+%%
+Type: language
 Subtag: zen
 Description: Zenaga
 Added: 2005-10-16
@@ -42047,6 +42161,8 @@ Type: language
 Subtag: zkb
 Description: Koibal
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: kjh
 %%
 Type: language
 Subtag: zkd
@@ -42148,6 +42264,11 @@ Subtag: zls
 Description: South Slavic languages
 Added: 2009-07-29
 Scope: collection
+%%
+Type: language
+Subtag: zlu
+Description: Zul
+Added: 2023-03-17
 %%
 Type: language
 Subtag: zlw
@@ -42654,6 +42775,8 @@ Type: language
 Subtag: zua
 Description: Zeem
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see cxh, dsk, dyr, tvi, zem
 %%
 Type: language
 Subtag: zuh
@@ -42861,7 +42984,8 @@ Type: extlang
 Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
-Preferred-Value: ajp
+Deprecated: 2023-03-17
+Preferred-Value: apc
 Prefix: ar
 Macrolanguage: ar
 %%
@@ -42874,7 +42998,7 @@ Prefix: sgn
 %%
 Type: extlang
 Subtag: apc
-Description: North Levantine Arabic
+Description: Levantine Arabic
 Added: 2009-07-29
 Preferred-Value: apc
 Prefix: ar
@@ -43693,6 +43817,14 @@ Added: 2009-07-29
 Preferred-Value: lcf
 Prefix: ms
 Macrolanguage: ms
+%%
+Type: extlang
+Subtag: lgs
+Description: Guinea-Bissau Sign Language
+Description: Língua Gestual Guineense
+Added: 2023-03-17
+Preferred-Value: lgs
+Prefix: sgn
 %%
 Type: extlang
 Subtag: liw

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038
+ *      8258795 8267038 8304761
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2022-08-08) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-03-22) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */
@@ -44,10 +44,10 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, aue, bcg, bic, bpp, cey, cnp, cqu, csp, csx, dif, dmw, dsz, ehs, ema,"
-        + " en-gb-oed, gti, iba, jks, kdz, kmb, koj, kru, ksp, kwq, kxe, kzk, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
-        + " ngv, nns, ola, oyb, pat, phr, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tjj, tjp, tvx,"
-        + " uss, uth, ysm, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
+        + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
+        + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
             new LanguageRange("aas", 1.0),
@@ -60,6 +60,10 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("sgn-ajs", 1.0),
             new LanguageRange("aog", 1.0),
             new LanguageRange("myd", 1.0),
+            new LanguageRange("apc", 1.0),
+            new LanguageRange("ar-apc", 1.0),
+            new LanguageRange("ar-ajp", 1.0),
+            new LanguageRange("ajp", 1.0),
             new LanguageRange("aue", 1.0),
             new LanguageRange("ktz", 1.0),
             new LanguageRange("bcg", 1.0),
@@ -69,10 +73,14 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("bpp", 1.0),
             new LanguageRange("nxu", 1.0),
             new LanguageRange("cey", 1.0),
+            new LanguageRange("cbr", 1.0),
+            new LanguageRange("nom", 1.0),
             new LanguageRange("cnp", 1.0),
             new LanguageRange("zh-cnp", 1.0),
             new LanguageRange("cqu", 1.0),
             new LanguageRange("quh", 1.0),
+            new LanguageRange("crr", 1.0),
+            new LanguageRange("pmk", 1.0),
             new LanguageRange("csp", 1.0),
             new LanguageRange("zh-csp", 1.0),
             new LanguageRange("csx", 1.0),
@@ -98,6 +106,8 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("sgn-jks", 1.0),
             new LanguageRange("kdz", 1.0),
             new LanguageRange("ncp", 1.0),
+            new LanguageRange("kjh", 1.0),
+            new LanguageRange("zkb", 1.0),
             new LanguageRange("kmb", 1.0),
             new LanguageRange("smd", 1.0),
             new LanguageRange("koj", 1.0),
@@ -113,6 +123,8 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("kzk", 1.0),
             new LanguageRange("gli", 1.0),
             new LanguageRange("drr", 1.0),
+            new LanguageRange("lgs", 1.0),
+            new LanguageRange("sgn-lgs", 1.0),
             new LanguageRange("lii", 1.0),
             new LanguageRange("raq", 1.0),
             new LanguageRange("lmm", 1.0),
@@ -144,6 +156,8 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("kxr", 1.0),
             new LanguageRange("phr", 1.0),
             new LanguageRange("pmu", 1.0),
+            new LanguageRange("plu", 1.0),
+            new LanguageRange("kgm", 1.0),
             new LanguageRange("pnd", 1.0),
             new LanguageRange("pub", 1.0),
             new LanguageRange("puz", 1.0),
@@ -163,13 +177,21 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("szy", 1.0),
             new LanguageRange("taj", 1.0),
             new LanguageRange("tsf", 1.0),
+            new LanguageRange("tdg", 1.0),
+            new LanguageRange("tmk", 1.0),
             new LanguageRange("tjj", 1.0),
             new LanguageRange("tjp", 1.0),
+            new LanguageRange("tpn", 1.0),
+            new LanguageRange("tpw", 1.0),
             new LanguageRange("tvx", 1.0),
+            new LanguageRange("umi", 1.0),
+            new LanguageRange("szd", 1.0),
             new LanguageRange("uss", 1.0),
             new LanguageRange("uth", 1.0),
             new LanguageRange("ysm", 1.0),
             new LanguageRange("sgn-ysm", 1.0),
+            new LanguageRange("zko", 1.0),
+            new LanguageRange("xss", 1.0),
             new LanguageRange("wkr", 0.9),
             new LanguageRange("ar-hyw", 0.8),
             new LanguageRange("yug", 0.5),


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8304761](https://bugs.openjdk.org/browse/JDK-8304761) needs maintainer approval

### Issue
 * [JDK-8304761](https://bugs.openjdk.org/browse/JDK-8304761): Update IANA Language Subtag Registry to Version 2023-03-22 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2673/head:pull/2673` \
`$ git checkout pull/2673`

Update a local copy of the PR: \
`$ git checkout pull/2673` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2673`

View PR using the GUI difftool: \
`$ git pr show -t 2673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2673.diff">https://git.openjdk.org/jdk11u-dev/pull/2673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2673#issuecomment-2066221740)