### PR TITLE
8220202: Simplify/standardize method naming for HtmlTree

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,8 +78,8 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     protected void addTypeParameters(ExecutableElement member, Content htmltree) {
         Content typeParameters = getTypeParameters(member);
         if (!typeParameters.isEmpty()) {
-            htmltree.addContent(typeParameters);
-            htmltree.addContent(Contents.SPACE);
+            htmltree.add(typeParameters);
+            htmltree.add(Contents.SPACE);
         }
     }
 
@@ -100,16 +100,16 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     @Override
     protected Content getDeprecatedLink(Element member) {
         Content deprecatedLinkContent = new ContentBuilder();
-        deprecatedLinkContent.addContent(utils.getFullyQualifiedName(member));
+        deprecatedLinkContent.add(utils.getFullyQualifiedName(member));
         if (!utils.isConstructor(member)) {
-            deprecatedLinkContent.addContent(".");
-            deprecatedLinkContent.addContent(member.getSimpleName());
+            deprecatedLinkContent.add(".");
+            deprecatedLinkContent.add(member.getSimpleName());
         }
         String signature = utils.flatSignature((ExecutableElement) member);
         if (signature.length() > 2) {
-            deprecatedLinkContent.addContent(Contents.ZERO_WIDTH_SPACE);
+            deprecatedLinkContent.add(Contents.ZERO_WIDTH_SPACE);
         }
-        deprecatedLinkContent.addContent(signature);
+        deprecatedLinkContent.add(signature);
 
         return writer.getDocLink(MEMBER, utils.getEnclosingTypeElement(member), member, deprecatedLinkContent);
     }
@@ -131,7 +131,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                 name(ee), false));
         Content code = HtmlTree.CODE(memberLink);
         addParameters(ee, false, code, name(ee).length() - 1);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**
@@ -143,7 +143,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content linksTree) {
-        linksTree.addContent(writer.getDocLink(MEMBER, te, member, name(member), false));
+        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member), false));
     }
 
     /**
@@ -158,10 +158,10 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
             boolean isVarArg, Content tree) {
         Content link = writer.getLink(new LinkInfoImpl(configuration, EXECUTABLE_MEMBER_PARAM,
                 param.asType()).varargs(isVarArg));
-        tree.addContent(link);
+        tree.add(link);
         if(name(param).length() > 0) {
-            tree.addContent(Contents.SPACE);
-            tree.addContent(name(param));
+            tree.add(Contents.SPACE);
+            tree.add(name(param));
         }
     }
 
@@ -176,12 +176,12 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     protected void addReceiverAnnotations(ExecutableElement member, TypeMirror rcvrType,
             List<? extends AnnotationMirror> annotationMirrors, Content tree) {
         writer.addReceiverAnnotationInfo(member, rcvrType, annotationMirrors, tree);
-        tree.addContent(Contents.SPACE);
-        tree.addContent(utils.getTypeName(rcvrType, false));
+        tree.add(Contents.SPACE);
+        tree.add(utils.getTypeName(rcvrType, false));
         LinkInfoImpl linkInfo = new LinkInfoImpl(configuration, RECEIVER_TYPE, rcvrType);
-        tree.addContent(writer.getTypeParameterLinks(linkInfo));
-        tree.addContent(Contents.SPACE);
-        tree.addContent("this");
+        tree.add(writer.getTypeParameterLinks(linkInfo));
+        tree.add(Contents.SPACE);
+        tree.add("this");
     }
 
 
@@ -216,7 +216,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         }
         int paramstart;
         for (paramstart = 0; paramstart < parameters.size(); paramstart++) {
-            paramTree.addContent(sep);
+            paramTree.add(sep);
             VariableElement param = parameters.get(paramstart);
 
             if (param.getKind() != ElementKind.INSTANCE_INIT) {
@@ -225,8 +225,8 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                             writer.addAnnotationInfo(indent.length(),
                             member, param, paramTree);
                     if (foundAnnotations) {
-                        paramTree.addContent(DocletConstants.NL);
-                        paramTree.addContent(indent);
+                        paramTree.add(DocletConstants.NL);
+                        paramTree.add(indent);
                     }
                 }
                 addParam(member, param,
@@ -236,28 +236,28 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         }
 
         for (int i = paramstart + 1; i < parameters.size(); i++) {
-            paramTree.addContent(",");
-            paramTree.addContent(DocletConstants.NL);
-            paramTree.addContent(indent);
+            paramTree.add(",");
+            paramTree.add(DocletConstants.NL);
+            paramTree.add(indent);
             if (includeAnnotations) {
                 boolean foundAnnotations =
                         writer.addAnnotationInfo(indent.length(), member, parameters.get(i),
                         paramTree);
                 if (foundAnnotations) {
-                    paramTree.addContent(DocletConstants.NL);
-                    paramTree.addContent(indent);
+                    paramTree.add(DocletConstants.NL);
+                    paramTree.add(indent);
                 }
             }
             addParam(member, parameters.get(i), (i == parameters.size() - 1) && member.isVarArgs(),
                     paramTree);
         }
         if (paramTree.isEmpty()) {
-            htmltree.addContent("()");
+            htmltree.add("()");
         } else {
-            htmltree.addContent(Contents.ZERO_WIDTH_SPACE);
-            htmltree.addContent("(");
-            htmltree.addContent(paramTree);
-            paramTree.addContent(")");
+            htmltree.add(Contents.ZERO_WIDTH_SPACE);
+            htmltree.add("(");
+            htmltree.add(paramTree);
+            paramTree.add(")");
         }
     }
 
@@ -271,19 +271,19 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         List<? extends TypeMirror> exceptions = member.getThrownTypes();
         if (!exceptions.isEmpty()) {
             CharSequence indent = makeSpace(indentSize + 1 - 7);
-            htmltree.addContent(DocletConstants.NL);
-            htmltree.addContent(indent);
-            htmltree.addContent("throws ");
+            htmltree.add(DocletConstants.NL);
+            htmltree.add(indent);
+            htmltree.add("throws ");
             indent = makeSpace(indentSize + 1);
             Content link = writer.getLink(new LinkInfoImpl(configuration, MEMBER, exceptions.get(0)));
-            htmltree.addContent(link);
+            htmltree.add(link);
             for(int i = 1; i < exceptions.size(); i++) {
-                htmltree.addContent(",");
-                htmltree.addContent(DocletConstants.NL);
-                htmltree.addContent(indent);
+                htmltree.add(",");
+                htmltree.add(DocletConstants.NL);
+                htmltree.add(indent);
                 Content exceptionLink = writer.getLink(new LinkInfoImpl(configuration, MEMBER,
                         exceptions.get(i)));
-                htmltree.addContent(exceptionLink);
+                htmltree.add(exceptionLink);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
@@ -163,16 +163,16 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
                 i++;
             }
         }
-        contentTree.addContent(dl);
+        contentTree.add(dl);
     }
 
     protected void addHeading(Character uc, Content contentTree) {
         String unicode = uc.toString();
-        contentTree.addContent(getMarkerAnchorForIndex(unicode));
+        contentTree.add(getMarkerAnchorForIndex(unicode));
         Content headContent = new StringContent(unicode);
         Content heading = HtmlTree.HEADING(HtmlConstants.CONTENT_HEADING, false,
                 HtmlStyle.title, headContent);
-        contentTree.addContent(heading);
+        contentTree.add(heading);
     }
 
     protected void addDescription(Content dl, Element element) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
@@ -109,7 +109,7 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
             for (Element element : memberlist) {
                 addDescription(dl, element);
             }
-            contentTree.addContent(dl);
+            contentTree.add(dl);
         }
     }
 
@@ -122,7 +122,7 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
             for (SearchIndexItem sii : searchList) {
                 addDescription(sii, dl);
             }
-            contentTree.addContent(dl);
+            contentTree.add(dl);
         }
     }
 
@@ -225,13 +225,13 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         si.setLabel(moduleName);
         si.setCategory(resources.getText("doclet.Modules"));
         Content dt = HtmlTree.DT(link);
-        dt.addContent(" - ");
-        dt.addContent(contents.module_);
-        dt.addContent(" " + moduleName);
-        dlTree.addContent(dt);
+        dt.add(" - ");
+        dt.add(contents.module_);
+        dt.add(" " + moduleName);
+        dlTree.add(dt);
         Content dd = new HtmlTree(HtmlTag.DD);
         addSummaryComment(mdle, dd);
-        dlTree.addContent(dd);
+        dlTree.add(dd);
     }
 
     /**
@@ -249,13 +249,13 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         si.setLabel(utils.getPackageName(pkg));
         si.setCategory(resources.getText("doclet.Packages"));
         Content dt = HtmlTree.DT(link);
-        dt.addContent(" - ");
-        dt.addContent(contents.package_);
-        dt.addContent(" " + utils.getPackageName(pkg));
-        dlTree.addContent(dt);
+        dt.add(" - ");
+        dt.add(contents.package_);
+        dt.add(" " + utils.getPackageName(pkg));
+        dlTree.add(dt);
         Content dd = new HtmlTree(HtmlTag.DD);
         addSummaryComment(pkg, dd);
-        dlTree.addContent(dd);
+        dlTree.add(dd);
     }
 
     /**
@@ -272,12 +272,12 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         si.setLabel(utils.getSimpleName(typeElement));
         si.setCategory(resources.getText("doclet.Types"));
         Content dt = HtmlTree.DT(link);
-        dt.addContent(" - ");
+        dt.add(" - ");
         addClassInfo(typeElement, dt);
-        dlTree.addContent(dt);
+        dlTree.add(dt);
         Content dd = new HtmlTree(HtmlTag.DD);
         addComment(typeElement, dd);
-        dlTree.addContent(dd);
+        dlTree.add(dd);
     }
 
     /**
@@ -288,7 +288,7 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
      * @param contentTree the content tree to which the class info will be added
      */
     protected void addClassInfo(TypeElement te, Content contentTree) {
-        contentTree.addContent(contents.getContent("doclet.in",
+        contentTree.add(contents.getContent("doclet.in",
                 utils.getTypeElementName(te, false),
                 getPackageLink(utils.containingPackage(te),
                     utils.getPackageName(utils.containingPackage(te)))
@@ -322,12 +322,12 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         Content span = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 getDocLink(LinkInfoImpl.Kind.INDEX, member, name));
         Content dt = HtmlTree.DT(span);
-        dt.addContent(" - ");
+        dt.add(" - ");
         addMemberDesc(member, dt);
-        dlTree.addContent(dt);
+        dlTree.add(dt);
         Content dd = new HtmlTree(HtmlTag.DD);
         addComment(member, dd);
-        dlTree.addContent(dd);
+        dlTree.add(dd);
     }
 
     protected void addDescription(SearchIndexItem sii, Content dlTree) {
@@ -335,16 +335,16 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         siiPath += sii.getUrl();
         HtmlTree labelLink = HtmlTree.A(siiPath, new StringContent(sii.getLabel()));
         Content dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.searchTagLink, labelLink));
-        dt.addContent(" - ");
-        dt.addContent(contents.getContent("doclet.Search_tag_in", sii.getHolder()));
-        dlTree.addContent(dt);
+        dt.add(" - ");
+        dt.add(contents.getContent("doclet.Search_tag_in", sii.getHolder()));
+        dlTree.add(dt);
         Content dd = new HtmlTree(HtmlTag.DD);
         if (sii.getDescription().isEmpty()) {
-            dd.addContent(Contents.SPACE);
+            dd.add(Contents.SPACE);
         } else {
-            dd.addContent(sii.getDescription());
+            dd.add(sii.getDescription());
         }
-        dlTree.addContent(dd);
+        dlTree.add(dd);
     }
 
     /**
@@ -362,17 +362,17 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.deprecationBlock);
         if (utils.isDeprecated(element)) {
-            div.addContent(span);
+            div.add(span);
             tags = utils.getBlockTags(element, DocTree.Kind.DEPRECATED);
             if (!tags.isEmpty())
                 addInlineDeprecatedComment(element, tags.get(0), div);
-            contentTree.addContent(div);
+            contentTree.add(div);
         } else {
             TypeElement encl = utils.getEnclosingTypeElement(element);
             while (encl != null) {
                 if (utils.isDeprecated(encl)) {
-                    div.addContent(span);
-                    contentTree.addContent(div);
+                    div.add(span);
+                    contentTree.add(div);
                     break;
                 }
                 encl = utils.getEnclosingTypeElement(encl);
@@ -395,15 +395,15 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
             Content resource = contents.getContent(utils.isStatic(member)
                     ? "doclet.Static_variable_in"
                     : "doclet.Variable_in", classdesc);
-            contentTree.addContent(resource);
+            contentTree.add(resource);
         } else if (utils.isConstructor(member)) {
-            contentTree.addContent(
+            contentTree.add(
                     contents.getContent("doclet.Constructor_for", classdesc));
         } else if (utils.isMethod(member)) {
             Content resource = contents.getContent(utils.isStatic(member)
                     ? "doclet.Static_method_in"
                     : "doclet.Method_in", classdesc);
-            contentTree.addContent(resource);
+            contentTree.add(resource);
         }
         addPreQualifiedClassLink(LinkInfoImpl.Kind.INDEX, containing,
                 false, contentTree);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -220,7 +220,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
      * @param htmltree the content tree to which the name will be added.
      */
     protected void addName(String name, Content htmltree) {
-        htmltree.addContent(name);
+        htmltree.add(name);
     }
 
     /**
@@ -257,8 +257,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
         }
         if (!set.isEmpty()) {
             String mods = set.stream().map(Modifier::toString).collect(Collectors.joining(" "));
-            htmltree.addContent(mods);
-            htmltree.addContent(Contents.SPACE);
+            htmltree.add(mods);
+            htmltree.add(Contents.SPACE);
         }
     }
 
@@ -285,8 +285,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
         HtmlTree code = new HtmlTree(HtmlTag.CODE);
         addModifier(member, code);
         if (type == null) {
-            code.addContent(utils.isClass(member) ? "class" : "interface");
-            code.addContent(Contents.SPACE);
+            code.add(utils.isClass(member) ? "class" : "interface");
+            code.add(Contents.SPACE);
         } else {
             List<? extends TypeParameterElement> list = utils.isExecutableElement(member)
                     ? ((ExecutableElement)member).getTypeParameters()
@@ -294,24 +294,24 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
             if (list != null && !list.isEmpty()) {
                 Content typeParameters = ((AbstractExecutableMemberWriter) this)
                         .getTypeParameters((ExecutableElement)member);
-                    code.addContent(typeParameters);
+                    code.add(typeParameters);
                 //Code to avoid ugly wrapping in member summary table.
                 if (typeParameters.charCount() > 10) {
-                    code.addContent(new HtmlTree(HtmlTag.BR));
+                    code.add(new HtmlTree(HtmlTag.BR));
                 } else {
-                    code.addContent(Contents.SPACE);
+                    code.add(Contents.SPACE);
                 }
-                code.addContent(
+                code.add(
                         writer.getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.SUMMARY_RETURN_TYPE, type)));
             } else {
-                code.addContent(
+                code.add(
                         writer.getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.SUMMARY_RETURN_TYPE, type)));
             }
 
         }
-        tdSummaryType.addContent(code);
+        tdSummaryType.add(code);
     }
 
     /**
@@ -355,7 +355,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
         if (!output.isEmpty()) {
             Content deprecatedContent = output;
             Content div = HtmlTree.DIV(HtmlStyle.deprecationBlock, deprecatedContent);
-            contentTree.addContent(div);
+            contentTree.add(div);
         }
     }
 
@@ -441,8 +441,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
                         && !utils.isAnnotationType(element)) {
                     HtmlTree name = new HtmlTree(HtmlTag.SPAN);
                     name.setStyle(HtmlStyle.typeNameLabel);
-                    name.addContent(name(te) + ".");
-                    typeContent.addContent(name);
+                    name.add(name(te) + ".");
+                    typeContent.add(name);
                 }
                 addSummaryLink(utils.isClass(element) || utils.isInterface(element)
                         ? LinkInfoImpl.Kind.CLASS_USE
@@ -452,7 +452,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
                 writer.addSummaryLinkComment(this, element, desc);
                 useTable.addRow(summaryType, typeContent, desc);
             }
-            contentTree.addContent(useTable.toContent());
+            contentTree.add(useTable.toContent());
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -322,24 +322,24 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter {
      */
     private void addModifier(Element member, Content code) {
         if (utils.isProtected(member)) {
-            code.addContent("protected ");
+            code.add("protected ");
         } else if (utils.isPrivate(member)) {
-            code.addContent("private ");
+            code.add("private ");
         } else if (!utils.isPublic(member)) { // Package private
-            code.addContent(configuration.getText("doclet.Package_private"));
-            code.addContent(" ");
+            code.add(configuration.getText("doclet.Package_private"));
+            code.add(" ");
         }
         boolean isAnnotatedTypeElement = utils.isAnnotationType(member.getEnclosingElement());
         if (!isAnnotatedTypeElement && utils.isMethod(member)) {
             if (!utils.isInterface(member.getEnclosingElement()) && utils.isAbstract(member)) {
-                code.addContent("abstract ");
+                code.add("abstract ");
             }
             if (utils.isDefault(member)) {
-                code.addContent("default ");
+                code.add("default ");
             }
         }
         if (utils.isStatic(member)) {
-            code.addContent("static ");
+            code.add("static ");
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractModuleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractModuleIndexWriter.java
@@ -139,9 +139,9 @@ public abstract class AbstractModuleIndexWriter extends HtmlDocletWriter {
         addOverview(main);
         Content footer = createTagIfAllowed(HtmlTag.FOOTER, HtmlTree::FOOTER, ContentBuilder::new);
         addNavigationBarFooter(footer);
-        body.addContent(header);
-        body.addContent(main);
-        body.addContent(footer);
+        body.add(header);
+        body.add(main);
+        body.add(footer);
         printHtmlDocument(configuration.metakeywords.getOverviewMetaKeywords(title,
                 configuration.doctitle), includeScript, body);
     }
@@ -168,9 +168,9 @@ public abstract class AbstractModuleIndexWriter extends HtmlDocletWriter {
         addOverview(main);
         Content footer = createTagIfAllowed(HtmlTag.FOOTER, HtmlTree::FOOTER, ContentBuilder::new);
         addNavigationBarFooter(footer);
-        body.addContent(header);
-        body.addContent(main);
-        body.addContent(footer);
+        body.add(header);
+        body.add(main);
+        body.add(footer);
         printHtmlDocument(configuration.metakeywords.getOverviewMetaKeywords(title,
                 configuration.doctitle), includeScript, body);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractModuleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractModuleIndexWriter.java
@@ -226,8 +226,8 @@ public abstract class AbstractModuleIndexWriter extends HtmlDocletWriter {
         HtmlTree ul = new HtmlTree(HtmlTag.UL);
         addAllClassesLink(ul);
         addAllPackagesLink(ul);
-        htmlTree.addContent(ul);
-        header.addContent(htmlTree);
+        htmlTree.add(ul);
+        header.add(htmlTree);
         addModulesList(main);
     }
 
@@ -249,8 +249,8 @@ public abstract class AbstractModuleIndexWriter extends HtmlDocletWriter {
         addAllClassesLink(ul);
         addAllPackagesLink(ul);
         addAllModulesLink(ul);
-        htmlTree.addContent(ul);
-        header.addContent(htmlTree);
+        htmlTree.add(ul);
+        header.add(htmlTree);
         addModulePackagesList(modules, text, tableSummary, main, mdle);
     }
 
@@ -265,7 +265,7 @@ public abstract class AbstractModuleIndexWriter extends HtmlDocletWriter {
             Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING,
                     HtmlStyle.title, title);
             Content div = HtmlTree.DIV(HtmlStyle.header, heading);
-            body.addContent(div);
+            body.add(div);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractPackageIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractPackageIndexWriter.java
@@ -124,9 +124,9 @@ public abstract class AbstractPackageIndexWriter extends HtmlDocletWriter {
         addOverview(main);
         Content footer = createTagIfAllowed(HtmlTag.FOOTER, HtmlTree::FOOTER, ContentBuilder::new);
         addNavigationBarFooter(footer);
-        body.addContent(header);
-        body.addContent(main);
-        body.addContent(footer);
+        body.add(header);
+        body.add(main);
+        body.add(footer);
         printHtmlDocument(configuration.metakeywords.getOverviewMetaKeywords(title,
                 configuration.doctitle), includeScript, body);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractPackageIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractPackageIndexWriter.java
@@ -164,8 +164,8 @@ public abstract class AbstractPackageIndexWriter extends HtmlDocletWriter {
             if (configuration.showModules  && configuration.modules.size() > 1) {
                 addAllModulesLink(ul);
             }
-            htmlTree.addContent(ul);
-            header.addContent(htmlTree);
+            htmlTree.add(ul);
+            header.add(htmlTree);
             addPackagesList(main);
         }
     }
@@ -181,7 +181,7 @@ public abstract class AbstractPackageIndexWriter extends HtmlDocletWriter {
             Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING,
                     HtmlStyle.title, title);
             Content div = HtmlTree.DIV(HtmlStyle.header, heading);
-            body.addContent(div);
+            body.add(div);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -93,9 +93,9 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
                 addExtendsImplements(parent, local, li);
                 addLevelInfo(local, classtree.directSubClasses(local, isEnum),
                              isEnum, li);   // Recurse
-                ul.addContent(li);
+                ul.add(li);
             }
-            contentTree.addContent(ul);
+            contentTree.add(ul);
         }
     }
 
@@ -156,21 +156,21 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
                         if (isFirst) {
                             isFirst = false;
                             if (utils.isInterface(typeElement)) {
-                                contentTree.addContent(" (");
-                                contentTree.addContent(contents.also);
-                                contentTree.addContent(" extends ");
+                                contentTree.add(" (");
+                                contentTree.add(contents.also);
+                                contentTree.add(" extends ");
                             } else {
-                                contentTree.addContent(" (implements ");
+                                contentTree.add(" (implements ");
                             }
                         } else {
-                            contentTree.addContent(", ");
+                            contentTree.add(", ");
                         }
                         addPreQualifiedClassLink(LinkInfoImpl.Kind.TREE, intf, contentTree);
                     }
                 }
             }
             if (!isFirst) {
-                contentTree.addContent(")");
+                contentTree.add(")");
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -123,13 +123,13 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
             if (configuration.allowTag(HtmlTag.SECTION)) {
                 htmlTree = HtmlTree.SECTION(sectionHeading);
             } else {
-                div.addContent(sectionHeading);
+                div.add(sectionHeading);
                 htmlTree = div;
             }
             addLevelInfo(!utils.isInterface(firstTypeElement) ? firstTypeElement : null,
                     sset, isEnums, htmlTree);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                div.addContent(htmlTree);
+                div.add(htmlTree);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesFrameWriter.java
@@ -168,7 +168,7 @@ public class AllClassesFrameWriter extends HtmlDocletWriter {
                 linkContent = getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, typeElement).label(label));
             }
             Content li = HtmlTree.LI(linkContent);
-            content.addContent(li);
+            content.add(li);
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesFrameWriter.java
@@ -118,13 +118,13 @@ public class AllClassesFrameWriter extends HtmlDocletWriter {
         Content htmlTree = createTagIfAllowed(HtmlTag.MAIN, HtmlTree::MAIN, ContentBuilder::new);
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING,
                 HtmlStyle.bar, contents.allClassesLabel);
-        htmlTree.addContent(heading);
+        htmlTree.add(heading);
         Content ul = new HtmlTree(HtmlTag.UL);
         // Generate the class links and add it to the tdFont tree.
         addAllClasses(ul, wantFrames);
         HtmlTree div = HtmlTree.DIV(HtmlStyle.indexContainer, ul);
-        htmlTree.addContent(div);
-        body.addContent(htmlTree);
+        htmlTree.add(div);
+        body.add(htmlTree);
         printHtmlDocument(null, false, body);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -166,14 +166,14 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
         Content pHeading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.title, titleContent);
         Content headerDiv = HtmlTree.DIV(HtmlStyle.header, pHeading);
-        content.addContent(headerDiv);
+        content.add(headerDiv);
         if (!table.isEmpty()) {
             HtmlTree li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
             HtmlTree ul = HtmlTree.UL(HtmlStyle.blockList, li);
             HtmlTree div = new HtmlTree(HtmlTag.DIV);
             div.setStyle(HtmlStyle.allClassesContainer);
-            div.addContent(ul);
-            content.addContent(div);
+            div.add(ul);
+            content.add(div);
             if (table.needsScript()) {
                 getMainBodyScript().append(table.getScript());
             }
@@ -192,7 +192,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
                 configuration, LinkInfoImpl.Kind.INDEX, klass));
         ContentBuilder description = new ContentBuilder();
         if (utils.isDeprecated(klass)) {
-            description.addContent(getDeprecatedPhrase(klass));
+            description.add(getDeprecatedPhrase(klass));
             List<? extends DocTree> tags = utils.getDeprecatedTrees(klass);
             if (!tags.isEmpty()) {
                 addSummaryDeprecatedComment(klass, tags.get(0), description);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -108,26 +108,26 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         Content allClassesContent = new ContentBuilder();
         addContents(allClassesContent);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(allClassesContent);
-            bodyTree.addContent(mainTree);
+            mainTree.add(allClassesContent);
+            bodyTree.add(mainTree);
         } else {
-            bodyTree.addContent(allClassesContent);
+            bodyTree.add(allClassesContent);
         }
         Content tree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : bodyTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        tree.addContent(navBar.getContent(false));
+        tree.add(navBar.getContent(false));
         addBottom(tree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            bodyTree.addContent(tree);
+            bodyTree.add(tree);
         }
         printHtmlDocument(null, true, bodyTree);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllPackagesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllPackagesIndexWriter.java
@@ -90,9 +90,9 @@ public class AllPackagesIndexWriter extends HtmlDocletWriter {
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.allPackagesContainer);
@@ -102,21 +102,21 @@ public class AllPackagesIndexWriter extends HtmlDocletWriter {
                 HtmlStyle.title, titleContent);
         Content headerDiv = HtmlTree.DIV(HtmlStyle.header, pHeading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(headerDiv);
-            mainTree.addContent(div);
-            bodyTree.addContent(mainTree);
+            mainTree.add(headerDiv);
+            mainTree.add(div);
+            bodyTree.add(mainTree);
         } else {
-            bodyTree.addContent(headerDiv);
-            bodyTree.addContent(div);
+            bodyTree.add(headerDiv);
+            bodyTree.add(div);
         }
         Content tree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : bodyTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        tree.addContent(navBar.getContent(false));
+        tree.add(navBar.getContent(false));
         addBottom(tree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            bodyTree.addContent(tree);
+            bodyTree.add(tree);
         }
         printHtmlDocument(null, true, bodyTree);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllPackagesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllPackagesIndexWriter.java
@@ -141,6 +141,6 @@ public class AllPackagesIndexWriter extends HtmlDocletWriter {
             }
         }
         HtmlTree li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-        content.addContent(HtmlTree.UL(HtmlStyle.blockList, li));
+        content.add(HtmlTree.UL(HtmlStyle.blockList, li));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeFieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeFieldWriterImpl.java
@@ -137,8 +137,8 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
         Content link =
                 writer.getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.MEMBER, getType(member)));
-        pre.addContent(link);
-        pre.addContent(Contents.SPACE);
+        pre.add(link);
+        pre.add(Contents.SPACE);
         if (configuration.linksource) {
             Content memberName = new StringContent(name(member));
             writer.addSrcLink(member, memberName, pre);
@@ -194,7 +194,7 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.fieldSummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -230,7 +230,7 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(
+        memberTree.add(links.createAnchor(
                 SectionName.ANNOTATION_TYPE_FIELD_SUMMARY));
     }
 
@@ -257,7 +257,7 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 writer.getDocLink(context, member, name(member), false));
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeFieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeFieldWriterImpl.java
@@ -71,7 +71,7 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
      */
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(
+        memberSummaryTree.add(
                 HtmlConstants.START_OF_ANNOTATION_TYPE_FIELD_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
@@ -96,7 +96,7 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
      * {@inheritDoc}
      */
     public void addAnnotationFieldDetailsMarker(Content memberDetails) {
-        memberDetails.addContent(HtmlConstants.START_OF_ANNOTATION_TYPE_FIELD_DETAILS);
+        memberDetails.add(HtmlConstants.START_OF_ANNOTATION_TYPE_FIELD_DETAILS);
     }
 
     /**
@@ -105,11 +105,11 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
     public void addAnnotationDetailsTreeHeader(TypeElement typeElement,
             Content memberDetailsTree) {
         if (!writer.printedAnnotationFieldHeading) {
-            memberDetailsTree.addContent(links.createAnchor(
+            memberDetailsTree.add(links.createAnchor(
                     SectionName.ANNOTATION_TYPE_FIELD_DETAIL));
             Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                     contents.fieldDetailsLabel);
-            memberDetailsTree.addContent(heading);
+            memberDetailsTree.add(heading);
             writer.printedAnnotationFieldHeading = true;
         }
     }
@@ -119,11 +119,11 @@ public class AnnotationTypeFieldWriterImpl extends AbstractMemberWriter
      */
     public Content getAnnotationDocTreeHeader(Element member,
             Content annotationDetailsTree) {
-        annotationDetailsTree.addContent(links.createAnchor(name(member)));
+        annotationDetailsTree.add(links.createAnchor(name(member)));
         Content annotationDocTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(name(member));
-        annotationDocTree.addContent(heading);
+        heading.add(name(member));
+        annotationDocTree.add(heading);
         return annotationDocTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeOptionalMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeOptionalMemberWriterImpl.java
@@ -101,8 +101,8 @@ public class AnnotationTypeOptionalMemberWriterImpl extends
                 Content dt = HtmlTree.DT(contents.default_);
                 Content dl = HtmlTree.DL(dt);
                 Content dd = HtmlTree.DD(new StringContent(value.toString()));
-                dl.addContent(dd);
-                annotationDocTree.addContent(dl);
+                dl.add(dd);
+                annotationDocTree.add(dl);
             }
         }
     }
@@ -114,7 +114,7 @@ public class AnnotationTypeOptionalMemberWriterImpl extends
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.annotateTypeOptionalMemberSummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -149,7 +149,7 @@ public class AnnotationTypeOptionalMemberWriterImpl extends
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(
+        memberTree.add(links.createAnchor(
                 SectionName.ANNOTATION_TYPE_OPTIONAL_ELEMENT_SUMMARY));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeOptionalMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeOptionalMemberWriterImpl.java
@@ -74,7 +74,7 @@ public class AnnotationTypeOptionalMemberWriterImpl extends
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(
+        memberSummaryTree.add(
                 HtmlConstants.START_OF_ANNOTATION_TYPE_OPTIONAL_MEMBER_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
@@ -142,8 +142,8 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
         Content link =
                 writer.getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.MEMBER, getType(member)));
-        pre.addContent(link);
-        pre.addContent(Contents.SPACE);
+        pre.add(link);
+        pre.add(Contents.SPACE);
         if (configuration.linksource) {
             Content memberName = new StringContent(name(member));
             writer.addSrcLink(member, memberName, pre);
@@ -199,7 +199,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.annotateTypeRequiredMemberSummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -250,7 +250,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
      * {@inheritDoc}
      */
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(
+        memberTree.add(links.createAnchor(
                 SectionName.ANNOTATION_TYPE_REQUIRED_ELEMENT_SUMMARY));
     }
 
@@ -274,7 +274,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 writer.getDocLink(context, member, name(member), false));
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
@@ -74,7 +74,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
      */
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(
+        memberSummaryTree.add(
                 HtmlConstants.START_OF_ANNOTATION_TYPE_REQUIRED_MEMBER_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
@@ -99,7 +99,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
      * {@inheritDoc}
      */
     public void addAnnotationDetailsMarker(Content memberDetails) {
-        memberDetails.addContent(HtmlConstants.START_OF_ANNOTATION_TYPE_DETAILS);
+        memberDetails.add(HtmlConstants.START_OF_ANNOTATION_TYPE_DETAILS);
     }
 
     /**
@@ -108,11 +108,11 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     public void addAnnotationDetailsTreeHeader(TypeElement te,
             Content memberDetailsTree) {
         if (!writer.printedAnnotationHeading) {
-            memberDetailsTree.addContent(links.createAnchor(
+            memberDetailsTree.add(links.createAnchor(
                     SectionName.ANNOTATION_TYPE_ELEMENT_DETAIL));
             Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                     contents.annotationTypeDetailsLabel);
-            memberDetailsTree.addContent(heading);
+            memberDetailsTree.add(heading);
             writer.printedAnnotationHeading = true;
         }
     }
@@ -123,12 +123,12 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     @Override
     public Content getAnnotationDocTreeHeader(Element member, Content annotationDetailsTree) {
         String simpleName = name(member);
-        annotationDetailsTree.addContent(links.createAnchor(
+        annotationDetailsTree.add(links.createAnchor(
                 simpleName + utils.signature((ExecutableElement) member)));
         Content annotationDocTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(simpleName);
-        annotationDocTree.addContent(heading);
+        heading.add(simpleName);
+        annotationDocTree.add(heading);
         return annotationDocTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeWriterImpl.java
@@ -95,41 +95,41 @@ public class AnnotationTypeWriterImpl extends SubWriterHolderWriter
         navBar.setNavLinkModule(linkContent);
         navBar.setMemberSummaryBuilder(configuration.getBuilderFactory().getMemberSummaryBuilder(this));
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
-        bodyTree.addContent(HtmlConstants.START_OF_CLASS_DATA);
+        bodyTree.add(HtmlConstants.START_OF_CLASS_DATA);
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.header);
         if (configuration.showModules) {
             ModuleElement mdle = configuration.docEnv.getElementUtils().getModuleOf(annotationType);
             Content typeModuleLabel = HtmlTree.SPAN(HtmlStyle.moduleLabelInType, contents.moduleLabel);
             Content moduleNameDiv = HtmlTree.DIV(HtmlStyle.subTitle, typeModuleLabel);
-            moduleNameDiv.addContent(Contents.SPACE);
-            moduleNameDiv.addContent(getModuleLink(mdle, new StringContent(mdle.getQualifiedName())));
-            div.addContent(moduleNameDiv);
+            moduleNameDiv.add(Contents.SPACE);
+            moduleNameDiv.add(getModuleLink(mdle, new StringContent(mdle.getQualifiedName())));
+            div.add(moduleNameDiv);
         }
         PackageElement pkg = utils.containingPackage(annotationType);
         if (!pkg.isUnnamed()) {
             Content typePackageLabel = HtmlTree.SPAN(HtmlStyle.packageLabelInType, contents.packageLabel);
             Content pkgNameDiv = HtmlTree.DIV(HtmlStyle.subTitle, typePackageLabel);
-            pkgNameDiv.addContent(Contents.SPACE);
+            pkgNameDiv.add(Contents.SPACE);
             Content pkgNameContent = getPackageLink(pkg, new StringContent(utils.getPackageName(pkg)));
-            pkgNameDiv.addContent(pkgNameContent);
-            div.addContent(pkgNameDiv);
+            pkgNameDiv.add(pkgNameContent);
+            div.add(pkgNameDiv);
         }
         LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
                 LinkInfoImpl.Kind.CLASS_HEADER, annotationType);
         Content headerContent = new StringContent(header);
         Content heading = HtmlTree.HEADING(HtmlConstants.CLASS_PAGE_HEADING, true,
                 HtmlStyle.title, headerContent);
-        heading.addContent(getTypeParameterLinks(linkInfo));
-        div.addContent(heading);
+        heading.add(getTypeParameterLinks(linkInfo));
+        div.add(heading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }
@@ -147,15 +147,15 @@ public class AnnotationTypeWriterImpl extends SubWriterHolderWriter
      */
     @Override
     public void addFooter(Content contentTree) {
-        contentTree.addContent(HtmlConstants.END_OF_CLASS_DATA);
+        contentTree.add(HtmlConstants.END_OF_CLASS_DATA);
         Content htmlTree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : contentTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            contentTree.addContent(htmlTree);
+            contentTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeWriterImpl.java
@@ -190,23 +190,23 @@ public class AnnotationTypeWriterImpl extends SubWriterHolderWriter
     @Override
     public void addAnnotationTypeSignature(String modifiers, Content annotationInfoTree) {
         Content hr = new HtmlTree(HtmlTag.HR);
-        annotationInfoTree.addContent(hr);
+        annotationInfoTree.add(hr);
         Content pre = new HtmlTree(HtmlTag.PRE);
         addAnnotationInfo(annotationType, pre);
-        pre.addContent(modifiers);
+        pre.add(modifiers);
         LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
                 LinkInfoImpl.Kind.CLASS_SIGNATURE, annotationType);
         Content annotationName = new StringContent(utils.getSimpleName(annotationType));
         Content parameterLinks = getTypeParameterLinks(linkInfo);
         if (configuration.linksource) {
             addSrcLink(annotationType, annotationName, pre);
-            pre.addContent(parameterLinks);
+            pre.add(parameterLinks);
         } else {
             Content span = HtmlTree.SPAN(HtmlStyle.memberNameLabel, annotationName);
-            span.addContent(parameterLinks);
-            pre.addContent(span);
+            span.add(parameterLinks);
+            pre.add(span);
         }
-        annotationInfoTree.addContent(pre);
+        annotationInfoTree.add(pre);
     }
 
     /**
@@ -248,7 +248,7 @@ public class AnnotationTypeWriterImpl extends SubWriterHolderWriter
                     addInlineDeprecatedComment(annotationType, deprs.get(0), div);
                 }
             }
-            annotationInfoTree.addContent(div);
+            annotationInfoTree.add(div);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -289,7 +289,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             addPackageAnnotationList(ul);
         }
         addClassList(ul);
-        contentTree.addContent(ul);
+        contentTree.add(ul);
     }
 
     /**
@@ -311,7 +311,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             addPackageUse(pkg, table);
         }
         Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-        contentTree.addContent(li);
+        contentTree.add(li);
     }
 
     /**
@@ -341,7 +341,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             table.addRow(getPackageLink(pkg), summary);
         }
         Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-        contentTree.addContent(li);
+        contentTree.add(li);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -255,23 +255,23 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         if (pkgSet.size() > 0) {
             addClassUse(div);
         } else {
-            div.addContent(contents.getContent("doclet.ClassUse_No.usage.of.0",
+            div.add(contents.getContent("doclet.ClassUse_No.usage.of.0",
                     utils.getFullyQualifiedName(typeElement)));
         }
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
-            body.addContent(mainTree);
+            mainTree.add(div);
+            body.add(mainTree);
         } else {
-            body.addContent(div);
+            body.add(div);
         }
         HtmlTree htmlTree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : body;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -362,16 +362,16 @@ public class ClassUseWriter extends SubWriterHolderWriter {
                             typeElement)),
                     getPackageLink(pkg, utils.getPackageName(pkg)));
             Content heading = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING, link);
-            htmlTree.addContent(heading);
+            htmlTree.add(heading);
             addClassUse(pkg, htmlTree);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
         Content li = HtmlTree.LI(HtmlStyle.blockList, ul);
-        contentTree.addContent(li);
+        contentTree.add(li);
     }
 
     /**
@@ -488,21 +488,21 @@ public class ClassUseWriter extends SubWriterHolderWriter {
                 .label(configuration.getText("doclet.Class")));
         navBar.setNavLinkClass(classLinkContent);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         ContentBuilder headContent = new ContentBuilder();
-        headContent.addContent(contents.getContent("doclet.ClassUse_Title", cltype));
-        headContent.addContent(new HtmlTree(HtmlTag.BR));
-        headContent.addContent(clname);
+        headContent.add(contents.getContent("doclet.ClassUse_Title", cltype));
+        headContent.add(new HtmlTree(HtmlTag.BR));
+        headContent.add(clname);
         Content heading = HtmlTree.HEADING(HtmlConstants.CLASS_PAGE_HEADING,
                 true, HtmlStyle.title, headContent);
         Content div = HtmlTree.DIV(HtmlStyle.header, heading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -106,31 +106,31 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         navBar.setNavLinkModule(linkContent);
         navBar.setMemberSummaryBuilder(configuration.getBuilderFactory().getMemberSummaryBuilder(this));
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
-        bodyTree.addContent(HtmlConstants.START_OF_CLASS_DATA);
+        bodyTree.add(HtmlConstants.START_OF_CLASS_DATA);
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.header);
         if (configuration.showModules) {
             ModuleElement mdle = configuration.docEnv.getElementUtils().getModuleOf(typeElement);
             Content classModuleLabel = HtmlTree.SPAN(HtmlStyle.moduleLabelInType, contents.moduleLabel);
             Content moduleNameDiv = HtmlTree.DIV(HtmlStyle.subTitle, classModuleLabel);
-            moduleNameDiv.addContent(Contents.SPACE);
-            moduleNameDiv.addContent(getModuleLink(mdle,
+            moduleNameDiv.add(Contents.SPACE);
+            moduleNameDiv.add(getModuleLink(mdle,
                     new StringContent(mdle.getQualifiedName())));
-            div.addContent(moduleNameDiv);
+            div.add(moduleNameDiv);
         }
         PackageElement pkg = utils.containingPackage(typeElement);
         if (!pkg.isUnnamed()) {
             Content classPackageLabel = HtmlTree.SPAN(HtmlStyle.packageLabelInType, contents.packageLabel);
             Content pkgNameDiv = HtmlTree.DIV(HtmlStyle.subTitle, classPackageLabel);
-            pkgNameDiv.addContent(Contents.SPACE);
+            pkgNameDiv.add(Contents.SPACE);
             Content pkgNameContent = getPackageLink(pkg,
                     new StringContent(utils.getPackageName(pkg)));
-            pkgNameDiv.addContent(pkgNameContent);
-            div.addContent(pkgNameDiv);
+            pkgNameDiv.add(pkgNameContent);
+            div.add(pkgNameDiv);
         }
         LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
                 LinkInfoImpl.Kind.CLASS_HEADER, typeElement);
@@ -139,12 +139,12 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         Content headerContent = new StringContent(header);
         Content heading = HtmlTree.HEADING(HtmlConstants.CLASS_PAGE_HEADING, true,
                 HtmlStyle.title, headerContent);
-        heading.addContent(getTypeParameterLinks(linkInfo));
-        div.addContent(heading);
+        heading.add(getTypeParameterLinks(linkInfo));
+        div.add(heading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }
@@ -162,15 +162,15 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
      */
     @Override
     public void addFooter(Content contentTree) {
-        contentTree.addContent(HtmlConstants.END_OF_CLASS_DATA);
+        contentTree.add(HtmlConstants.END_OF_CLASS_DATA);
         Content htmlTree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : contentTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            contentTree.addContent(htmlTree);
+            contentTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -205,10 +205,10 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
     @Override
     public void addClassSignature(String modifiers, Content classInfoTree) {
         Content hr = new HtmlTree(HtmlTag.HR);
-        classInfoTree.addContent(hr);
+        classInfoTree.add(hr);
         Content pre = new HtmlTree(HtmlTag.PRE);
         addAnnotationInfo(typeElement, pre);
-        pre.addContent(modifiers);
+        pre.add(modifiers);
         LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
                 LinkInfoImpl.Kind.CLASS_SIGNATURE, typeElement);
         //Let's not link to ourselves in the signature.
@@ -217,21 +217,21 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         Content parameterLinks = getTypeParameterLinks(linkInfo);
         if (configuration.linksource) {
             addSrcLink(typeElement, className, pre);
-            pre.addContent(parameterLinks);
+            pre.add(parameterLinks);
         } else {
             Content span = HtmlTree.SPAN(HtmlStyle.typeNameLabel, className);
-            span.addContent(parameterLinks);
-            pre.addContent(span);
+            span.add(parameterLinks);
+            pre.add(span);
         }
         if (!utils.isInterface(typeElement)) {
             TypeMirror superclass = utils.getFirstVisibleSuperClass(typeElement);
             if (superclass != null) {
-                pre.addContent(DocletConstants.NL);
-                pre.addContent("extends ");
+                pre.add(DocletConstants.NL);
+                pre.add("extends ");
                 Content link = getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.CLASS_SIGNATURE_PARENT_NAME,
                         superclass));
-                pre.addContent(link);
+                pre.add(link);
             }
         }
         List<? extends TypeMirror> interfaces = typeElement.getInterfaces();
@@ -243,19 +243,19 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                     continue;
                 }
                 if (isFirst) {
-                    pre.addContent(DocletConstants.NL);
-                    pre.addContent(utils.isInterface(typeElement) ? "extends " : "implements ");
+                    pre.add(DocletConstants.NL);
+                    pre.add(utils.isInterface(typeElement) ? "extends " : "implements ");
                     isFirst = false;
                 } else {
-                    pre.addContent(", ");
+                    pre.add(", ");
                 }
                 Content link = getLink(new LinkInfoImpl(configuration,
                                                         LinkInfoImpl.Kind.CLASS_SIGNATURE_PARENT_NAME,
                                                         type));
-                pre.addContent(link);
+                pre.add(link);
             }
         }
-        classInfoTree.addContent(pre);
+        classInfoTree.add(pre);
     }
 
     /**
@@ -298,17 +298,17 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (sup != null) {
                 HtmlTree ul = new HtmlTree(HtmlTag.UL);
                 ul.setStyle(HtmlStyle.inheritance);
-                ul.addContent(getTreeForClassHelper(type));
+                ul.add(getTreeForClassHelper(type));
                 if (liTree != null)
-                    ul.addContent(liTree);
+                    ul.add(liTree);
                 Content li = HtmlTree.LI(ul);
                 liTree = li;
                 type = sup;
             } else
-                classTreeUl.addContent(getTreeForClassHelper(type));
+                classTreeUl.add(getTreeForClassHelper(type));
         } while (sup != null);
         if (liTree != null)
-            classTreeUl.addContent(liTree);
+            classTreeUl.add(liTree);
         return classTreeUl;
     }
 
@@ -325,17 +325,17 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                     new LinkInfoImpl(configuration, LinkInfoImpl.Kind.TREE,
                     typeElement));
             if (configuration.shouldExcludeQualifier(utils.containingPackage(typeElement).toString())) {
-                li.addContent(utils.asTypeElement(type).getSimpleName());
-                li.addContent(typeParameters);
+                li.add(utils.asTypeElement(type).getSimpleName());
+                li.add(typeParameters);
             } else {
-                li.addContent(utils.asTypeElement(type).getQualifiedName());
-                li.addContent(typeParameters);
+                li.add(utils.asTypeElement(type).getQualifiedName());
+                li.add(typeParameters);
             }
         } else {
             Content link = getLink(new LinkInfoImpl(configuration,
                     LinkInfoImpl.Kind.CLASS_TREE_PARENT, type)
                     .label(configuration.getClassName(utils.asTypeElement(type))));
-            li.addContent(link);
+            li.add(link);
         }
         return li;
     }
@@ -348,7 +348,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (!utils.isClass(typeElement)) {
             return;
         }
-        classContentTree.addContent(getClassInheritenceTree(typeElement.asType()));
+        classContentTree.add(getClassInheritenceTree(typeElement.asType()));
     }
 
     /**
@@ -360,7 +360,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             Content typeParam = (new ParamTaglet()).getTagletOutput(typeElement,
                     getTagletWriterInstance(false));
             Content dl = HtmlTree.DL(typeParam);
-            classInfoTree.addContent(dl);
+            classInfoTree.add(dl);
         }
     }
 
@@ -379,9 +379,9 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                 Content label = contents.subclassesLabel;
                 Content dt = HtmlTree.DT(label);
                 Content dl = HtmlTree.DL(dt);
-                dl.addContent(getClassLinks(LinkInfoImpl.Kind.SUBCLASSES,
+                dl.add(getClassLinks(LinkInfoImpl.Kind.SUBCLASSES,
                         subclasses));
-                classInfoTree.addContent(dl);
+                classInfoTree.add(dl);
             }
         }
     }
@@ -397,9 +397,9 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                 Content label = contents.subinterfacesLabel;
                 Content dt = HtmlTree.DT(label);
                 Content dl = HtmlTree.DL(dt);
-                dl.addContent(getClassLinks(LinkInfoImpl.Kind.SUBINTERFACES,
+                dl.add(getClassLinks(LinkInfoImpl.Kind.SUBINTERFACES,
                         subInterfaces));
-                classInfoTree.addContent(dl);
+                classInfoTree.add(dl);
             }
         }
     }
@@ -421,9 +421,9 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             Content label = contents.implementingClassesLabel;
             Content dt = HtmlTree.DT(label);
             Content dl = HtmlTree.DL(dt);
-            dl.addContent(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_CLASSES,
+            dl.add(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_CLASSES,
                     implcl));
-            classInfoTree.addContent(dl);
+            classInfoTree.add(dl);
         }
     }
 
@@ -438,8 +438,8 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             Content label = contents.allImplementedInterfacesLabel;
             Content dt = HtmlTree.DT(label);
             Content dl = HtmlTree.DL(dt);
-            dl.addContent(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_INTERFACES, interfaces));
-            classInfoTree.addContent(dl);
+            dl.add(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_INTERFACES, interfaces));
+            classInfoTree.add(dl);
         }
     }
 
@@ -456,8 +456,8 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             Content label = contents.allSuperinterfacesLabel;
             Content dt = HtmlTree.DT(label);
             Content dl = HtmlTree.DL(dt);
-            dl.addContent(getClassLinks(LinkInfoImpl.Kind.SUPER_INTERFACES, interfaces));
-            classInfoTree.addContent(dl);
+            dl.add(getClassLinks(LinkInfoImpl.Kind.SUPER_INTERFACES, interfaces));
+            classInfoTree.add(dl);
         }
     }
 
@@ -478,10 +478,10 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                 Content dt = HtmlTree.DT(label);
                 Content dl = HtmlTree.DL(dt);
                 Content dd = new HtmlTree(HtmlTag.DD);
-                dd.addContent(getLink(new LinkInfoImpl(configuration,
+                dd.add(getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.CLASS, e)));
-                dl.addContent(dd);
-                classInfoTree.addContent(dl);
+                dl.add(dd);
+                classInfoTree.add(dl);
                 return null;
             }
         }.visit(outerClass);
@@ -496,9 +496,9 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             Content dt = HtmlTree.DT(contents.functionalInterface);
             Content dl = HtmlTree.DL(dt);
             Content dd = new HtmlTree(HtmlTag.DD);
-            dd.addContent(contents.functionalInterfaceMessage);
-            dl.addContent(dd);
-            classInfoTree.addContent(dl);
+            dd.add(contents.functionalInterfaceMessage);
+            dl.add(dd);
+            classInfoTree.add(dl);
         }
     }
 
@@ -530,7 +530,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                     addInlineDeprecatedComment(typeElement, deprs.get(0), div);
                 }
             }
-            classInfoTree.addContent(div);
+            classInfoTree.add(div);
         }
     }
 
@@ -547,7 +547,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         for (Object type : list) {
             if (!isFirst) {
                 Content separator = new StringContent(", ");
-                dd.addContent(separator);
+                dd.add(separator);
             } else {
                 isFirst = false;
             }
@@ -555,11 +555,11 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (type instanceof TypeElement) {
                 Content link = getLink(
                         new LinkInfoImpl(configuration, context, (TypeElement)(type)));
-                dd.addContent(HtmlTree.CODE(link));
+                dd.add(HtmlTree.CODE(link));
             } else {
                 Content link = getLink(
                         new LinkInfoImpl(configuration, context, ((TypeMirror)type)));
-                dd.addContent(HtmlTree.CODE(link));
+                dd.add(HtmlTree.CODE(link));
             }
         }
         return dd;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -145,13 +145,13 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         } else {
             String parsedPackageName = utils.parsePackageName(pkg);
             Content packageNameContent = getPackageLabel(parsedPackageName);
-            packageNameContent.addContent(".*");
+            packageNameContent.add(".*");
             link = links.createLink(DocLink.fragment(parsedPackageName),
                     packageNameContent, "", "");
             PackageElement abbrevPkg = configuration.workArounds.getAbbreviatedPackageElement(pkg);
             printedPackageHeaders.add(abbrevPkg);
         }
-        contentListTree.addContent(HtmlTree.LI(link));
+        contentListTree.add(HtmlTree.LI(link));
     }
 
     /**
@@ -255,10 +255,10 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         PackageElement enclosingPackage  = utils.containingPackage(typeElement);
         Content caption = new ContentBuilder();
         if (!enclosingPackage.isUnnamed()) {
-            caption.addContent(enclosingPackage.getQualifiedName());
-            caption.addContent(".");
+            caption.add(enclosingPackage.getQualifiedName());
+            caption.add(".");
         }
-        caption.addContent(classlink);
+        caption.add(classlink);
 
         Table table = new Table(configuration.htmlVersion, HtmlStyle.constantsSummary)
                 .setSummary(constantsTableSummary)
@@ -271,7 +271,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
             table.addRow(getTypeColumn(field), getNameColumn(field), getValue(field));
         }
         Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-        classConstantTree.addContent(li);
+        classConstantTree.add(li);
     }
 
     /**
@@ -284,17 +284,17 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         Content anchor = links.createAnchor(
                 currentTypeElement.getQualifiedName() + "." + member.getSimpleName());
         Content typeContent = new ContentBuilder();
-        typeContent.addContent(anchor);
+        typeContent.add(anchor);
         Content code = new HtmlTree(HtmlTag.CODE);
         for (Modifier mod : member.getModifiers()) {
             Content modifier = new StringContent(mod.toString());
-            code.addContent(modifier);
-            code.addContent(Contents.SPACE);
+            code.add(modifier);
+            code.add(Contents.SPACE);
         }
         Content type = getLink(new LinkInfoImpl(configuration,
                 LinkInfoImpl.Kind.CONSTANT_SUMMARY, member.asType()));
-        code.addContent(type);
-        typeContent.addContent(code);
+        code.add(type);
+        typeContent.add(code);
         return typeContent;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -116,9 +116,9 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         return bodyTree;
     }
@@ -168,13 +168,13 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
                 headingContent);
         if (configuration.allowTag(HtmlTag.SECTION)) {
             HtmlTree section = HtmlTree.SECTION(heading);
-            section.addContent(contentListTree);
-            div.addContent(section);
-            mainTree.addContent(div);
+            section.add(contentListTree);
+            div.add(section);
+            mainTree.add(div);
         } else {
-            div.addContent(heading);
-            div.addContent(contentListTree);
-            contentTree.addContent(div);
+            div.add(heading);
+            div.add(contentListTree);
+            contentTree.add(div);
         }
     }
 
@@ -195,24 +195,24 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
     public void addPackageName(PackageElement pkg, Content summariesTree, boolean first) {
         Content pkgNameContent;
         if (!first && configuration.allowTag(HtmlTag.SECTION)) {
-            summariesTree.addContent(summaryTree);
+            summariesTree.add(summaryTree);
         }
         if (pkg.isUnnamed()) {
-            summariesTree.addContent(links.createAnchor(SectionName.UNNAMED_PACKAGE_ANCHOR));
+            summariesTree.add(links.createAnchor(SectionName.UNNAMED_PACKAGE_ANCHOR));
             pkgNameContent = contents.defaultPackageLabel;
         } else {
             String parsedPackageName = utils.parsePackageName(pkg);
-            summariesTree.addContent(links.createAnchor(parsedPackageName));
+            summariesTree.add(links.createAnchor(parsedPackageName));
             pkgNameContent = getPackageLabel(parsedPackageName);
         }
         Content headingContent = new StringContent(".*");
         Content heading = HtmlTree.HEADING(HtmlConstants.PACKAGE_HEADING, true,
                 pkgNameContent);
-        heading.addContent(headingContent);
+        heading.add(headingContent);
         if (configuration.allowTag(HtmlTag.SECTION)) {
             summaryTree = HtmlTree.SECTION(heading);
         } else {
-            summariesTree.addContent(heading);
+            summariesTree.add(heading);
         }
     }
 
@@ -232,9 +232,9 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
     @Override
     public void addClassConstant(Content summariesTree, Content classConstantTree) {
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            summaryTree.addContent(classConstantTree);
+            summaryTree.add(classConstantTree);
         } else {
-            summariesTree.addContent(classConstantTree);
+            summariesTree.add(classConstantTree);
         }
     }
 
@@ -328,13 +328,13 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
     @Override
     public void addConstantSummaries(Content contentTree, Content summariesTree) {
         if (configuration.allowTag(HtmlTag.SECTION) && summaryTree != null) {
-            summariesTree.addContent(summaryTree);
+            summariesTree.add(summaryTree);
         }
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(summariesTree);
-            contentTree.addContent(mainTree);
+            mainTree.add(summariesTree);
+            contentTree.add(mainTree);
         } else {
-            contentTree.addContent(summariesTree);
+            contentTree.add(summariesTree);
         }
     }
 
@@ -347,10 +347,10 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
                 ? HtmlTree.FOOTER()
                 : contentTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            contentTree.addContent(htmlTree);
+            contentTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriterImpl.java
@@ -98,7 +98,7 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_CONSTRUCTOR_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_CONSTRUCTOR_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -118,13 +118,13 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
     @Override
     public Content getConstructorDetailsTreeHeader(TypeElement typeElement,
             Content memberDetailsTree) {
-        memberDetailsTree.addContent(HtmlConstants.START_OF_CONSTRUCTOR_DETAILS);
+        memberDetailsTree.add(HtmlConstants.START_OF_CONSTRUCTOR_DETAILS);
         Content constructorDetailsTree = writer.getMemberTreeHeader();
-        constructorDetailsTree.addContent(links.createAnchor(
+        constructorDetailsTree.add(links.createAnchor(
                 SectionName.CONSTRUCTOR_DETAIL));
         Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                 contents.constructorDetailsLabel);
-        constructorDetailsTree.addContent(heading);
+        constructorDetailsTree.add(heading);
         return constructorDetailsTree;
     }
 
@@ -136,13 +136,13 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
             Content constructorDetailsTree) {
         String erasureAnchor;
         if ((erasureAnchor = getErasureAnchor(constructor)) != null) {
-            constructorDetailsTree.addContent(links.createAnchor((erasureAnchor)));
+            constructorDetailsTree.add(links.createAnchor((erasureAnchor)));
         }
-        constructorDetailsTree.addContent(links.createAnchor(writer.getAnchor(constructor)));
+        constructorDetailsTree.add(links.createAnchor(writer.getAnchor(constructor)));
         Content constructorDocTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(name(constructor));
-        constructorDocTree.addContent(heading);
+        heading.add(name(constructor));
+        constructorDocTree.add(heading);
         return constructorDocTree;
     }
 
@@ -302,16 +302,16 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
         if (foundNonPubConstructor) {
             Content code = new HtmlTree(HtmlTag.CODE);
             if (utils.isProtected(member)) {
-                code.addContent("protected ");
+                code.add("protected ");
             } else if (utils.isPrivate(member)) {
-                code.addContent("private ");
+                code.add("private ");
             } else if (utils.isPublic(member)) {
-                code.addContent(Contents.SPACE);
+                code.add(Contents.SPACE);
             } else {
-                code.addContent(
+                code.add(
                         configuration.getText("doclet.Package_private"));
             }
-            tdSummaryType.addContent(code);
+            tdSummaryType.add(code);
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriterImpl.java
@@ -229,7 +229,7 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.constructorSummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -277,7 +277,7 @@ public class ConstructorWriterImpl extends AbstractExecutableMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(SectionName.CONSTRUCTOR_SUMMARY));
+        memberTree.add(links.createAnchor(SectionName.CONSTRUCTOR_SUMMARY));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,7 +360,7 @@ public class Contents {
         Matcher m = p.matcher(text);
         int start = 0;
         while (m.find(start)) {
-            c.addContent(text.substring(start, m.start()));
+            c.add(text.substring(start, m.start()));
 
             Object o = null;
             switch (m.group(1).charAt(0)) {
@@ -370,17 +370,17 @@ public class Contents {
             }
 
             if (o == null) {
-                c.addContent("{" + m.group(1) + "}");
+                c.add("{" + m.group(1) + "}");
             } else if (o instanceof String) {
-                c.addContent((String) o);
+                c.add((String) o);
             } else if (o instanceof Content) {
-                c.addContent((Content) o);
+                c.add((Content) o);
             }
 
             start = m.end();
         }
 
-        c.addContent(text.substring(start));
+        c.add(text.substring(start));
         return c;
     }
 
@@ -399,11 +399,11 @@ public class Contents {
         int start = 0;
         int p;
         while ((p = text.indexOf(" ", start)) != -1) {
-            c.addContent(text.substring(start, p));
-            c.addContent(RawHtml.nbsp);
+            c.add(text.substring(start, p));
+            c.add(RawHtml.nbsp);
             start = p + 1;
         }
-        c.addContent(text.substring(start));
+        c.add(text.substring(start));
         return c; // TODO: should be made immutable
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -333,7 +333,7 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
         if (builder.hasDocumentation(kind)) {
             Content li = HtmlTree.LI(links.createLink(getAnchorName(kind),
                     contents.getContent(getHeadingKey(kind))));
-            contentTree.addContent(li);
+            contentTree.add(li);
         }
     }
 
@@ -368,7 +368,7 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
      */
     private void addAnchor(DeprecatedAPIListBuilder builder, DeprElementKind kind, Content htmlTree) {
         if (builder.hasDocumentation(kind)) {
-            htmlTree.addContent(links.createAnchor(getAnchorName(kind)));
+            htmlTree.add(links.createAnchor(getAnchorName(kind)));
         }
     }
 
@@ -429,13 +429,13 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 if (!tags.isEmpty()) {
                     addInlineDeprecatedComment(e, tags.get(0), desc);
                 } else {
-                    desc.addContent(HtmlTree.EMPTY);
+                    desc.add(HtmlTree.EMPTY);
                 }
                 table.addRow(link, desc);
             }
             Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
             Content ul = HtmlTree.UL(HtmlStyle.blockList, li);
-            contentTree.addContent(ul);
+            contentTree.add(ul);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -287,7 +287,7 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
         HtmlTree htmlTree = (configuration.allowTag(HtmlTag.MAIN))
                 ? HtmlTree.MAIN()
                 : body;
-        htmlTree.addContent(getContentsList(deprapi));
+        htmlTree.add(getContentsList(deprapi));
         String memberTableSummary;
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.contentContainer);
@@ -304,19 +304,19 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
             }
         }
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            htmlTree.addContent(div);
-            body.addContent(htmlTree);
+            htmlTree.add(div);
+            body.add(htmlTree);
         } else {
-            body.addContent(div);
+            body.add(div);
         }
         htmlTree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : body;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -349,13 +349,13 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 HtmlStyle.title, headContent);
         Content div = HtmlTree.DIV(HtmlStyle.header, heading);
         Content headingContent = contents.contentsHeading;
-        div.addContent(HtmlTree.HEADING(HtmlConstants.CONTENT_HEADING, true,
+        div.add(HtmlTree.HEADING(HtmlConstants.CONTENT_HEADING, true,
                 headingContent));
         Content ul = new HtmlTree(HtmlTag.UL);
         for (DeprElementKind kind : DeprElementKind.values()) {
             addIndexLink(deprapi, kind, ul);
         }
-        div.addContent(ul);
+        div.add(ul);
         return div;
     }
 
@@ -385,9 +385,9 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         return bodyTree;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
@@ -183,15 +183,15 @@ public class DocFilesHandlerImpl implements DocFilesHandler {
         Content pkgLinkContent = docletWriter.getPackageLink(pkg, docletWriter.contents.packageLabel);
         navBar.setNavLinkPackage(pkgLinkContent);
         navBar.setUserHeader(docletWriter.getUserHeaderFooter(true));
-        htmlContent.addContent(navBar.getContent(true));
+        htmlContent.add(navBar.getContent(true));
         List<? extends DocTree> fullBody = utils.getFullBody(dfElement);
         Content bodyContent = docletWriter.commentTagsToContent(null, dfElement, fullBody, false);
 
         docletWriter.addTagsInfo(dfElement, bodyContent);
-        htmlContent.addContent(bodyContent);
+        htmlContent.add(bodyContent);
 
         navBar.setUserFooter(docletWriter.getUserHeaderFooter(false));
-        htmlContent.addContent(navBar.getContent(false));
+        htmlContent.add(navBar.getContent(false));
         docletWriter.addBottom(htmlContent);
         docletWriter.printHtmlDocument(Collections.emptyList(), false, htmlContent);
         return true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -71,7 +71,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_ENUM_CONSTANT_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_ENUM_CONSTANT_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -91,13 +91,13 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     public Content getEnumConstantsDetailsTreeHeader(TypeElement typeElement,
             Content memberDetailsTree) {
-        memberDetailsTree.addContent(HtmlConstants.START_OF_ENUM_CONSTANT_DETAILS);
+        memberDetailsTree.add(HtmlConstants.START_OF_ENUM_CONSTANT_DETAILS);
         Content enumConstantsDetailsTree = writer.getMemberTreeHeader();
-        enumConstantsDetailsTree.addContent(links.createAnchor(
+        enumConstantsDetailsTree.add(links.createAnchor(
                 SectionName.ENUM_CONSTANT_DETAIL));
         Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                 contents.enumConstantDetailLabel);
-        enumConstantsDetailsTree.addContent(heading);
+        enumConstantsDetailsTree.add(heading);
         return enumConstantsDetailsTree;
     }
 
@@ -107,11 +107,11 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     public Content getEnumConstantsTreeHeader(VariableElement enumConstant,
             Content enumConstantsDetailsTree) {
-        enumConstantsDetailsTree.addContent(links.createAnchor(name(enumConstant)));
+        enumConstantsDetailsTree.add(links.createAnchor(name(enumConstant)));
         Content enumConstantsTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(name(enumConstant));
-        enumConstantsTree.addContent(heading);
+        heading.add(name(enumConstant));
+        enumConstantsTree.add(heading);
         return enumConstantsTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -125,8 +125,8 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
         addModifiers(enumConstant, pre);
         Content enumConstantLink = writer.getLink(new LinkInfoImpl(
                 configuration, LinkInfoImpl.Kind.MEMBER, enumConstant.asType()));
-        pre.addContent(enumConstantLink);
-        pre.addContent(" ");
+        pre.add(enumConstantLink);
+        pre.add(" ");
         if (configuration.linksource) {
             Content enumConstantName = new StringContent(name(enumConstant));
             writer.addSrcLink(enumConstant, enumConstantName, pre);
@@ -188,7 +188,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.enumConstantSummary);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -221,7 +221,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(SectionName.ENUM_CONSTANT_SUMMARY));
+        memberTree.add(links.createAnchor(SectionName.ENUM_CONSTANT_SUMMARY));
     }
 
     /**
@@ -247,7 +247,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 writer.getDocLink(context, member, name(member), false));
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -127,8 +127,8 @@ public class FieldWriterImpl extends AbstractMemberWriter
         addModifiers(field, pre);
         Content fieldlink = writer.getLink(new LinkInfoImpl(
                 configuration, LinkInfoImpl.Kind.MEMBER, field.asType()));
-        pre.addContent(fieldlink);
-        pre.addContent(" ");
+        pre.add(fieldlink);
+        pre.add(" ");
         if (configuration.linksource) {
             Content fieldName = new StringContent(name(field));
             writer.addSrcLink(field, fieldName, pre);
@@ -192,7 +192,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.fieldSummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -227,7 +227,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(
+        memberTree.add(links.createAnchor(
                 SectionName.FIELD_SUMMARY));
     }
 
@@ -236,7 +236,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addInheritedSummaryAnchor(TypeElement typeElement, Content inheritedTree) {
-        inheritedTree.addContent(links.createAnchor(
+        inheritedTree.add(links.createAnchor(
                 SectionName.FIELDS_INHERITANCE, configuration.getClassName(typeElement)));
     }
 
@@ -259,9 +259,9 @@ public class FieldWriterImpl extends AbstractMemberWriter
         }
         Content labelHeading = HtmlTree.HEADING(HtmlConstants.INHERITED_SUMMARY_HEADING,
                 label);
-        labelHeading.addContent(Contents.SPACE);
-        labelHeading.addContent(classLink);
-        inheritedTree.addContent(labelHeading);
+        labelHeading.add(Contents.SPACE);
+        labelHeading.add(classLink);
+        inheritedTree.add(labelHeading);
     }
 
     /**
@@ -273,7 +273,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 writer.getDocLink(context, typeElement , member, name(member), false));
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**
@@ -281,7 +281,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
-        linksTree.addContent(
+        linksTree.add(
                 writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member,
                 name(member), false));
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -75,7 +75,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_FIELD_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_FIELD_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -94,13 +94,13 @@ public class FieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     public Content getFieldDetailsTreeHeader(TypeElement typeElement, Content memberDetailsTree) {
-        memberDetailsTree.addContent(HtmlConstants.START_OF_FIELD_DETAILS);
+        memberDetailsTree.add(HtmlConstants.START_OF_FIELD_DETAILS);
         Content fieldDetailsTree = writer.getMemberTreeHeader();
-        fieldDetailsTree.addContent(links.createAnchor(
+        fieldDetailsTree.add(links.createAnchor(
                 SectionName.FIELD_DETAIL));
         Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                 contents.fieldDetailsLabel);
-        fieldDetailsTree.addContent(heading);
+        fieldDetailsTree.add(heading);
         return fieldDetailsTree;
     }
 
@@ -109,11 +109,11 @@ public class FieldWriterImpl extends AbstractMemberWriter
      */
     @Override
     public Content getFieldDocTreeHeader(VariableElement field, Content fieldDetailsTree) {
-        fieldDetailsTree.addContent(links.createAnchor(name(field)));
+        fieldDetailsTree.add(links.createAnchor(name(field)));
         Content fieldTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(name(field));
-        fieldTree.addContent(heading);
+        heading.add(name(field));
+        fieldTree.add(heading);
         return fieldTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FrameOutputWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FrameOutputWriter.java
@@ -25,6 +25,7 @@
 
 package jdk.javadoc.internal.doclets.formats.html;
 
+import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
@@ -95,21 +96,21 @@ public class FrameOutputWriter extends HtmlDocletWriter {
     protected void generateFrameFile() throws DocFileIOException {
         Content frame = getFrameDetails();
         HtmlTree body = new HtmlTree(HtmlTag.BODY);
-        body.addAttr(HtmlAttr.ONLOAD, "loadFrames()");
+        body.put(HtmlAttr.ONLOAD, "loadFrames()");
         String topFilePath = configuration.topFile.getPath();
         Script script = new Script(
                 "\nif (targetPage == \"\" || targetPage == \"undefined\")\n" +
                 "     window.location.replace(")
                 .appendStringLiteral(topFilePath, '\'')
                 .append(");\n");
-        body.addContent(script.asContent());
+        body.add(script.asContent());
         Content noScript = HtmlTree.NOSCRIPT(contents.noScriptMessage);
-        body.addContent(noScript);
+        body.add(noScript);
         if (configuration.allowTag(HtmlTag.MAIN)) {
             HtmlTree main = HtmlTree.MAIN(frame);
-            body.addContent(main);
+            body.add(main);
         } else {
-            body.addContent(frame);
+            body.add(frame);
         }
         if (configuration.windowtitle.length() > 0) {
             printFramesDocument(configuration.windowtitle, body);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FrameOutputWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FrameOutputWriter.java
@@ -26,7 +26,6 @@
 package jdk.javadoc.internal.doclets.formats.html;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.Head;
-import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
@@ -161,7 +160,7 @@ public class FrameOutputWriter extends HtmlDocletWriter {
         addAllClassesFrameTag(leftContainerDiv);
         addClassFrameTag(rightContainerDiv);
         HtmlTree mainContainer = HtmlTree.DIV(HtmlStyle.mainContainer, leftContainerDiv);
-        mainContainer.addContent(rightContainerDiv);
+        mainContainer.add(rightContainerDiv);
         return mainContainer;
     }
 
@@ -174,7 +173,7 @@ public class FrameOutputWriter extends HtmlDocletWriter {
         HtmlTree frame = HtmlTree.IFRAME(DocPaths.MODULE_OVERVIEW_FRAME.getPath(),
                 "packageListFrame", configuration.getText("doclet.All_Modules"));
         HtmlTree leftTop = HtmlTree.DIV(HtmlStyle.leftTop, frame);
-        contentTree.addContent(leftTop);
+        contentTree.add(leftTop);
     }
 
     /**
@@ -186,7 +185,7 @@ public class FrameOutputWriter extends HtmlDocletWriter {
         HtmlTree frame = HtmlTree.IFRAME(DocPaths.OVERVIEW_FRAME.getPath(),
                 "packageListFrame", configuration.getText("doclet.All_Packages"));
         HtmlTree leftTop = HtmlTree.DIV(HtmlStyle.leftTop, frame);
-        contentTree.addContent(leftTop);
+        contentTree.add(leftTop);
     }
 
     /**
@@ -198,7 +197,7 @@ public class FrameOutputWriter extends HtmlDocletWriter {
         HtmlTree frame = HtmlTree.IFRAME(DocPaths.ALLCLASSES_FRAME.getPath(),
                 "packageFrame", configuration.getText("doclet.All_classes_and_interfaces"));
         HtmlTree leftBottom = HtmlTree.DIV(HtmlStyle.leftBottom, frame);
-        contentTree.addContent(leftBottom);
+        contentTree.add(leftBottom);
     }
 
     /**
@@ -210,7 +209,7 @@ public class FrameOutputWriter extends HtmlDocletWriter {
         HtmlTree frame = HtmlTree.IFRAME(configuration.topFile.getPath(), "classFrame",
                 configuration.getText("doclet.Package_class_and_interface_descriptions"));
         frame.setStyle(HtmlStyle.rightIframe);
-        contentTree.addContent(frame);
+        contentTree.add(frame);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -94,19 +94,19 @@ public class HelpWriter extends HtmlDocletWriter {
                 : body;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         addHelpFileContents(body);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
             htmlTree = HtmlTree.FOOTER();
         }
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -126,11 +126,11 @@ public class HelpWriter extends HtmlDocletWriter {
         Content div = HtmlTree.DIV(HtmlStyle.header, heading);
         Content intro = HtmlTree.DIV(HtmlStyle.subTitle,
                 contents.getContent("doclet.help.intro"));
-        div.addContent(intro);
+        div.add(intro);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            contentTree.addContent(div);
+            contentTree.add(div);
         }
         HtmlTree htmlTree;
         HtmlTree ul = new HtmlTree(HtmlTag.UL);
@@ -151,11 +151,11 @@ public class HelpWriter extends HtmlDocletWriter {
                     resources.getText("doclet.Overview"));
             Content overviewBody = contents.getContent(overviewKey, overviewLink);
             Content overviewPara = HtmlTree.P(overviewBody);
-            htmlTree.addContent(overviewPara);
+            htmlTree.add(overviewPara);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -168,16 +168,16 @@ public class HelpWriter extends HtmlDocletWriter {
                     : HtmlTree.LI(HtmlStyle.blockList, moduleHead);
             Content moduleIntro = contents.getContent("doclet.help.module.intro");
             Content modulePara = HtmlTree.P(moduleIntro);
-            htmlTree.addContent(modulePara);
+            htmlTree.add(modulePara);
             HtmlTree ulModule = new HtmlTree(HtmlTag.UL);
-            ulModule.addContent(HtmlTree.LI(contents.packagesLabel));
-            ulModule.addContent(HtmlTree.LI(contents.modulesLabel));
-            ulModule.addContent(HtmlTree.LI(contents.servicesLabel));
-            htmlTree.addContent(ulModule);
+            ulModule.add(HtmlTree.LI(contents.packagesLabel));
+            ulModule.add(HtmlTree.LI(contents.modulesLabel));
+            ulModule.add(HtmlTree.LI(contents.servicesLabel));
+            htmlTree.add(ulModule);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
 
         }
@@ -190,19 +190,19 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, packageHead);
         Content packageIntro = contents.getContent("doclet.help.package.intro");
         Content packagePara = HtmlTree.P(packageIntro);
-        htmlTree.addContent(packagePara);
+        htmlTree.add(packagePara);
         HtmlTree ulPackage = new HtmlTree(HtmlTag.UL);
-        ulPackage.addContent(HtmlTree.LI(contents.interfaces));
-        ulPackage.addContent(HtmlTree.LI(contents.classes));
-        ulPackage.addContent(HtmlTree.LI(contents.enums));
-        ulPackage.addContent(HtmlTree.LI(contents.exceptions));
-        ulPackage.addContent(HtmlTree.LI(contents.errors));
-        ulPackage.addContent(HtmlTree.LI(contents.annotationTypes));
-        htmlTree.addContent(ulPackage);
+        ulPackage.add(HtmlTree.LI(contents.interfaces));
+        ulPackage.add(HtmlTree.LI(contents.classes));
+        ulPackage.add(HtmlTree.LI(contents.enums));
+        ulPackage.add(HtmlTree.LI(contents.exceptions));
+        ulPackage.add(HtmlTree.LI(contents.errors));
+        ulPackage.add(HtmlTree.LI(contents.annotationTypes));
+        htmlTree.add(ulPackage);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Class/interface
@@ -213,37 +213,37 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, classHead);
         Content classIntro = contents.getContent("doclet.help.class_interface.intro");
         Content classPara = HtmlTree.P(classIntro);
-        htmlTree.addContent(classPara);
+        htmlTree.add(classPara);
         HtmlTree ul1 = new HtmlTree(HtmlTag.UL);
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.inheritance_diagram")));
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.subclasses")));
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.subinterfaces")));
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.implementations")));
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.declaration")));
-        ul1.addContent(HtmlTree.LI(contents.getContent("doclet.help.class_interface.description")));
-        htmlTree.addContent(ul1);
-        htmlTree.addContent(new HtmlTree(HtmlTag.BR));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.inheritance_diagram")));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.subclasses")));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.subinterfaces")));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.implementations")));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.declaration")));
+        ul1.add(HtmlTree.LI(contents.getContent("doclet.help.class_interface.description")));
+        htmlTree.add(ul1);
+        htmlTree.add(new HtmlTree(HtmlTag.BR));
         HtmlTree ul2 = new HtmlTree(HtmlTag.UL);
-        ul2.addContent(HtmlTree.LI(contents.nestedClassSummary));
-        ul2.addContent(HtmlTree.LI(contents.fieldSummaryLabel));
-        ul2.addContent(HtmlTree.LI(contents.propertySummaryLabel));
-        ul2.addContent(HtmlTree.LI(contents.constructorSummaryLabel));
-        ul2.addContent(HtmlTree.LI(contents.methodSummary));
-        htmlTree.addContent(ul2);
-        htmlTree.addContent(new HtmlTree(HtmlTag.BR));
+        ul2.add(HtmlTree.LI(contents.nestedClassSummary));
+        ul2.add(HtmlTree.LI(contents.fieldSummaryLabel));
+        ul2.add(HtmlTree.LI(contents.propertySummaryLabel));
+        ul2.add(HtmlTree.LI(contents.constructorSummaryLabel));
+        ul2.add(HtmlTree.LI(contents.methodSummary));
+        htmlTree.add(ul2);
+        htmlTree.add(new HtmlTree(HtmlTag.BR));
         HtmlTree ul3 = new HtmlTree(HtmlTag.UL);
-        ul3.addContent(HtmlTree.LI(contents.fieldDetailsLabel));
-        ul3.addContent(HtmlTree.LI(contents.propertyDetailsLabel));
-        ul3.addContent(HtmlTree.LI(contents.constructorDetailsLabel));
-        ul3.addContent(HtmlTree.LI(contents.methodDetailLabel));
-        htmlTree.addContent(ul3);
+        ul3.add(HtmlTree.LI(contents.fieldDetailsLabel));
+        ul3.add(HtmlTree.LI(contents.propertyDetailsLabel));
+        ul3.add(HtmlTree.LI(contents.constructorDetailsLabel));
+        ul3.add(HtmlTree.LI(contents.methodDetailLabel));
+        htmlTree.add(ul3);
         Content classSummary = contents.getContent("doclet.help.class_interface.summary");
         Content para = HtmlTree.P(classSummary);
-        htmlTree.addContent(para);
+        htmlTree.add(para);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Annotation Types
@@ -254,18 +254,18 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, aHead);
         Content aIntro = contents.getContent("doclet.help.annotation_type.intro");
         Content aPara = HtmlTree.P(aIntro);
-        htmlTree.addContent(aPara);
+        htmlTree.add(aPara);
         HtmlTree aul = new HtmlTree(HtmlTag.UL);
-        aul.addContent(HtmlTree.LI(contents.getContent("doclet.help.annotation_type.declaration")));
-        aul.addContent(HtmlTree.LI(contents.getContent("doclet.help.annotation_type.description")));
-        aul.addContent(HtmlTree.LI(contents.annotateTypeRequiredMemberSummaryLabel));
-        aul.addContent(HtmlTree.LI(contents.annotateTypeOptionalMemberSummaryLabel));
-        aul.addContent(HtmlTree.LI(contents.annotationTypeMemberDetail));
-        htmlTree.addContent(aul);
+        aul.add(HtmlTree.LI(contents.getContent("doclet.help.annotation_type.declaration")));
+        aul.add(HtmlTree.LI(contents.getContent("doclet.help.annotation_type.description")));
+        aul.add(HtmlTree.LI(contents.annotateTypeRequiredMemberSummaryLabel));
+        aul.add(HtmlTree.LI(contents.annotateTypeOptionalMemberSummaryLabel));
+        aul.add(HtmlTree.LI(contents.annotationTypeMemberDetail));
+        htmlTree.add(aul);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Enums
@@ -275,17 +275,17 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, enumHead);
         Content eIntro = contents.getContent("doclet.help.enum.intro");
         Content enumPara = HtmlTree.P(eIntro);
-        htmlTree.addContent(enumPara);
+        htmlTree.add(enumPara);
         HtmlTree eul = new HtmlTree(HtmlTag.UL);
-        eul.addContent(HtmlTree.LI(contents.getContent("doclet.help.enum.declaration")));
-        eul.addContent(HtmlTree.LI(contents.getContent("doclet.help.enum.definition")));
-        eul.addContent(HtmlTree.LI(contents.enumConstantSummary));
-        eul.addContent(HtmlTree.LI(contents.enumConstantDetailLabel));
-        htmlTree.addContent(eul);
+        eul.add(HtmlTree.LI(contents.getContent("doclet.help.enum.declaration")));
+        eul.add(HtmlTree.LI(contents.getContent("doclet.help.enum.definition")));
+        eul.add(HtmlTree.LI(contents.enumConstantSummary));
+        eul.add(HtmlTree.LI(contents.enumConstantDetailLabel));
+        htmlTree.add(eul);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Class Use
@@ -297,11 +297,11 @@ public class HelpWriter extends HtmlDocletWriter {
                     : HtmlTree.LI(HtmlStyle.blockList, useHead);
             Content useBody = contents.getContent("doclet.help.use.body");
             Content usePara = HtmlTree.P(useBody);
-            htmlTree.addContent(usePara);
+            htmlTree.add(usePara);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -317,15 +317,15 @@ public class HelpWriter extends HtmlDocletWriter {
                     configuration.getText("doclet.Class_Hierarchy")),
                     HtmlTree.CODE(new StringContent("java.lang.Object")));
             Content treePara = HtmlTree.P(treeIntro);
-            htmlTree.addContent(treePara);
+            htmlTree.add(treePara);
             HtmlTree tul = new HtmlTree(HtmlTag.UL);
-            tul.addContent(HtmlTree.LI(contents.getContent("doclet.help.tree.overview")));
-            tul.addContent(HtmlTree.LI(contents.getContent("doclet.help.tree.package")));
-            htmlTree.addContent(tul);
+            tul.add(HtmlTree.LI(contents.getContent("doclet.help.tree.overview")));
+            tul.add(HtmlTree.LI(contents.getContent("doclet.help.tree.package")));
+            htmlTree.add(tul);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -340,11 +340,11 @@ public class HelpWriter extends HtmlDocletWriter {
                     links.createLink(DocPaths.DEPRECATED_LIST,
                     configuration.getText("doclet.Deprecated_API")));
             Content dPara = HtmlTree.P(deprBody);
-            htmlTree.addContent(dPara);
+            htmlTree.add(dPara);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -365,11 +365,11 @@ public class HelpWriter extends HtmlDocletWriter {
                     : HtmlTree.LI(HtmlStyle.blockList, indexHead);
             Content indexBody = contents.getContent("doclet.help.index.body", indexlink);
             Content indexPara = HtmlTree.P(indexBody);
-            htmlTree.addContent(indexPara);
+            htmlTree.add(indexPara);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -382,12 +382,12 @@ public class HelpWriter extends HtmlDocletWriter {
                     : HtmlTree.LI(HtmlStyle.blockList, frameHead);
             Content framesBody = contents.getContent("doclet.help.frames.body");
             Content framePara = HtmlTree.P(framesBody);
-            htmlTree.addContent(framePara);
+            htmlTree.add(framePara);
 
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+                ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
             } else {
-                ul.addContent(htmlTree);
+                ul.add(htmlTree);
             }
         }
 
@@ -401,11 +401,11 @@ public class HelpWriter extends HtmlDocletWriter {
                 links.createLink(DocPaths.AllClasses(configuration.frames),
                 resources.getText("doclet.All_Classes")));
         Content allclassesPara = HtmlTree.P(allClassesBody);
-        htmlTree.addContent(allclassesPara);
+        htmlTree.add(allclassesPara);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Serialized Form
@@ -416,11 +416,11 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, sHead);
         Content serialBody = contents.getContent("doclet.help.serial_form.body");
         Content serialPara = HtmlTree.P(serialBody);
-        htmlTree.addContent(serialPara);
+        htmlTree.add(serialPara);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Constant Field Values
@@ -433,11 +433,11 @@ public class HelpWriter extends HtmlDocletWriter {
                 links.createLink(DocPaths.CONSTANT_VALUES,
                 resources.getText("doclet.Constants_Summary")));
         Content constPara = HtmlTree.P(constantsBody);
-        htmlTree.addContent(constPara);
+        htmlTree.add(constPara);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         // Search
@@ -448,23 +448,23 @@ public class HelpWriter extends HtmlDocletWriter {
                 : HtmlTree.LI(HtmlStyle.blockList, searchHead);
         Content searchBody = contents.getContent("doclet.help.search.body");
         Content searchPara = HtmlTree.P(searchBody);
-        htmlTree.addContent(searchPara);
+        htmlTree.add(searchPara);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            ul.addContent(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
+            ul.add(HtmlTree.LI(HtmlStyle.blockList, htmlTree));
         } else {
-            ul.addContent(htmlTree);
+            ul.add(htmlTree);
         }
 
         Content divContent = HtmlTree.DIV(HtmlStyle.contentContainer, ul);
-        divContent.addContent(new HtmlTree(HtmlTag.HR));
+        divContent.add(new HtmlTree(HtmlTag.HR));
         Content footnote = HtmlTree.SPAN(HtmlStyle.emphasizedPhrase,
                 contents.getContent("doclet.help.footnote"));
-        divContent.addContent(footnote);
+        divContent.add(footnote);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(divContent);
-            contentTree.addContent(mainTree);
+            mainTree.add(divContent);
+            contentTree.add(mainTree);
         } else {
-            contentTree.addContent(divContent);
+            contentTree.add(divContent);
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -29,6 +29,7 @@ import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.TableHeader;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,6 +69,7 @@ import com.sun.source.doctree.TextTree;
 import com.sun.source.util.SimpleDocTreeVisitor;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
+import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTag;
@@ -1514,7 +1516,7 @@ public class HtmlDocletWriter {
                 @Override
                 public Boolean visitText(TextTree node, Content c) {
                     String text = node.getBody();
-                    result.addContent(new RawHtml(textCleanup(text, isLastNode, commentRemoved)));
+                    result.add(new RawHtml(textCleanup(text, isLastNode, commentRemoved)));
                     return false;
                 }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -29,7 +29,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.TableHeader;
 
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -69,7 +68,6 @@ import com.sun.source.doctree.TextTree;
 import com.sun.source.util.SimpleDocTreeVisitor;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
-import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTag;
@@ -284,7 +282,7 @@ public class HtmlDocletWriter {
         Content div = HtmlTree.DIV(script.asContent());
         Content div_noscript = HtmlTree.DIV(contents.noScriptMessage);
         Content noScript = HtmlTree.NOSCRIPT(div_noscript);
-        div.addContent(noScript);
+        div.add(noScript);
         return div;
     }
 
@@ -333,8 +331,8 @@ public class HtmlDocletWriter {
         TagletWriter.genTagOutput(configuration.tagletManager, e,
             configuration.tagletManager.getBlockTaglets(e),
                 getTagletWriterInstance(false), output);
-        dl.addContent(output);
-        htmltree.addContent(dl);
+        dl.add(output);
+        htmltree.add(dl);
     }
 
     /**
@@ -472,7 +470,7 @@ public class HtmlDocletWriter {
      */
     public void addTop(Content htmlTree) {
         Content top = new RawHtml(replaceDocRootDir(configuration.top));
-        fixedNavDiv.addContent(top);
+        fixedNavDiv.add(top);
     }
 
     /**
@@ -484,7 +482,7 @@ public class HtmlDocletWriter {
         Content bottom = new RawHtml(replaceDocRootDir(configuration.bottom));
         Content small = HtmlTree.SMALL(bottom);
         Content p = HtmlTree.P(HtmlStyle.legalCopy, small);
-        htmlTree.addContent(p);
+        htmlTree.add(p);
     }
 
     /**
@@ -511,7 +509,7 @@ public class HtmlDocletWriter {
         Content space = Contents.SPACE;
         Content tabSpan = HtmlTree.SPAN(HtmlStyle.tabEnd, space);
         Content caption = HtmlTree.CAPTION(captionSpan);
-        caption.addContent(tabSpan);
+        caption.add(tabSpan);
         return caption;
     }
 
@@ -662,9 +660,9 @@ public class HtmlDocletWriter {
                     .resolve(docPaths.forClass(te));
             Content content = links.createLink(href
                     .fragment(SourceToHTMLConverter.getAnchorName(utils, element)), label, "", "");
-            htmltree.addContent(content);
+            htmltree.add(content);
         } else {
-            htmltree.addContent(label);
+            htmltree.add(label);
         }
     }
 
@@ -786,9 +784,9 @@ public class HtmlDocletWriter {
         ContentBuilder classlink = new ContentBuilder();
         PackageElement pkg = utils.containingPackage(typeElement);
         if (pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
-            classlink.addContent(getEnclosingPackageName(typeElement));
+            classlink.add(getEnclosingPackageName(typeElement));
         }
-        classlink.addContent(getLink(new LinkInfoImpl(configuration,
+        classlink.add(getLink(new LinkInfoImpl(configuration,
                 context, typeElement).label(utils.getSimpleName(typeElement)).strong(isStrong)));
         return classlink;
     }
@@ -807,13 +805,13 @@ public class HtmlDocletWriter {
             TypeElement typeElement, boolean isStrong, Content contentTree) {
         PackageElement pkg = utils.containingPackage(typeElement);
         if(pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
-            contentTree.addContent(getEnclosingPackageName(typeElement));
+            contentTree.add(getEnclosingPackageName(typeElement));
         }
         LinkInfoImpl linkinfo = new LinkInfoImpl(configuration, context, typeElement)
                 .label(utils.getSimpleName(typeElement))
                 .strong(isStrong);
         Content link = getLink(linkinfo);
-        contentTree.addContent(link);
+        contentTree.add(link);
     }
 
     /**
@@ -1224,14 +1222,14 @@ public class HtmlDocletWriter {
         Content result = commentTagsToContent(null, element, tags, first);
         if (depr) {
             div = HtmlTree.DIV(HtmlStyle.deprecationComment, result);
-            htmltree.addContent(div);
+            htmltree.add(div);
         }
         else {
             div = HtmlTree.DIV(HtmlStyle.block, result);
-            htmltree.addContent(div);
+            htmltree.add(div);
         }
         if (tags.isEmpty()) {
-            htmltree.addContent(Contents.SPACE);
+            htmltree.add(Contents.SPACE);
         }
     }
 
@@ -1284,8 +1282,8 @@ public class HtmlDocletWriter {
 
         final Content result = new ContentBuilder() {
             @Override
-            public void addContent(CharSequence text) {
-                super.addContent(utils.normalizeNewlines(text));
+            public void add(CharSequence text) {
+                super.add(utils.normalizeNewlines(text));
             }
         };
         CommentHelper ch = utils.getCommentHelper(element);
@@ -1335,7 +1333,7 @@ public class HtmlDocletWriter {
                 public Boolean visitAttribute(AttributeTree node, Content c) {
                     StringBuilder sb = new StringBuilder(SPACER).append(node.getName());
                     if (node.getValueKind() == ValueKind.EMPTY) {
-                        result.addContent(sb);
+                        result.add(sb);
                         return false;
                     }
                     sb.append("=");
@@ -1352,7 +1350,7 @@ public class HtmlDocletWriter {
                             break;
                     }
                     sb.append(quote);
-                    result.addContent(sb);
+                    result.add(sb);
                     Content docRootContent = new ContentBuilder();
 
                     boolean isHRef = inAnAtag() && node.getName().toString().equalsIgnoreCase("href");
@@ -1360,16 +1358,16 @@ public class HtmlDocletWriter {
                         if (utils.isText(dt) && isHRef) {
                             String text = ((TextTree) dt).getBody();
                             if (text.startsWith("/..") && !configuration.docrootparent.isEmpty()) {
-                                result.addContent(configuration.docrootparent);
+                                result.add(configuration.docrootparent);
                                 docRootContent = new ContentBuilder();
-                                result.addContent(textCleanup(text.substring(3), isLastNode));
+                                result.add(textCleanup(text.substring(3), isLastNode));
                             } else {
                                 if (!docRootContent.isEmpty()) {
                                     docRootContent = copyDocRootContent(docRootContent);
                                 } else {
                                     text = redirectRelativeLinks(element, (TextTree) dt);
                                 }
-                                result.addContent(textCleanup(text, isLastNode));
+                                result.add(textCleanup(text, isLastNode));
                             }
                         } else {
                             docRootContent = copyDocRootContent(docRootContent);
@@ -1377,19 +1375,19 @@ public class HtmlDocletWriter {
                         }
                     }
                     copyDocRootContent(docRootContent);
-                    result.addContent(quote);
+                    result.add(quote);
                     return false;
                 }
 
                 @Override
                 public Boolean visitComment(CommentTree node, Content c) {
-                    result.addContent(new RawHtml(node.getBody()));
+                    result.add(new RawHtml(node.getBody()));
                     return false;
                 }
 
                 private Content copyDocRootContent(Content content) {
                     if (!content.isEmpty()) {
-                        result.addContent(content);
+                        result.add(content);
                         return new ContentBuilder();
                     }
                     return content;
@@ -1403,9 +1401,9 @@ public class HtmlDocletWriter {
                             node,
                             getTagletWriterInstance(isFirstSentence));
                     if (c != null) {
-                        c.addContent(docRootContent);
+                        c.add(docRootContent);
                     } else {
-                        result.addContent(docRootContent);
+                        result.add(docRootContent);
                     }
                     return false;
                 }
@@ -1413,13 +1411,13 @@ public class HtmlDocletWriter {
                 @Override
                 public Boolean visitEndElement(EndElementTree node, Content c) {
                     RawHtml rawHtml = new RawHtml("</" + node.getName() + ">");
-                    result.addContent(rawHtml);
+                    result.add(rawHtml);
                     return false;
                 }
 
                 @Override
                 public Boolean visitEntity(EntityTree node, Content c) {
-                    result.addContent(new RawHtml(node.toString()));
+                    result.add(new RawHtml(node.toString()));
                     return false;
                 }
 
@@ -1427,7 +1425,7 @@ public class HtmlDocletWriter {
                 public Boolean visitErroneous(ErroneousTree node, Content c) {
                     messages.warning(ch.getDocTreePath(node),
                             "doclet.tag.invalid_usage", node);
-                    result.addContent(new RawHtml(node.toString()));
+                    result.add(new RawHtml(node.toString()));
                     return false;
                 }
 
@@ -1436,7 +1434,7 @@ public class HtmlDocletWriter {
                     Content output = TagletWriter.getInlineTagOutput(element,
                             configuration.tagletManager, holderTag,
                             tag, getTagletWriterInstance(isFirstSentence));
-                    result.addContent(output);
+                    result.add(output);
                     // if we obtained the first sentence successfully, nothing more to do
                     return (isFirstSentence && !output.isEmpty());
                 }
@@ -1447,7 +1445,7 @@ public class HtmlDocletWriter {
                             configuration.tagletManager, holderTag, tag,
                             getTagletWriterInstance(isFirstSentence));
                     if (output != null) {
-                        result.addContent(output);
+                        result.add(output);
                     }
                     return false;
                 }
@@ -1455,7 +1453,7 @@ public class HtmlDocletWriter {
                 @Override
                 public Boolean visitLink(LinkTree node, Content c) {
                     // we need to pass the DocTreeImpl here, so ignore node
-                    result.addContent(seeTagToContent(element, tag));
+                    result.add(seeTagToContent(element, tag));
                     return false;
                 }
 
@@ -1465,14 +1463,14 @@ public class HtmlDocletWriter {
                     Content content = new StringContent(utils.normalizeNewlines(s));
                     if (node.getKind() == CODE)
                         content = HtmlTree.CODE(content);
-                    result.addContent(content);
+                    result.add(content);
                     return false;
                 }
 
                 @Override
                 public Boolean visitSee(SeeTree node, Content c) {
                     // we need to pass the DocTreeImpl here, so ignore node
-                    result.addContent(seeTagToContent(element, tag));
+                    result.add(seeTagToContent(element, tag));
                     return false;
                 }
 
@@ -1480,12 +1478,12 @@ public class HtmlDocletWriter {
                 public Boolean visitStartElement(StartElementTree node, Content c) {
                     String text = "<" + node.getName();
                     RawHtml rawHtml = new RawHtml(utils.normalizeNewlines(text));
-                    result.addContent(rawHtml);
+                    result.add(rawHtml);
 
                     for (DocTree dt : node.getAttributes()) {
                         dt.accept(this, null);
                     }
-                    result.addContent(new RawHtml(node.isSelfClosing() ? "/>" : ">"));
+                    result.add(new RawHtml(node.isSelfClosing() ? "/>" : ">"));
                     return false;
                 }
 
@@ -1494,7 +1492,7 @@ public class HtmlDocletWriter {
                     Content output = TagletWriter.getInlineTagOutput(element,
                             configuration.tagletManager, holderTag, tag,
                             getTagletWriterInstance(isFirstSentence));
-                    result.addContent(output);
+                    result.add(output);
                     return false;
                 }
 
@@ -1526,7 +1524,7 @@ public class HtmlDocletWriter {
                             configuration.tagletManager, holderTag, tag,
                             getTagletWriterInstance(isFirstSentence));
                     if (output != null) {
-                        result.addContent(output);
+                        result.add(output);
                     }
                     return false;
                 }
@@ -1737,8 +1735,8 @@ public class HtmlDocletWriter {
             return false;
         }
         for (Content annotation: annotations) {
-            htmltree.addContent(sep);
-            htmltree.addContent(annotation);
+            htmltree.add(sep);
+            htmltree.add(annotation);
             if (!lineBreak) {
                 sep = " ";
             }
@@ -1827,8 +1825,8 @@ public class HtmlDocletWriter {
 
                     String sep = "";
                     for (AnnotationValue av : annotationTypeValues) {
-                        annotation.addContent(sep);
-                        annotation.addContent(annotationValueToContent(av));
+                        annotation.add(sep);
+                        annotation.add(annotationValueToContent(av));
                         sep = " ";
                     }
                 }
@@ -1851,8 +1849,8 @@ public class HtmlDocletWriter {
                     }
                     String sep = "";
                     for (AnnotationValue av : annotationTypeValues) {
-                        annotation.addContent(sep);
-                        annotation.addContent(annotationValueToContent(av));
+                        annotation.add(sep);
+                        annotation.add(annotationValueToContent(av));
                         sep = " ";
                     }
                 }
@@ -1867,7 +1865,7 @@ public class HtmlDocletWriter {
                 addAnnotations(annotationElement, linkInfo, annotation, pairs,
                                indent, linkBreak);
             }
-            annotation.addContent(linkBreak ? DocletConstants.NL : "");
+            annotation.add(linkBreak ? DocletConstants.NL : "");
             results.add(annotation);
         }
         return results;
@@ -1888,10 +1886,10 @@ public class HtmlDocletWriter {
                                 Map<? extends ExecutableElement, ? extends AnnotationValue> map,
                                 int indent, boolean linkBreak) {
         linkInfo.label = new StringContent("@");
-        linkInfo.label.addContent(annotationDoc.getSimpleName());
-        annotation.addContent(getLink(linkInfo));
+        linkInfo.label.add(annotationDoc.getSimpleName());
+        annotation.add(getLink(linkInfo));
         if (!map.isEmpty()) {
-            annotation.addContent("(");
+            annotation.add("(");
             boolean isFirst = true;
             Set<? extends ExecutableElement> keys = map.keySet();
             boolean multipleValues = keys.size() > 1;
@@ -1899,20 +1897,20 @@ public class HtmlDocletWriter {
                 if (isFirst) {
                     isFirst = false;
                 } else {
-                    annotation.addContent(",");
+                    annotation.add(",");
                     if (linkBreak) {
-                        annotation.addContent(DocletConstants.NL);
+                        annotation.add(DocletConstants.NL);
                         int spaces = annotationDoc.getSimpleName().length() + 2;
                         for (int k = 0; k < (spaces + indent); k++) {
-                            annotation.addContent(" ");
+                            annotation.add(" ");
                         }
                     }
                 }
                 String simpleName = element.getSimpleName().toString();
                 if (multipleValues || !"value".equals(simpleName)) { // Omit "value=" where unnecessary
-                    annotation.addContent(getDocLink(LinkInfoImpl.Kind.ANNOTATION,
+                    annotation.add(getDocLink(LinkInfoImpl.Kind.ANNOTATION,
                                                      element, simpleName, false));
-                    annotation.addContent("=");
+                    annotation.add("=");
                 }
                 AnnotationValue annotationValue = map.get(element);
                 List<AnnotationValue> annotationTypeValues = new ArrayList<>();
@@ -1928,17 +1926,17 @@ public class HtmlDocletWriter {
                         return null;
                     }
                 }.visit(annotationValue, annotationValue);
-                annotation.addContent(annotationTypeValues.size() == 1 ? "" : "{");
+                annotation.add(annotationTypeValues.size() == 1 ? "" : "{");
                 String sep = "";
                 for (AnnotationValue av : annotationTypeValues) {
-                    annotation.addContent(sep);
-                    annotation.addContent(annotationValueToContent(av));
+                    annotation.add(sep);
+                    annotation.add(annotationValueToContent(av));
                     sep = ",";
                 }
-                annotation.addContent(annotationTypeValues.size() == 1 ? "" : "}");
+                annotation.add(annotationTypeValues.size() == 1 ? "" : "}");
                 isContainerDocumented = false;
             }
-            annotation.addContent(")");
+            annotation.add(")");
         }
     }
 
@@ -2019,7 +2017,7 @@ public class HtmlDocletWriter {
                 List<Content> list = getAnnotations(0, a, false);
                 ContentBuilder buf = new ContentBuilder();
                 for (Content c : list) {
-                    buf.addContent(c);
+                    buf.add(c);
                 }
                 return buf;
             }
@@ -2033,8 +2031,8 @@ public class HtmlDocletWriter {
                 ContentBuilder buf = new ContentBuilder();
                 String sep = "";
                 for (AnnotationValue av : vals) {
-                    buf.addContent(sep);
-                    buf.addContent(visit(av));
+                    buf.add(sep);
+                    buf.add(visit(av));
                     sep = " ";
                 }
                 return buf;
@@ -2088,9 +2086,9 @@ public class HtmlDocletWriter {
         // and package-frame
         if (includeScript) {
             this.mainBodyScript = getWinTitleScript();
-            body.addContent(mainBodyScript.asContent());
+            body.add(mainBodyScript.asContent());
             Content noScript = HtmlTree.NOSCRIPT(HtmlTree.DIV(contents.noScriptMessage));
-            body.addContent(noScript);
+            body.add(noScript);
         }
         return body;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -110,8 +110,8 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
             Content headingContent = new StringContent(heading);
             Content serialHeading = HtmlTree.HEADING(HtmlConstants.SERIALIZED_MEMBER_HEADING,
                     headingContent);
-            li.addContent(serialHeading);
-            li.addContent(serializableFieldsTree);
+            li.add(serialHeading);
+            li.add(serializableFieldsTree);
         }
         return li;
     }
@@ -121,32 +121,32 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
             String fieldDimensions, String fieldName, Content contentTree) {
         Content nameContent = new StringContent(fieldName);
         Content heading = HtmlTree.HEADING(HtmlConstants.MEMBER_HEADING, nameContent);
-        contentTree.addContent(heading);
+        contentTree.add(heading);
         Content pre = new HtmlTree(HtmlTag.PRE);
         if (fieldType == null) {
-            pre.addContent(fieldTypeStr);
+            pre.add(fieldTypeStr);
         } else {
             Content fieldContent = writer.getLink(new LinkInfoImpl(
                     configuration, LinkInfoImpl.Kind.SERIAL_MEMBER, fieldType));
-            pre.addContent(fieldContent);
+            pre.add(fieldContent);
         }
-        pre.addContent(fieldDimensions + " ");
-        pre.addContent(fieldName);
-        contentTree.addContent(pre);
+        pre.add(fieldDimensions + " ");
+        pre.add(fieldName);
+        contentTree.add(pre);
     }
 
     @Override
     public void addMemberHeader(TypeMirror fieldType, String fieldName, Content contentTree) {
         Content nameContent = new StringContent(fieldName);
         Content heading = HtmlTree.HEADING(HtmlConstants.MEMBER_HEADING, nameContent);
-        contentTree.addContent(heading);
+        contentTree.add(heading);
         Content pre = new HtmlTree(HtmlTag.PRE);
         Content fieldContent = writer.getLink(new LinkInfoImpl(
                 configuration, LinkInfoImpl.Kind.SERIAL_MEMBER, fieldType));
-        pre.addContent(fieldContent);
-        pre.addContent(" ");
-        pre.addContent(fieldName);
-        contentTree.addContent(pre);
+        pre.add(fieldContent);
+        pre.add(" ");
+        pre.add(fieldName);
+        contentTree.add(pre);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -187,7 +187,7 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         if (!description.isEmpty()) {
             Content serialFieldContent = new RawHtml(ch.getText(description));
             Content div = HtmlTree.DIV(HtmlStyle.block, serialFieldContent);
-            contentTree.addContent(div);
+            contentTree.add(div);
         }
     }
 
@@ -203,8 +203,8 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
                 configuration.tagletManager.getBlockTaglets(field),
                 writer.getTagletWriterInstance(false), tagContent);
         Content dlTags = new HtmlTree(HtmlTag.DL);
-        dlTags.addContent(tagContent);
-        contentTree.addContent(dlTags);  // TODO: what if empty?
+        dlTags.add(tagContent);
+        contentTree.add(dlTags);  // TODO: what if empty?
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
@@ -98,7 +98,7 @@ public class HtmlSerialMethodWriter extends MethodWriterImpl implements
         Content serialHeading = HtmlTree.HEADING(HtmlConstants.SERIALIZED_MEMBER_HEADING,
                 headingContent);
         Content li = HtmlTree.LI(HtmlStyle.blockList, serialHeading);
-        li.addContent(serializableMethodContent);
+        li.add(serializableMethodContent);
         return li;
     }
 
@@ -158,8 +158,8 @@ public class HtmlSerialMethodWriter extends MethodWriterImpl implements
             tagletManager.getSerializedFormTaglets(),
             writer.getTagletWriterInstance(false), tagContent);
         Content dlTags = new HtmlTree(HtmlTag.DL);
-        dlTags.addContent(tagContent);
-        methodsContentTree.addContent(dlTags);
+        dlTags.add(tagContent);
+        methodsContentTree.add(dlTags);
         if (name(member).compareTo("writeExternal") == 0
                 && utils.getSerialDataTrees(member).isEmpty()) {
             serialWarning(member, "doclet.MissingSerialDataTag",

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
@@ -120,8 +120,8 @@ public class HtmlSerialMethodWriter extends MethodWriterImpl implements
      * @param methodsContentTree the content tree to which the member header will be added
      */
     public void addMemberHeader(ExecutableElement member, Content methodsContentTree) {
-        methodsContentTree.addContent(getHead(member));
-        methodsContentTree.addContent(getSignature(member));
+        methodsContentTree.add(getHead(member));
+        methodsContentTree.add(getSignature(member));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
@@ -25,6 +25,7 @@
 
 package jdk.javadoc.internal.doclets.formats.html;
 
+import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
@@ -90,24 +91,24 @@ public class IndexRedirectWriter extends HtmlDocletWriter {
                 .appendStringLiteral(targetPath, '\'')
                 .append(")");
         HtmlTree metaRefresh = new HtmlTree(HtmlTag.META)
-                .addAttr(HtmlAttr.HTTP_EQUIV, "Refresh")
-                .addAttr(HtmlAttr.CONTENT, "0;" + targetPath);
+                .put(HtmlAttr.HTTP_EQUIV, "Refresh")
+                .put(HtmlAttr.CONTENT, "0;" + targetPath);
         head.addContent(
                 script.asContent(),
                 configuration.isOutputHtml5() ? HtmlTree.NOSCRIPT(metaRefresh) : metaRefresh);
 
         ContentBuilder bodyContent = new ContentBuilder();
-        bodyContent.addContent(HtmlTree.NOSCRIPT(
+        bodyContent.add(HtmlTree.NOSCRIPT(
                 HtmlTree.P(contents.getContent("doclet.No_Script_Message"))));
 
-        bodyContent.addContent(HtmlTree.P(HtmlTree.A(targetPath, new StringContent(targetPath))));
+        bodyContent.add(HtmlTree.P(HtmlTree.A(targetPath, new StringContent(targetPath))));
 
         Content body = new HtmlTree(HtmlTag.BODY);
         if (configuration.allowTag(HtmlTag.MAIN)) {
             HtmlTree main = HtmlTree.MAIN(bodyContent);
-            body.addContent(main);
+            body.add(main);
         } else {
-            body.addContent(bodyContent);
+            body.add(bodyContent);
         }
 
         Content htmlTree = HtmlTree.HTML(configuration.getLocale().getLanguage(), head.toContent(), body);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
@@ -27,7 +27,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
-import jdk.javadoc.internal.doclets.formats.html.markup.DocType;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTag;
@@ -39,8 +38,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFile;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
-
-import java.util.Collections;
 
 /**
  * Writes a file that tries to redirect to an alternate page.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,14 +97,14 @@ public class LinkFactoryImpl extends LinkFactory {
                 DocPath filename = getPath(classLinkInfo);
                 if (linkInfo.linkToSelf ||
                                 !(docPaths.forName(typeElement)).equals(m_writer.filename)) {
-                        link.addContent(m_writer.links.createLink(
+                        link.add(m_writer.links.createLink(
                                 filename.fragment(classLinkInfo.where),
                                 label,
                                 classLinkInfo.isStrong,
                                 title,
                                 classLinkInfo.target));
                         if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-                            link.addContent(getTypeParameterLinks(linkInfo));
+                            link.add(getTypeParameterLinks(linkInfo));
                         }
                         return link;
                 }
@@ -114,17 +114,17 @@ public class LinkFactoryImpl extends LinkFactory {
                 typeElement, classLinkInfo.where,
                 label, classLinkInfo.isStrong, true);
             if (crossLink != null) {
-                link.addContent(crossLink);
+                link.add(crossLink);
                 if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-                    link.addContent(getTypeParameterLinks(linkInfo));
+                    link.add(getTypeParameterLinks(linkInfo));
                 }
                 return link;
             }
         }
         // Can't link so just write label.
-        link.addContent(label);
+        link.add(label);
         if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-            link.addContent(getTypeParameterLinks(linkInfo));
+            link.add(getTypeParameterLinks(linkInfo));
         }
         return link;
     }
@@ -157,17 +157,17 @@ public class LinkFactoryImpl extends LinkFactory {
         }
         if (((linkInfo.includeTypeInClassLinkLabel && isClassLabel)
                 || (linkInfo.includeTypeAsSepLink && !isClassLabel)) && !vars.isEmpty()) {
-            links.addContent("<");
+            links.add("<");
             boolean many = false;
             for (TypeMirror t : vars) {
                 if (many) {
-                    links.addContent(",");
-                    links.addContent(Contents.ZERO_WIDTH_SPACE);
+                    links.add(",");
+                    links.add(Contents.ZERO_WIDTH_SPACE);
                 }
-                links.addContent(getTypeParameterLink(linkInfo, t));
+                links.add(getTypeParameterLink(linkInfo, t));
                 many = true;
             }
-            links.addContent(">");
+            links.add(">");
         }
         return links;
     }
@@ -222,13 +222,13 @@ public class LinkFactoryImpl extends LinkFactory {
         boolean isFirst = true;
         for (Content anno : annos) {
             if (!isFirst) {
-                links.addContent(" ");
+                links.add(" ");
             }
-            links.addContent(anno);
+            links.add(anno);
             isFirst = false;
         }
         if (!annos.isEmpty()) {
-            links.addContent(" ");
+            links.add(" ");
         }
 
         return links;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -191,9 +191,9 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                         utils.isClass(holder)
                                 ? contents.descfrmClassLabel
                                 : contents.descfrmInterfaceLabel);
-                descfrmLabel.addContent(Contents.SPACE);
-                descfrmLabel.addContent(codelLink);
-                methodDocTree.addContent(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
+                descfrmLabel.add(Contents.SPACE);
+                descfrmLabel.add(codelLink);
+                methodDocTree.add(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
                 writer.addInlineComment(method, methodDocTree);
             }
         }
@@ -235,7 +235,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.methodSummary);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -277,7 +277,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(SectionName.METHOD_SUMMARY));
+        memberTree.add(links.createAnchor(SectionName.METHOD_SUMMARY));
     }
 
     /**
@@ -285,7 +285,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
      */
     @Override
     public void addInheritedSummaryAnchor(TypeElement typeElement, Content inheritedTree) {
-        inheritedTree.addContent(links.createAnchor(
+        inheritedTree.add(links.createAnchor(
                 SectionName.METHODS_INHERITANCE, configuration.getClassName(typeElement)));
     }
 
@@ -308,9 +308,9 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
         }
         Content labelHeading = HtmlTree.HEADING(HtmlConstants.INHERITED_SUMMARY_HEADING,
                 label);
-        labelHeading.addContent(Contents.SPACE);
-        labelHeading.addContent(classLink);
-        inheritedTree.addContent(labelHeading);
+        labelHeading.add(Contents.SPACE);
+        labelHeading.add(classLink);
+        inheritedTree.add(labelHeading);
     }
 
     /**
@@ -354,7 +354,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                 context = LinkInfoImpl.Kind.METHOD_SPECIFIED_BY;
             }
             Content dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.overrideSpecifyLabel, label));
-            dl.addContent(dt);
+            dl.add(dt);
             Content overriddenTypeLink =
                     writer.getLink(new LinkInfoImpl(writer.configuration, context, overriddenType));
             Content codeOverridenTypeLink = HtmlTree.CODE(overriddenTypeLink);
@@ -364,11 +364,11 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                     .where(writer.links.getName(writer.getAnchor(method))).label(method.getSimpleName()));
             Content codeMethLink = HtmlTree.CODE(methlink);
             Content dd = HtmlTree.DD(codeMethLink);
-            dd.addContent(Contents.SPACE);
-            dd.addContent(writer.contents.inClass);
-            dd.addContent(Contents.SPACE);
-            dd.addContent(codeOverridenTypeLink);
-            dl.addContent(dd);
+            dd.add(Contents.SPACE);
+            dd.add(writer.contents.inClass);
+            dd.add(Contents.SPACE);
+            dd.add(codeOverridenTypeLink);
+            dl.add(dd);
         }
     }
 
@@ -394,17 +394,17 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                     writer.configuration, LinkInfoImpl.Kind.METHOD_SPECIFIED_BY, intfac));
             Content codeIntfacLink = HtmlTree.CODE(intfaclink);
             Content dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.overrideSpecifyLabel, contents.specifiedByLabel));
-            dl.addContent(dt);
+            dl.add(dt);
             Content methlink = writer.getDocLink(
                     LinkInfoImpl.Kind.MEMBER, implementedMeth,
                     implementedMeth.getSimpleName(), false);
             Content codeMethLink = HtmlTree.CODE(methlink);
             Content dd = HtmlTree.DD(codeMethLink);
-            dd.addContent(Contents.SPACE);
-            dd.addContent(contents.inInterface);
-            dd.addContent(Contents.SPACE);
-            dd.addContent(codeIntfacLink);
-            dl.addContent(dd);
+            dd.add(Contents.SPACE);
+            dd.add(contents.inInterface);
+            dd.add(Contents.SPACE);
+            dd.add(codeIntfacLink);
+            dl.add(dd);
         }
     }
 
@@ -419,8 +419,8 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
         if (type != null) {
             Content linkContent = writer.getLink(
                     new LinkInfoImpl(configuration, LinkInfoImpl.Kind.RETURN_TYPE, type));
-            htmltree.addContent(linkContent);
-            htmltree.addContent(Contents.SPACE);
+            htmltree.add(linkContent);
+            htmltree.add(Contents.SPACE);
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -87,7 +87,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
      */
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement, Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_METHOD_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_METHOD_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -106,12 +106,12 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
      */
     @Override
     public Content getMethodDetailsTreeHeader(TypeElement typeElement, Content memberDetailsTree) {
-        memberDetailsTree.addContent(HtmlConstants.START_OF_METHOD_DETAILS);
+        memberDetailsTree.add(HtmlConstants.START_OF_METHOD_DETAILS);
         Content methodDetailsTree = writer.getMemberTreeHeader();
-        methodDetailsTree.addContent(links.createAnchor(SectionName.METHOD_DETAIL));
+        methodDetailsTree.add(links.createAnchor(SectionName.METHOD_DETAIL));
         Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                 contents.methodDetailLabel);
-        methodDetailsTree.addContent(heading);
+        methodDetailsTree.add(heading);
         return methodDetailsTree;
     }
 
@@ -122,13 +122,13 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     public Content getMethodDocTreeHeader(ExecutableElement method, Content methodDetailsTree) {
         String erasureAnchor;
         if ((erasureAnchor = getErasureAnchor(method)) != null) {
-            methodDetailsTree.addContent(links.createAnchor((erasureAnchor)));
+            methodDetailsTree.add(links.createAnchor((erasureAnchor)));
         }
-        methodDetailsTree.addContent(links.createAnchor(writer.getAnchor(method)));
+        methodDetailsTree.add(links.createAnchor(writer.getAnchor(method)));
         Content methodDocTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(name(method));
-        methodDocTree.addContent(heading);
+        heading.add(name(method));
+        methodDocTree.add(heading);
         return methodDocTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleFrameWriter.java
@@ -178,7 +178,7 @@ public class ModuleFrameWriter extends HtmlDocletWriter {
                 if (!printedHeader) {
                     Content heading = HtmlTree.HEADING(HtmlConstants.CONTENT_HEADING,
                             true, labelContent);
-                    htmlTree.addContent(heading);
+                    htmlTree.add(heading);
                     printedHeader = true;
                 }
                 Content arr_i_name = new StringContent(utils.getSimpleName(typeElement));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleFrameWriter.java
@@ -106,13 +106,13 @@ public class ModuleFrameWriter extends HtmlDocletWriter {
                 : configuration.docPaths.moduleSummary(moduleElement);
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, HtmlStyle.bar,
                 mdlgen.links.createLink(moduleSummary, mdlLabel, "", "classFrame"));
-        htmlTree.addContent(heading);
+        htmlTree.add(heading);
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.indexContainer);
         mdlgen.addClassListing(div);
-        htmlTree.addContent(div);
+        htmlTree.add(div);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         mdlgen.printHtmlDocument(
                 configuration.metakeywords.getMetaKeywordsForModule(moduleElement), false, body);
@@ -188,11 +188,11 @@ public class ModuleFrameWriter extends HtmlDocletWriter {
                 Content link = getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.ALL_CLASSES_FRAME, typeElement).label(arr_i_name).target("classFrame"));
                 Content li = HtmlTree.LI(link);
-                ul.addContent(li);
+                ul.add(li);
             }
-            htmlTree.addContent(ul);
+            htmlTree.add(ul);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                contentTree.addContent(htmlTree);
+                contentTree.add(htmlTree);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexFrameWriter.java
@@ -90,10 +90,10 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
         HtmlTree ul = new HtmlTree(HtmlTag.UL);
         ul.setTitle(contents.modulesLabel);
         for (ModuleElement mdle: configuration.modules) {
-            ul.addContent(getModuleLink(mdle));
+            ul.add(getModuleLink(mdle));
         }
-        htmlTree.addContent(ul);
-        main.addContent(htmlTree);
+        htmlTree.add(ul);
+        main.add(htmlTree);
     }
 
     /**
@@ -116,8 +116,8 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
         DocLink cFrameLink = new DocLink(docPaths.moduleSummary(mdle));
         HtmlTree anchor = HtmlTree.A(mdlLink.toString(), label);
         String onclickStr = "updateModuleFrame('" + mtFrameLink + "','" + cFrameLink + "');";
-        anchor.addAttr(HtmlAttr.TARGET, target);
-        anchor.addAttr(HtmlAttr.ONCLICK, onclickStr);
+        anchor.put(HtmlAttr.TARGET, target);
+        anchor.put(HtmlAttr.ONCLICK, onclickStr);
         return anchor;
     }
 
@@ -152,7 +152,7 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
         Content linkContent = links.createLink(DocPaths.ALLCLASSES_FRAME,
                 contents.allClassesLabel, "", "packageFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -165,7 +165,7 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
         Content linkContent = links.createLink(DocPaths.OVERVIEW_FRAME,
                 contents.allPackagesLabel, "", "packageListFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -173,7 +173,7 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
      */
     protected void addNavigationBarFooter(Content footer) {
         Content p = HtmlTree.P(Contents.SPACE);
-        footer.addContent(p);
+        footer.add(p);
     }
 
     protected void addModulePackagesList(Map<ModuleElement, Set<PackageElement>> modules, String text,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexFrameWriter.java
@@ -133,7 +133,7 @@ public class ModuleIndexFrameWriter extends AbstractModuleIndexWriter {
         }
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.bar, headerContent);
-        header.addContent(heading);
+        header.add(heading);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexWriter.java
@@ -102,8 +102,8 @@ public class ModuleIndexWriter extends AbstractModuleIndexWriter {
         if (configuration.showModules) {
             addAllModulesLink(ul);
         }
-        htmltree.addContent(ul);
-        header.addContent(htmltree);
+        htmltree.add(ul);
+        header.add(htmltree);
         addModulesList(main);
     }
 
@@ -149,7 +149,7 @@ public class ModuleIndexWriter extends AbstractModuleIndexWriter {
             }
 
             Content div = HtmlTree.DIV(HtmlStyle.contentContainer, table.toContent());
-            main.addContent(div);
+            main.add(div);
 
             if (table.needsScript()) {
                 mainBodyScript.append(table.getScript());
@@ -171,7 +171,7 @@ public class ModuleIndexWriter extends AbstractModuleIndexWriter {
             HtmlTree div = new HtmlTree(HtmlTag.DIV);
             div.setStyle(HtmlStyle.contentContainer);
             addOverviewComment(div);
-            main.addContent(div);
+            main.add(div);
         }
     }
 
@@ -199,7 +199,7 @@ public class ModuleIndexWriter extends AbstractModuleIndexWriter {
     protected void addNavigationBarHeader(Content header) {
         addTop(header);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        header.addContent(navBar.getContent(true));
+        header.add(navBar.getContent(true));
     }
 
     /**
@@ -211,7 +211,7 @@ public class ModuleIndexWriter extends AbstractModuleIndexWriter {
     @Override
     protected void addNavigationBarFooter(Content footer) {
         navBar.setUserFooter(getUserHeaderFooter(false));
-        footer.addContent(navBar.getContent(false));
+        footer.add(navBar.getContent(false));
         addBottom(footer);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModulePackageIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModulePackageIndexFrameWriter.java
@@ -111,8 +111,8 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Content moduleNameContent = new StringContent(mdle.getQualifiedName().toString());
         Content heading = HtmlTree.HEADING(HtmlConstants.PACKAGE_HEADING, true,
                 getTargetModuleLink("classFrame", moduleNameContent, mdle));
-        heading.addContent(Contents.SPACE);
-        heading.addContent(contents.packagesLabel);
+        heading.add(Contents.SPACE);
+        heading.add(contents.packagesLabel);
         HtmlTree htmlTree = (configuration.allowTag(HtmlTag.MAIN))
                 ? HtmlTree.MAIN(HtmlStyle.indexContainer, heading)
                 : HtmlTree.DIV(HtmlStyle.indexContainer, heading);
@@ -121,11 +121,11 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Set<PackageElement> modulePackages = configuration.modulePackages.get(mdle);
         for (PackageElement pkg: modulePackages) {
             if ((!(configuration.nodeprecated && utils.isDeprecated(pkg)))) {
-                ul.addContent(getPackage(pkg, mdle));
+                ul.add(getPackage(pkg, mdle));
             }
         }
-        htmlTree.addContent(ul);
-        body.addContent(htmlTree);
+        htmlTree.add(ul);
+        body.add(htmlTree);
     }
 
     /**
@@ -164,7 +164,7 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         }
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.bar, headerContent);
-        header.addContent(heading);
+        header.add(heading);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModulePackageIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModulePackageIndexFrameWriter.java
@@ -88,19 +88,19 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Content profNameContent = new StringContent(mdle.getQualifiedName().toString());
         Content heading = HtmlTree.HEADING(HtmlConstants.PACKAGE_HEADING, true,
                 getTargetModuleLink("classFrame", profNameContent, mdle));
-        heading.addContent(Contents.SPACE);
-        heading.addContent(contents.packagesLabel);
+        heading.add(Contents.SPACE);
+        heading.add(contents.packagesLabel);
         HtmlTree htmlTree = HtmlTree.DIV(HtmlStyle.indexContainer, heading);
         HtmlTree ul = new HtmlTree(HtmlTag.UL);
         ul.setTitle(contents.packagesLabel);
         List<PackageElement> packages = new ArrayList<>(modules.get(mdle));
         for (PackageElement pkg : packages) {
             if ((!(configuration.nodeprecated && utils.isDeprecated(pkg)))) {
-                ul.addContent(getPackage(pkg, mdle));
+                ul.add(getPackage(pkg, mdle));
             }
         }
-        htmlTree.addContent(ul);
-        main.addContent(htmlTree);
+        htmlTree.add(ul);
+        main.add(htmlTree);
     }
 
     /**
@@ -192,7 +192,7 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Content linkContent = links.createLink(allClassesFrame,
                 contents.allClassesLabel, "", "packageFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -208,7 +208,7 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Content linkContent = links.createLink(overviewFrame,
                 contents.allPackagesLabel, "", "packageListFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -224,7 +224,7 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
         Content linkContent = links.createLink(moduleOverviewFrame,
                 contents.allModulesLabel, "", "packageListFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -232,6 +232,6 @@ public class ModulePackageIndexFrameWriter extends AbstractModuleIndexWriter {
      */
     protected void addNavigationBarFooter(Content footer) {
         Content p = HtmlTree.P(Contents.SPACE);
-        footer.addContent(p);
+        footer.add(p);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -531,7 +531,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 Table table = getTable3(caption, tableSummary, HtmlStyle.requiresSummary,
                             requiresTableHeader);
                 addModulesList(requires, table);
-                li.addContent(table.toContent());
+                li.add(table.toContent());
             }
             // Display indirect modules table in both "api" and "all" mode.
             if (display(indirectModules)) {
@@ -543,10 +543,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 Table amrTable = getTable3(amrCaption, amrTableSummary, HtmlStyle.requiresSummary,
                             requiresTableHeader);
                 addModulesList(indirectModules, amrTable);
-                li.addContent(amrTable.toContent());
+                li.add(amrTable.toContent());
             }
             HtmlTree ul = HtmlTree.UL(HtmlStyle.blockList, li);
-            summaryContentTree.addContent(ul);
+            summaryContentTree.add(ul);
         }
     }
 
@@ -692,7 +692,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             table.addRow(pkg, row);
         }
 
-        li.addContent(table.toContent());
+        li.add(table.toContent());
         if (table.needsScript()) {
             mainBodyScript.append(table.getScript());
         }
@@ -722,9 +722,9 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             Content list = new ContentBuilder();
             for (ModuleElement m : modules) {
                 if (!list.isEmpty()) {
-                    list.addContent(new StringContent(", "));
+                    list.add(new StringContent(", "));
                 }
-                list.addContent(getModuleLink(m, new StringContent(m.getQualifiedName())));
+                list.add(getModuleLink(m, new StringContent(m.getQualifiedName())));
             }
             return list;
         }
@@ -744,8 +744,8 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             Content list = new ContentBuilder();
             String sep = "";
             for (PackageElement pkg : pkgList) {
-                list.addContent(sep);
-                list.addContent(getPackageLink(pkg, new StringContent(utils.getPackageName(pkg))));
+                list.add(sep);
+                list.add(getPackageLink(pkg, new StringContent(utils.getPackageName(pkg))));
                 sep = " ";
             }
             table.addRow(moduleLinkContent, list);
@@ -777,7 +777,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                         usesProvidesTableHeader);
                 addProvidesList(table);
                 if (!table.isEmpty()) {
-                    li.addContent(table.toContent());
+                    li.add(table.toContent());
                 }
             }
             if (haveUses){
@@ -789,11 +789,11 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                         usesProvidesTableHeader);
                 addUsesList(table);
                 if (!table.isEmpty()) {
-                    li.addContent(table.toContent());
+                    li.add(table.toContent());
                 }
             }
             HtmlTree ul = HtmlTree.UL(HtmlStyle.blockList, li);
-            summaryContentTree.addContent(ul);
+            summaryContentTree.add(ul);
         }
     }
 
@@ -814,12 +814,12 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             if (display(usesTrees)) {
                 description = usesTrees.get(t);
                 if (description != null && !description.isEmpty()) {
-                    summary.addContent(HtmlTree.DIV(HtmlStyle.block, description));
+                    summary.add(HtmlTree.DIV(HtmlStyle.block, description));
                 } else {
                     addSummaryComment(t, summary);
                 }
             } else {
-                summary.addContent(Contents.SPACE);
+                summary.add(Contents.SPACE);
             }
             table.addRow(typeLinkContent, summary);
         }
@@ -843,26 +843,26 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             Content desc = new ContentBuilder();
             if (display(providesTrees)) {
                 description = providesTrees.get(srv);
-                desc.addContent((description != null && !description.isEmpty())
+                desc.add((description != null && !description.isEmpty())
                         ? HtmlTree.DIV(HtmlStyle.block, description)
                         : Contents.SPACE);
             } else {
-                desc.addContent(Contents.SPACE);
+                desc.add(Contents.SPACE);
                 }
             // Only display the implementation details in the "all" mode.
             if (moduleMode == ModuleMode.ALL && !implSet.isEmpty()) {
-                desc.addContent(new HtmlTree(HtmlTag.BR));
-                desc.addContent("(");
+                desc.add(new HtmlTree(HtmlTag.BR));
+                desc.add("(");
                 HtmlTree implSpan = HtmlTree.SPAN(HtmlStyle.implementationLabel, contents.implementation);
-                desc.addContent(implSpan);
-                desc.addContent(Contents.SPACE);
+                desc.add(implSpan);
+                desc.add(Contents.SPACE);
                 String sep = "";
                 for (TypeElement impl : implSet) {
-                    desc.addContent(sep);
-                    desc.addContent(getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.PACKAGE, impl)));
+                    desc.add(sep);
+                    desc.add(getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.PACKAGE, impl)));
                     sep = ", ";
                 }
-                desc.addContent(")");
+                desc.add(")");
             }
             table.addRow(srvLinkContent, desc);
         }
@@ -880,14 +880,14 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             HtmlTree deprDiv = new HtmlTree(HtmlTag.DIV);
             deprDiv.setStyle(HtmlStyle.deprecationBlock);
             Content deprPhrase = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(mdle));
-            deprDiv.addContent(deprPhrase);
+            deprDiv.add(deprPhrase);
             if (!deprs.isEmpty()) {
                 List<? extends DocTree> commentTags = ch.getDescription(configuration, deprs.get(0));
                 if (!commentTags.isEmpty()) {
                     addInlineDeprecatedComment(mdle, deprs.get(0), deprDiv);
                 }
             }
-            div.addContent(deprDiv);
+            div.add(deprDiv);
         }
     }
 
@@ -975,7 +975,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             HtmlTree deprDiv = new HtmlTree(HtmlTag.DIV);
             deprDiv.setStyle(HtmlStyle.deprecationBlock);
             Content deprPhrase = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(pkg));
-            deprDiv.addContent(deprPhrase);
+            deprDiv.add(deprPhrase);
             if (!deprs.isEmpty()) {
                 CommentHelper ch = utils.getCommentHelper(pkg);
                 List<? extends DocTree> commentTags = ch.getDescription(configuration, deprs.get(0));
@@ -983,7 +983,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                     addInlineDeprecatedComment(pkg, deprs.get(0), deprDiv);
                 }
             }
-            li.addContent(deprDiv);
+            li.add(deprDiv);
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -206,27 +206,27 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 || display(indirectOpenPackages));
         navBar.setDisplaySummaryServicesLink(displayServices(uses, usesTrees) || displayServices(provides.keySet(), providesTrees));
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.header);
         Content annotationContent = new HtmlTree(HtmlTag.P);
         addAnnotationInfo(mdle, annotationContent);
-        div.addContent(annotationContent);
+        div.add(annotationContent);
         Content label = mdle.isOpen() && (configuration.docEnv.getModuleMode() == ModuleMode.ALL)
                 ? contents.openModuleLabel : contents.moduleLabel;
         Content tHeading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.title, label);
-        tHeading.addContent(Contents.SPACE);
+        tHeading.add(Contents.SPACE);
         Content moduleHead = new RawHtml(heading);
-        tHeading.addContent(moduleHead);
-        div.addContent(tHeading);
+        tHeading.add(moduleHead);
+        div.add(tHeading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }
@@ -467,9 +467,9 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
      */
     public void addSummaryHeader(Content startMarker, SectionName markerAnchor, Content heading,
             Content htmltree) {
-        htmltree.addContent(startMarker);
-        htmltree.addContent(links.createAnchor(markerAnchor));
-        htmltree.addContent(HtmlTree.HEADING(HtmlTag.H3, heading));
+        htmltree.add(startMarker);
+        htmltree.add(links.createAnchor(markerAnchor));
+        htmltree.add(HtmlTree.HEADING(HtmlTag.H3, heading));
     }
 
     /**
@@ -591,7 +591,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 Table aepTable = getTable2(new StringContent(aepText), aepTableSummary,
                         HtmlStyle.packagesSummary, indirectPackagesHeader);
                 addIndirectPackages(aepTable, indirectPackages);
-                li.addContent(aepTable.toContent());
+                li.add(aepTable.toContent());
             }
             if (display(indirectOpenPackages)) {
                 String aopText = resources.getText("doclet.Indirect_Opens_Summary");
@@ -602,10 +602,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 Table aopTable = getTable2(new StringContent(aopText), aopTableSummary,
                         HtmlStyle.packagesSummary, indirectPackagesHeader);
                 addIndirectPackages(aopTable, indirectOpenPackages);
-                li.addContent(aopTable.toContent());
+                li.add(aopTable.toContent());
             }
             HtmlTree ul = HtmlTree.UL(HtmlStyle.blockList, li);
-            summaryContentTree.addContent(ul);
+            summaryContentTree.add(ul);
         }
     }
 
@@ -899,11 +899,11 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
         if (!utils.getFullBody(mdle).isEmpty()) {
             Content tree = configuration.allowTag(HtmlTag.SECTION) ? HtmlTree.SECTION() : moduleContentTree;
             addDeprecationInfo(tree);
-            tree.addContent(HtmlConstants.START_OF_MODULE_DESCRIPTION);
-            tree.addContent(links.createAnchor(SectionName.MODULE_DESCRIPTION));
+            tree.add(HtmlConstants.START_OF_MODULE_DESCRIPTION);
+            tree.add(links.createAnchor(SectionName.MODULE_DESCRIPTION));
             addInlineComment(mdle, tree);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                moduleContentTree.addContent(tree);
+                moduleContentTree.add(tree);
             }
         }
     }
@@ -918,7 +918,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 : moduleContentTree;
         addTagsInfo(mdle, tree);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            moduleContentTree.addContent(tree);
+            moduleContentTree.add(tree);
         }
     }
 
@@ -928,10 +928,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
     @Override
     public void addModuleContent(Content contentTree, Content moduleContentTree) {
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(moduleContentTree);
-            contentTree.addContent(mainTree);
+            mainTree.add(moduleContentTree);
+            contentTree.add(mainTree);
         } else {
-            contentTree.addContent(moduleContentTree);
+            contentTree.add(moduleContentTree);
         }
     }
 
@@ -944,10 +944,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 ? HtmlTree.FOOTER()
                 : contentTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            contentTree.addContent(htmlTree);
+            contentTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -72,7 +72,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement,
             Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_NESTED_CLASS_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_NESTED_CLASS_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -163,9 +163,9 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
         }
         Content labelHeading = HtmlTree.HEADING(HtmlConstants.INHERITED_SUMMARY_HEADING,
                 label);
-        labelHeading.addContent(Contents.SPACE);
-        labelHeading.addContent(classLink);
-        inheritedTree.addContent(labelHeading);
+        labelHeading.add(Contents.SPACE);
+        labelHeading.add(classLink);
+        inheritedTree.add(labelHeading);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -93,7 +93,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.nestedClassSummary);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -130,7 +130,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(
+        memberTree.add(links.createAnchor(
                 SectionName.NESTED_CLASS_SUMMARY));
     }
 
@@ -139,7 +139,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addInheritedSummaryAnchor(TypeElement typeElement, Content inheritedTree) {
-        inheritedTree.addContent(links.createAnchor(
+        inheritedTree.add(links.createAnchor(
                 SectionName.NESTED_CLASSES_INHERITANCE,
                 utils.getFullyQualifiedName(typeElement)));
     }
@@ -177,7 +177,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
                 writer.getLink(new LinkInfoImpl(configuration, context, (TypeElement)member)));
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**
@@ -185,7 +185,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
-        linksTree.addContent(
+        linksTree.add(
                 writer.getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.MEMBER,
                         (TypeElement)member)));
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageFrameWriter.java
@@ -183,7 +183,7 @@ public class PackageFrameWriter extends HtmlDocletWriter {
                 if (!printedHeader) {
                     Content heading = HtmlTree.HEADING(HtmlConstants.CONTENT_HEADING,
                                                        true, labelContent);
-                    htmlTree.addContent(heading);
+                    htmlTree.add(heading);
                     printedHeader = true;
                 }
                 Content arr_i_name = new StringContent(utils.getSimpleName(typeElement));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageFrameWriter.java
@@ -106,13 +106,13 @@ public class PackageFrameWriter extends HtmlDocletWriter {
                 : body;
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, HtmlStyle.bar,
                 packgen.getTargetPackageLink(packageElement, "classFrame", pkgNameContent));
-        htmlTree.addContent(heading);
+        htmlTree.add(heading);
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.indexContainer);
         packgen.addClassListing(div);
-        htmlTree.addContent(div);
+        htmlTree.add(div);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         packgen.printHtmlDocument(
                 configuration.metakeywords.getMetaKeywords(packageElement), false, body);
@@ -192,11 +192,11 @@ public class PackageFrameWriter extends HtmlDocletWriter {
                 Content link = getLink(new LinkInfoImpl(configuration,
                                                         LinkInfoImpl.Kind.PACKAGE_FRAME, typeElement).label(arr_i_name).target("classFrame"));
                 Content li = HtmlTree.LI(link);
-                ul.addContent(li);
+                ul.add(li);
             }
-            htmlTree.addContent(ul);
+            htmlTree.add(ul);
             if (configuration.allowTag(HtmlTag.SECTION)) {
-                contentTree.addContent(htmlTree);
+                contentTree.add(htmlTree);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexFrameWriter.java
@@ -88,11 +88,11 @@ public class PackageIndexFrameWriter extends AbstractPackageIndexWriter {
             // package is marked as deprecated.
             if (aPackage != null &&
                 (!(configuration.nodeprecated && utils.isDeprecated(aPackage)))) {
-                ul.addContent(getPackage(aPackage));
+                ul.add(getPackage(aPackage));
             }
         }
-        htmlTree.addContent(ul);
-        main.addContent(htmlTree);
+        htmlTree.add(ul);
+        main.add(htmlTree);
     }
 
     /**
@@ -152,7 +152,7 @@ public class PackageIndexFrameWriter extends AbstractPackageIndexWriter {
         Content linkContent = links.createLink(DocPaths.ALLCLASSES_FRAME,
                 contents.allClassesLabel, "", "packageFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -166,7 +166,7 @@ public class PackageIndexFrameWriter extends AbstractPackageIndexWriter {
         Content linkContent = links.createLink(DocPaths.MODULE_OVERVIEW_FRAME,
                 contents.allModulesLabel, "", "packageListFrame");
         Content li = HtmlTree.LI(linkContent);
-        ul.addContent(li);
+        ul.add(li);
     }
 
     /**
@@ -175,6 +175,6 @@ public class PackageIndexFrameWriter extends AbstractPackageIndexWriter {
     @Override
     protected void addNavigationBarFooter(Content footer) {
         Content p = HtmlTree.P(Contents.SPACE);
-        footer.addContent(p);
+        footer.add(p);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexFrameWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexFrameWriter.java
@@ -131,7 +131,7 @@ public class PackageIndexFrameWriter extends AbstractPackageIndexWriter {
         }
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.bar, headerContent);
-        header.addContent(heading);
+        header.add(heading);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexWriter.java
@@ -132,7 +132,7 @@ public class PackageIndexWriter extends AbstractPackageIndexWriter {
             }
 
             Content div = HtmlTree.DIV(HtmlStyle.contentContainer, table.toContent());
-            main.addContent(div);
+            main.add(div);
 
             if (table.needsScript()) {
                 getMainBodyScript().append(table.getScript());
@@ -154,7 +154,7 @@ public class PackageIndexWriter extends AbstractPackageIndexWriter {
             HtmlTree div = new HtmlTree(HtmlTag.DIV);
             div.setStyle(HtmlStyle.contentContainer);
             addOverviewComment(div);
-            main.addContent(div);
+            main.add(div);
         }
     }
 
@@ -182,7 +182,7 @@ public class PackageIndexWriter extends AbstractPackageIndexWriter {
     protected void addNavigationBarHeader(Content header) {
         addTop(header);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        header.addContent(navBar.getContent(true));
+        header.add(navBar.getContent(true));
     }
 
     /**
@@ -194,7 +194,7 @@ public class PackageIndexWriter extends AbstractPackageIndexWriter {
     @Override
     protected void addNavigationBarFooter(Content footer) {
         navBar.setUserFooter(getUserHeaderFooter(false));
-        footer.addContent(navBar.getContent(false));
+        footer.add(navBar.getContent(false));
         addBottom(footer);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageTreeWriter.java
@@ -109,25 +109,25 @@ public class PackageTreeWriter extends AbstractTreeWriter {
         if (configuration.packages.size() > 1) {
             addLinkToMainTree(div);
         }
-        htmlTree.addContent(div);
+        htmlTree.add(div);
         HtmlTree divTree = new HtmlTree(HtmlTag.DIV);
         divTree.setStyle(HtmlStyle.contentContainer);
         addTree(classtree.baseClasses(), "doclet.Class_Hierarchy", divTree);
         addTree(classtree.baseInterfaces(), "doclet.Interface_Hierarchy", divTree);
         addTree(classtree.baseAnnotationTypes(), "doclet.Annotation_Type_Hierarchy", divTree);
         addTree(classtree.baseEnums(), "doclet.Enum_Hierarchy", divTree, true);
-        htmlTree.addContent(divTree);
+        htmlTree.add(divTree);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         HtmlTree tree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : body;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        tree.addContent(navBar.getContent(false));
+        tree.add(navBar.getContent(false));
         addBottom(tree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(tree);
+            body.add(tree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -149,9 +149,9 @@ public class PackageTreeWriter extends AbstractTreeWriter {
                 contents.moduleLabel);
         navBar.setNavLinkModule(linkContent);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         return bodyTree;
     }
@@ -164,10 +164,10 @@ public class PackageTreeWriter extends AbstractTreeWriter {
     protected void addLinkToMainTree(Content div) {
         Content span = HtmlTree.SPAN(HtmlStyle.packageHierarchyLabel,
                 contents.packageHierarchies);
-        div.addContent(span);
+        div.add(span);
         HtmlTree ul = new HtmlTree (HtmlTag.UL);
         ul.setStyle(HtmlStyle.horizontal);
-        ul.addContent(getNavLinkMainTree(configuration.getText("doclet.All_Packages")));
-        div.addContent(ul);
+        ul.add(getNavLinkMainTree(configuration.getText("doclet.All_Packages")));
+        div.add(ul);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
@@ -130,24 +130,24 @@ public class PackageUseWriter extends SubWriterHolderWriter {
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.contentContainer);
         if (usingPackageToUsedClasses.isEmpty()) {
-            div.addContent(contents.getContent("doclet.ClassUse_No.usage.of.0", utils.getPackageName(packageElement)));
+            div.add(contents.getContent("doclet.ClassUse_No.usage.of.0", utils.getPackageName(packageElement)));
         } else {
             addPackageUse(div);
         }
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
-            body.addContent(mainTree);
+            mainTree.add(div);
+            body.add(mainTree);
         } else {
-            body.addContent(div);
+            body.add(div);
         }
         HtmlTree tree = (configuration.allowTag(HtmlTag.FOOTER))
                 ? HtmlTree.FOOTER()
                 : body;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        tree.addContent(navBar.getContent(false));
+        tree.add(navBar.getContent(false));
         addBottom(tree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(tree);
+            body.add(tree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -210,7 +210,7 @@ public class PackageUseWriter extends SubWriterHolderWriter {
             HtmlTree li = new HtmlTree(HtmlTag.LI);
             li.setStyle(HtmlStyle.blockList);
             if (usingPackage != null) {
-                li.addContent(links.createAnchor(utils.getPackageName(usingPackage)));
+                li.add(links.createAnchor(utils.getPackageName(usingPackage)));
             }
             String tableSummary = resources.getText("doclet.Use_Table_Summary",
                                                         resources.getText("doclet.classes"));
@@ -257,21 +257,21 @@ public class PackageUseWriter extends SubWriterHolderWriter {
                 contents.moduleLabel);
         navBar.setNavLinkModule(linkContent);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         ContentBuilder headContent = new ContentBuilder();
-        headContent.addContent(contents.getContent("doclet.ClassUse_Title", packageText));
-        headContent.addContent(new HtmlTree(HtmlTag.BR));
-        headContent.addContent(name);
+        headContent.add(contents.getContent("doclet.ClassUse_Title", packageText));
+        headContent.add(new HtmlTree(HtmlTag.BR));
+        headContent.add(name);
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.title, headContent);
         Content div = HtmlTree.DIV(HtmlStyle.header, heading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
@@ -164,7 +164,7 @@ public class PackageUseWriter extends SubWriterHolderWriter {
             addPackageList(ul);
         }
         addClassList(ul);
-        contentTree.addContent(ul);
+        contentTree.add(ul);
     }
 
     /**
@@ -189,12 +189,12 @@ public class PackageUseWriter extends SubWriterHolderWriter {
             if (pkg != null && !pkg.isUnnamed()) {
                 addSummaryComment(pkg, summary);
             } else {
-                summary.addContent(Contents.SPACE);
+                summary.add(Contents.SPACE);
             }
             table.addRow(packageLink, summary);
         }
         Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-        contentTree.addContent(li);
+        contentTree.add(li);
     }
 
     /**
@@ -234,8 +234,8 @@ public class PackageUseWriter extends SubWriterHolderWriter {
 
                 table.addRow(typeContent, summary);
             }
-            li.addContent(table.toContent());
-            contentTree.addContent(li);
+            li.add(table.toContent());
+            contentTree.add(li);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -115,9 +115,9 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 contents.moduleLabel);
         navBar.setNavLinkModule(linkContent);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         HtmlTree div = new HtmlTree(HtmlTag.DIV);
         div.setStyle(HtmlStyle.header);
@@ -125,24 +125,24 @@ public class PackageWriterImpl extends HtmlDocletWriter
             ModuleElement mdle = configuration.docEnv.getElementUtils().getModuleOf(packageElement);
             Content classModuleLabel = HtmlTree.SPAN(HtmlStyle.moduleLabelInPackage, contents.moduleLabel);
             Content moduleNameDiv = HtmlTree.DIV(HtmlStyle.subTitle, classModuleLabel);
-            moduleNameDiv.addContent(Contents.SPACE);
-            moduleNameDiv.addContent(getModuleLink(mdle,
+            moduleNameDiv.add(Contents.SPACE);
+            moduleNameDiv.add(getModuleLink(mdle,
                     new StringContent(mdle.getQualifiedName().toString())));
-            div.addContent(moduleNameDiv);
+            div.add(moduleNameDiv);
         }
         Content annotationContent = new HtmlTree(HtmlTag.P);
         addAnnotationInfo(packageElement, annotationContent);
-        div.addContent(annotationContent);
+        div.add(annotationContent);
         Content tHeading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.title, contents.packageLabel);
-        tHeading.addContent(Contents.SPACE);
+        tHeading.add(Contents.SPACE);
         Content packageHead = new StringContent(heading);
-        tHeading.addContent(packageHead);
-        div.addContent(tHeading);
+        tHeading.add(packageHead);
+        div.add(tHeading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }
@@ -289,7 +289,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
     public void addPackageDescription(Content packageContentTree) {
         if (!utils.getBody(packageElement).isEmpty()) {
             Content tree = configuration.allowTag(HtmlTag.SECTION) ? sectionTree : packageContentTree;
-            tree.addContent(links.createAnchor(SectionName.PACKAGE_DESCRIPTION));
+            tree.add(links.createAnchor(SectionName.PACKAGE_DESCRIPTION));
             addDeprecationInfo(tree);
             addInlineComment(packageElement, tree);
         }
@@ -305,7 +305,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 : packageContentTree;
         addTagsInfo(packageElement, htmlTree);
         if (configuration.allowTag(HtmlTag.SECTION)) {
-            packageContentTree.addContent(sectionTree);
+            packageContentTree.add(sectionTree);
         }
     }
 
@@ -315,10 +315,10 @@ public class PackageWriterImpl extends HtmlDocletWriter
     @Override
     public void addPackageContent(Content contentTree, Content packageContentTree) {
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(packageContentTree);
-            contentTree.addContent(mainTree);
+            mainTree.add(packageContentTree);
+            contentTree.add(mainTree);
         } else {
-            contentTree.addContent(packageContentTree);
+            contentTree.add(packageContentTree);
         }
     }
 
@@ -331,10 +331,10 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 ? HtmlTree.FOOTER()
                 : contentTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            contentTree.addContent(htmlTree);
+            contentTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -169,14 +169,14 @@ public class PackageWriterImpl extends HtmlDocletWriter
             HtmlTree deprDiv = new HtmlTree(HtmlTag.DIV);
             deprDiv.setStyle(HtmlStyle.deprecationBlock);
             Content deprPhrase = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(packageElement));
-            deprDiv.addContent(deprPhrase);
+            deprDiv.add(deprPhrase);
             if (!deprs.isEmpty()) {
                 List<? extends DocTree> commentTags = ch.getDescription(configuration, deprs.get(0));
                 if (!commentTags.isEmpty()) {
                     addInlineDeprecatedComment(packageElement, deprs.get(0), deprDiv);
                 }
             }
-            div.addContent(deprDiv);
+            div.add(deprDiv);
         }
     }
 
@@ -267,7 +267,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
                         configuration, LinkInfoImpl.Kind.PACKAGE, klass));
                 ContentBuilder description = new ContentBuilder();
                 if (utils.isDeprecated(klass)) {
-                    description.addContent(getDeprecatedPhrase(klass));
+                    description.add(getDeprecatedPhrase(klass));
                     List<? extends DocTree> tags = utils.getDeprecatedTrees(klass);
                     if (!tags.isEmpty()) {
                         addSummaryDeprecatedComment(klass, tags.get(0), description);
@@ -278,7 +278,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 table.addRow(classLink, description);
             }
             Content li = HtmlTree.LI(HtmlStyle.blockList, table.toContent());
-            summaryContentTree.addContent(li);
+            summaryContentTree.add(li);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -122,8 +122,8 @@ public class PropertyWriterImpl extends AbstractMemberWriter
         Content propertylink = writer.getLink(new LinkInfoImpl(
                 configuration, LinkInfoImpl.Kind.MEMBER,
                 utils.getReturnType(property)));
-        pre.addContent(propertylink);
-        pre.addContent(" ");
+        pre.add(propertylink);
+        pre.add(" ");
         if (configuration.linksource) {
             Content propertyName = new StringContent(name(property));
             writer.addSrcLink(property, propertyName, pre);
@@ -162,9 +162,9 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                         utils.isClass(holder)
                                 ? contents.descfrmClassLabel
                                 : contents.descfrmInterfaceLabel);
-                descfrmLabel.addContent(Contents.SPACE);
-                descfrmLabel.addContent(codeLink);
-                propertyDocTree.addContent(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
+                descfrmLabel.add(Contents.SPACE);
+                descfrmLabel.add(codeLink);
+                propertyDocTree.add(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
                 writer.addInlineComment(property, propertyDocTree);
             }
         }
@@ -206,7 +206,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     public void addSummaryLabel(Content memberTree) {
         Content label = HtmlTree.HEADING(HtmlConstants.SUMMARY_HEADING,
                 contents.propertySummaryLabel);
-        memberTree.addContent(label);
+        memberTree.add(label);
     }
 
     /**
@@ -241,7 +241,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addSummaryAnchor(TypeElement typeElement, Content memberTree) {
-        memberTree.addContent(links.createAnchor(SectionName.PROPERTY_SUMMARY));
+        memberTree.add(links.createAnchor(SectionName.PROPERTY_SUMMARY));
     }
 
     /**
@@ -249,7 +249,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
      */
     @Override
     public void addInheritedSummaryAnchor(TypeElement typeElement, Content inheritedTree) {
-        inheritedTree.addContent(links.createAnchor(
+        inheritedTree.add(links.createAnchor(
                 SectionName.PROPERTIES_INHERITANCE,
                 configuration.getClassName(typeElement)));
     }
@@ -273,9 +273,9 @@ public class PropertyWriterImpl extends AbstractMemberWriter
         }
         Content labelHeading = HtmlTree.HEADING(HtmlConstants.INHERITED_SUMMARY_HEADING,
                 label);
-        labelHeading.addContent(Contents.SPACE);
-        labelHeading.addContent(classLink);
-        inheritedTree.addContent(labelHeading);
+        labelHeading.add(Contents.SPACE);
+        labelHeading.add(classLink);
+        inheritedTree.add(labelHeading);
     }
 
     /**
@@ -292,7 +292,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                 true));
 
         Content code = HtmlTree.CODE(memberLink);
-        tdSummary.addContent(code);
+        tdSummary.add(code);
     }
 
     /**
@@ -304,7 +304,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
         Content content = writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member,
                 utils.isProperty(mname) ? utils.getPropertyName(mname) : mname,
                 false, true);
-        linksTree.addContent(content);
+        linksTree.add(content);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -68,7 +68,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
      */
     @Override
     public Content getMemberSummaryHeader(TypeElement typeElement, Content memberSummaryTree) {
-        memberSummaryTree.addContent(HtmlConstants.START_OF_PROPERTY_SUMMARY);
+        memberSummaryTree.add(HtmlConstants.START_OF_PROPERTY_SUMMARY);
         Content memberTree = writer.getMemberTreeHeader();
         writer.addSummaryHeader(this, typeElement, memberTree);
         return memberTree;
@@ -88,12 +88,12 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     public Content getPropertyDetailsTreeHeader(TypeElement typeElement,
             Content memberDetailsTree) {
-        memberDetailsTree.addContent(HtmlConstants.START_OF_PROPERTY_DETAILS);
+        memberDetailsTree.add(HtmlConstants.START_OF_PROPERTY_DETAILS);
         Content propertyDetailsTree = writer.getMemberTreeHeader();
-        propertyDetailsTree.addContent(links.createAnchor(SectionName.PROPERTY_DETAIL));
+        propertyDetailsTree.add(links.createAnchor(SectionName.PROPERTY_DETAIL));
         Content heading = HtmlTree.HEADING(HtmlConstants.DETAILS_HEADING,
                 contents.propertyDetailsLabel);
-        propertyDetailsTree.addContent(heading);
+        propertyDetailsTree.add(heading);
         return propertyDetailsTree;
     }
 
@@ -103,11 +103,11 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     public Content getPropertyDocTreeHeader(ExecutableElement property,
             Content propertyDetailsTree) {
-        propertyDetailsTree.addContent(links.createAnchor(name(property)));
+        propertyDetailsTree.add(links.createAnchor(name(property)));
         Content propertyDocTree = writer.getMemberTreeHeader();
         Content heading = new HtmlTree(HtmlConstants.MEMBER_HEADING);
-        heading.addContent(utils.getPropertyLabel(name(property)));
-        propertyDocTree.addContent(heading);
+        heading.add(utils.getPropertyLabel(name(property)));
+        propertyDocTree.add(heading);
         return propertyDocTree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -137,8 +137,8 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
     public Content getPackageHeader(String packageName) {
         Content heading = HtmlTree.HEADING(HtmlConstants.PACKAGE_HEADING, true,
                 contents.packageLabel);
-        heading.addContent(Contents.SPACE);
-        heading.addContent(packageName);
+        heading.add(Contents.SPACE);
+        heading.add(packageName);
         return heading;
     }
 
@@ -215,9 +215,9 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
     public void addSerialUIDInfo(String header, String serialUID,
             Content serialUidTree) {
         Content headerContent = new StringContent(header);
-        serialUidTree.addContent(HtmlTree.DT(headerContent));
+        serialUidTree.add(HtmlTree.DT(headerContent));
         Content serialContent = new StringContent(serialUID);
-        serialUidTree.addContent(HtmlTree.DD(serialContent));
+        serialUidTree.add(HtmlTree.DD(serialContent));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -85,18 +85,18 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         Content h1Content = new StringContent(header);
         Content heading = HtmlTree.HEADING(HtmlConstants.TITLE_HEADING, true,
                 HtmlStyle.title, h1Content);
         Content div = HtmlTree.DIV(HtmlStyle.header, heading);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(div);
+            mainTree.add(div);
         } else {
-            bodyTree.addContent(div);
+            bodyTree.add(div);
         }
         return bodyTree;
     }
@@ -188,7 +188,7 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
             configuration.getContent(
             "doclet.Class_0_extends_implements_serializable", classLink,
             superClassLink);
-        li.addContent(HtmlTree.HEADING(HtmlConstants.SERIALIZED_MEMBER_HEADING,
+        li.add(HtmlTree.HEADING(HtmlConstants.SERIALIZED_MEMBER_HEADING,
                 className));
         return li;
     }
@@ -241,7 +241,7 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
         HtmlTree divContent = HtmlTree.DIV(HtmlStyle.serializedFormContainer,
                 serializedTreeContent);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(divContent);
+            mainTree.add(divContent);
             return mainTree;
         } else {
             return divContent;
@@ -253,7 +253,7 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
      */
     public void addPackageSerializedTree(Content serializedSummariesTree,
             Content packageSerializedTree) {
-        serializedSummariesTree.addContent((configuration.allowTag(HtmlTag.SECTION))
+        serializedSummariesTree.add((configuration.allowTag(HtmlTag.SECTION))
                 ? HtmlTree.LI(HtmlStyle.blockList, packageSerializedTree)
                 : packageSerializedTree);
     }
@@ -268,10 +268,10 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
                 ? HtmlTree.FOOTER()
                 : serializedTree;
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            serializedTree.addContent(htmlTree);
+            serializedTree.add(htmlTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SingleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SingleIndexWriter.java
@@ -98,9 +98,9 @@ public class SingleIndexWriter extends AbstractIndexWriter {
                 : body;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         HtmlTree divTree = new HtmlTree(HtmlTag.DIV);
         divTree.setStyle(HtmlStyle.contentContainer);
@@ -118,17 +118,17 @@ public class SingleIndexWriter extends AbstractIndexWriter {
             }
         }
         addLinksForIndexes(divTree);
-        body.addContent((configuration.allowTag(HtmlTag.MAIN))
+        body.add((configuration.allowTag(HtmlTag.MAIN))
                 ? HtmlTree.MAIN(divTree)
                 : divTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
             htmlTree = HtmlTree.FOOTER();
         }
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         createSearchIndexFiles();
         printHtmlDocument(null, true, body);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SingleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SingleIndexWriter.java
@@ -142,17 +142,17 @@ public class SingleIndexWriter extends AbstractIndexWriter {
     protected void addLinksForIndexes(Content contentTree) {
         for (Object ch : elements) {
             String unicode = ch.toString();
-            contentTree.addContent(
+            contentTree.add(
                     links.createLink(getNameForIndex(unicode),
                             new StringContent(unicode)));
-            contentTree.addContent(Contents.SPACE);
+            contentTree.add(Contents.SPACE);
         }
-        contentTree.addContent(new HtmlTree(HtmlTag.BR));
-        contentTree.addContent(links.createLink(DocPaths.ALLCLASSES_INDEX,
+        contentTree.add(new HtmlTree(HtmlTag.BR));
+        contentTree.add(links.createLink(DocPaths.ALLCLASSES_INDEX,
                 contents.allClassesLabel));
         if (!configuration.packages.isEmpty()) {
-            contentTree.addContent(Contents.SPACE);
-            contentTree.addContent(links.createLink(DocPaths.ALLPACKAGES_INDEX,
+            contentTree.add(Contents.SPACE);
+            contentTree.add(links.createLink(DocPaths.ALLPACKAGES_INDEX,
                     contents.allPackagesLabel));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
@@ -240,7 +240,7 @@ public class SourceToHTMLConverter {
         }
         DocPath p = relativePath.resolve(stylesheet);
         HtmlTree link = HtmlTree.LINK("stylesheet", "text/css", p.getPath(), "Style");
-        head.addContent(link);
+        head.add(link);
         addStylesheets(head);
     }
 
@@ -252,7 +252,7 @@ public class SourceToHTMLConverter {
                 DocPath ssheetPath = DocPath.create(file.getName());
                 HtmlTree slink = HtmlTree.LINK("stylesheet", "text/css", relativePath.resolve(ssheetPath).getPath(),
                         "Style");
-                tree.addContent(slink);
+                tree.add(slink);
             });
         }
     }
@@ -276,13 +276,13 @@ public class SourceToHTMLConverter {
         HtmlTree span = new HtmlTree(HtmlTag.SPAN);
         span.setStyle(HtmlStyle.sourceLineNo);
         if (lineno < 10) {
-            span.addContent("00" + Integer.toString(lineno));
+            span.add("00" + Integer.toString(lineno));
         } else if (lineno < 100) {
-            span.addContent("0" + Integer.toString(lineno));
+            span.add("0" + Integer.toString(lineno));
         } else {
-            span.addContent(Integer.toString(lineno));
+            span.add(Integer.toString(lineno));
         }
-        pre.addContent(span);
+        pre.add(span);
     }
 
     /**
@@ -297,8 +297,8 @@ public class SourceToHTMLConverter {
             Content anchor = HtmlTree.A(configuration.htmlVersion,
                     "line." + Integer.toString(currentLineNo),
                     new StringContent(utils.replaceTabs(line)));
-            pre.addContent(anchor);
-            pre.addContent(NEW_LINE);
+            pre.add(anchor);
+            pre.add(NEW_LINE);
         }
     }
 
@@ -309,7 +309,7 @@ public class SourceToHTMLConverter {
      */
     private static void addBlankLines(Content pre) {
         for (int i = 0; i < NUM_BLANK_LINES; i++) {
-            pre.addContent(NEW_LINE);
+            pre.add(NEW_LINE);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
@@ -195,7 +195,7 @@ public class SourceToHTMLConverter {
             }
             addBlankLines(pre);
             Content div = HtmlTree.DIV(HtmlStyle.sourceContainer, pre);
-            body.addContent((configuration.allowTag(HtmlTag.MAIN)) ? HtmlTree.MAIN(div) : div);
+            body.add((configuration.allowTag(HtmlTag.MAIN)) ? HtmlTree.MAIN(div) : div);
             writeToFile(body, outputdir.resolve(configuration.docPaths.forClass(te)));
         } catch (IOException e) {
             String message = resources.getText("doclet.exception.read.file", fo.getName());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SplitIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SplitIndexWriter.java
@@ -163,16 +163,16 @@ public class SplitIndexWriter extends AbstractIndexWriter {
     protected void addLinksForIndexes(Content contentTree) {
         for (int i = 0; i < indexElements.size(); i++) {
             int j = i + 1;
-            contentTree.addContent(links.createLink(DocPaths.indexN(j),
+            contentTree.add(links.createLink(DocPaths.indexN(j),
                     new StringContent(indexElements.get(i).toString())));
-            contentTree.addContent(Contents.SPACE);
+            contentTree.add(Contents.SPACE);
         }
-        contentTree.addContent(new HtmlTree(HtmlTag.BR));
-        contentTree.addContent(links.createLink(pathToRoot.resolve(DocPaths.ALLCLASSES_INDEX),
+        contentTree.add(new HtmlTree(HtmlTag.BR));
+        contentTree.add(links.createLink(pathToRoot.resolve(DocPaths.ALLCLASSES_INDEX),
                 contents.allClassesLabel));
         if (!configuration.packages.isEmpty()) {
-            contentTree.addContent(Contents.SPACE);
-            contentTree.addContent(links.createLink(pathToRoot.resolve(DocPaths.ALLPACKAGES_INDEX),
+            contentTree.add(Contents.SPACE);
+            contentTree.add(links.createLink(pathToRoot.resolve(DocPaths.ALLPACKAGES_INDEX),
                     contents.allPackagesLabel));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SplitIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SplitIndexWriter.java
@@ -126,9 +126,9 @@ public class SplitIndexWriter extends AbstractIndexWriter {
                 : body;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         HtmlTree divTree = new HtmlTree(HtmlTag.DIV);
         divTree.setStyle(HtmlStyle.contentContainer);
@@ -142,15 +142,15 @@ public class SplitIndexWriter extends AbstractIndexWriter {
                     configuration.tagSearchIndexMap.get(unicode), divTree);
         }
         addLinksForIndexes(divTree);
-        body.addContent((configuration.allowTag(HtmlTag.MAIN)) ? HtmlTree.MAIN(divTree) : divTree);
+        body.add((configuration.allowTag(HtmlTag.MAIN)) ? HtmlTree.MAIN(divTree) : divTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
             htmlTree = HtmlTree.FOOTER();
         }
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         printHtmlDocument(null, true, body);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
@@ -196,10 +196,10 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
      */
     public void addClassContentTree(Content contentTree, Content classContentTree) {
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            mainTree.addContent(classContentTree);
-            contentTree.addContent(mainTree);
+            mainTree.add(classContentTree);
+            contentTree.add(mainTree);
         } else {
-            contentTree.addContent(classContentTree);
+            contentTree.add(classContentTree);
         }
     }
 
@@ -233,9 +233,9 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
     public void addMemberTree(Content memberSummaryTree, Content memberTree) {
         if (configuration.allowTag(HtmlTag.SECTION)) {
             HtmlTree htmlTree = HtmlTree.SECTION(getMemberTree(memberTree));
-            memberSummaryTree.addContent(htmlTree);
+            memberSummaryTree.add(htmlTree);
         } else {
-            memberSummaryTree.addContent(getMemberTree(memberTree));
+            memberSummaryTree.add(getMemberTree(memberTree));
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,14 +122,14 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
             if (!deprs.isEmpty()) {
                 addSummaryDeprecatedComment(member, deprs.get(0), div);
             }
-            tdSummary.addContent(div);
+            tdSummary.add(div);
             return;
         } else {
             Element te = member.getEnclosingElement();
             if (te != null &&  utils.isTypeElement(te) && utils.isDeprecated(te)) {
                 Content deprLabel = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(te));
                 div = HtmlTree.DIV(HtmlStyle.block, deprLabel);
-                tdSummary.addContent(div);
+                tdSummary.add(div);
             }
         }
         addSummaryComment(member, firstSentenceTags, tdSummary);
@@ -172,7 +172,7 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
     public void addInheritedMemberSummary(AbstractMemberWriter mw, TypeElement typeElement,
             Element member, boolean isFirst, Content linksTree) {
         if (! isFirst) {
-            linksTree.addContent(", ");
+            linksTree.add(", ");
         }
         mw.addInheritedSummaryLink(typeElement, member, linksTree);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -28,6 +28,8 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.List;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
@@ -231,10 +233,10 @@ public class TagletWriterImpl extends TagletWriter {
     public Content paramTagOutput(Element element, DocTree paramTag, String paramName) {
         ContentBuilder body = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
-        body.addContent(HtmlTree.CODE(new RawHtml(paramName)));
-        body.addContent(" - ");
+        body.add(HtmlTree.CODE(new RawHtml(paramName)));
+        body.add(" - ");
         List<? extends DocTree> description = ch.getDescription(configuration, paramTag);
-        body.addContent(htmlWriter.commentTagsToContent(paramTag, element, description, false));
+        body.add(htmlWriter.commentTagsToContent(paramTag, element, description, false));
         HtmlTree result = HtmlTree.DD(body);
         return result;
     }
@@ -259,9 +261,9 @@ public class TagletWriterImpl extends TagletWriter {
     public Content returnTagOutput(Element element, DocTree returnTag) {
         ContentBuilder result = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
-        result.addContent(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.returnLabel,
+        result.add(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.returnLabel,
                 new StringContent(configuration.getText("doclet.Returns")))));
-        result.addContent(HtmlTree.DD(htmlWriter.commentTagsToContent(
+        result.add(HtmlTree.DD(htmlWriter.commentTagsToContent(
                 returnTag, element, ch.getDescription(configuration, returnTag), false)));
         return result;
     }
@@ -285,7 +287,7 @@ public class TagletWriterImpl extends TagletWriter {
                     ((ClassWriterImpl) htmlWriter).getTypeElement().getQualifiedName() + "." +
                     utils.getSimpleName(holder);
             DocLink link = constantsPath.fragment(whichConstant);
-            body.addContent(htmlWriter.links.createLink(link,
+            body.add(htmlWriter.links.createLink(link,
                     new StringContent(configuration.getText("doclet.Constants_Summary"))));
         }
         if (utils.isClass(holder) && utils.isSerializable((TypeElement)holder)) {
@@ -295,7 +297,7 @@ public class TagletWriterImpl extends TagletWriter {
                 appendSeparatorIfNotEmpty(body);
                 DocPath serialPath = htmlWriter.pathToRoot.resolve(DocPaths.SERIALIZED_FORM);
                 DocLink link = serialPath.fragment(utils.getFullyQualifiedName(holder));
-                body.addContent(htmlWriter.links.createLink(link,
+                body.add(htmlWriter.links.createLink(link,
                         new StringContent(configuration.getText("doclet.Serialized_Form"))));
             }
         }
@@ -303,17 +305,17 @@ public class TagletWriterImpl extends TagletWriter {
             return body;
 
         ContentBuilder result = new ContentBuilder();
-        result.addContent(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.seeLabel,
+        result.add(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.seeLabel,
                 new StringContent(configuration.getText("doclet.See_Also")))));
-        result.addContent(HtmlTree.DD(body));
+        result.add(HtmlTree.DD(body));
         return result;
 
     }
 
     private void appendSeparatorIfNotEmpty(ContentBuilder body) {
         if (!body.isEmpty()) {
-            body.addContent(", ");
-            body.addContent(DocletConstants.NL);
+            body.add(", ");
+            body.add(DocletConstants.NL);
         }
     }
 
@@ -323,18 +325,18 @@ public class TagletWriterImpl extends TagletWriter {
     public Content simpleTagOutput(Element element, List<? extends DocTree> simpleTags, String header) {
         CommentHelper ch = utils.getCommentHelper(element);
         ContentBuilder result = new ContentBuilder();
-        result.addContent(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.simpleTagLabel, new RawHtml(header))));
+        result.add(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.simpleTagLabel, new RawHtml(header))));
         ContentBuilder body = new ContentBuilder();
         boolean many = false;
         for (DocTree simpleTag : simpleTags) {
             if (many) {
-                body.addContent(", ");
+                body.add(", ");
             }
             List<? extends DocTree> bodyTags = ch.getBody(configuration, simpleTag);
-            body.addContent(htmlWriter.commentTagsToContent(simpleTag, element, bodyTags, false));
+            body.add(htmlWriter.commentTagsToContent(simpleTag, element, bodyTags, false));
             many = true;
         }
-        result.addContent(HtmlTree.DD(body));
+        result.add(HtmlTree.DD(body));
         return result;
     }
 
@@ -343,11 +345,11 @@ public class TagletWriterImpl extends TagletWriter {
      */
     public Content simpleTagOutput(Element element, DocTree simpleTag, String header) {
         ContentBuilder result = new ContentBuilder();
-        result.addContent(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.simpleTagLabel, new RawHtml(header))));
+        result.add(HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.simpleTagLabel, new RawHtml(header))));
         CommentHelper ch = utils.getCommentHelper(element);
         List<? extends DocTree> description = ch.getDescription(configuration, simpleTag);
         Content body = htmlWriter.commentTagsToContent(simpleTag, element, description, false);
-        result.addContent(HtmlTree.DD(body));
+        result.add(HtmlTree.DD(body));
         return result;
     }
 
@@ -378,12 +380,12 @@ public class TagletWriterImpl extends TagletWriter {
             link.excludeTypeBounds = true;
             excName = htmlWriter.getLink(link);
         }
-        body.addContent(HtmlTree.CODE(excName));
+        body.add(HtmlTree.CODE(excName));
         List<? extends DocTree> description = ch.getDescription(configuration, throwsTag);
         Content desc = htmlWriter.commentTagsToContent(throwsTag, element, description, false);
         if (desc != null && !desc.isEmpty()) {
-            body.addContent(" - ");
-            body.addContent(desc);
+            body.add(" - ");
+            body.add(desc);
         }
         HtmlTree result = HtmlTree.DD(body);
         return result;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.List;
 
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ModuleElement;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
@@ -179,29 +177,29 @@ public class TagletWriterImpl extends TagletWriter {
         List<? extends DocTree> deprs = utils.getBlockTags(element, DocTree.Kind.DEPRECATED);
         if (utils.isTypeElement(element)) {
             if (utils.isDeprecated(element)) {
-                result.addContent(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
+                result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
                         htmlWriter.getDeprecatedPhrase(element)));
                 if (!deprs.isEmpty()) {
                     List<? extends DocTree> commentTags = ch.getDescription(configuration, deprs.get(0));
                     if (!commentTags.isEmpty()) {
-                        result.addContent(commentTagsToOutput(null, element, commentTags, false));
+                        result.add(commentTagsToOutput(null, element, commentTags, false));
                     }
                 }
             }
         } else {
             if (utils.isDeprecated(element)) {
-                result.addContent(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
+                result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
                         htmlWriter.getDeprecatedPhrase(element)));
                 if (!deprs.isEmpty()) {
                     List<? extends DocTree> bodyTags = ch.getBody(configuration, deprs.get(0));
                     Content body = commentTagsToOutput(null, element, bodyTags, false);
                     if (!body.isEmpty())
-                        result.addContent(HtmlTree.DIV(HtmlStyle.deprecationComment, body));
+                        result.add(HtmlTree.DIV(HtmlStyle.deprecationComment, body));
                 }
             } else {
                 Element ee = utils.getEnclosingTypeElement(element);
                 if (utils.isDeprecated(ee)) {
-                    result.addContent(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
+                    result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
                         htmlWriter.getDeprecatedPhrase(ee)));
                 }
             }
@@ -247,10 +245,10 @@ public class TagletWriterImpl extends TagletWriter {
     public Content propertyTagOutput(Element element, DocTree tag, String prefix) {
         Content body = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
-        body.addContent(new RawHtml(prefix));
-        body.addContent(" ");
-        body.addContent(HtmlTree.CODE(new RawHtml(ch.getText(tag))));
-        body.addContent(".");
+        body.add(new RawHtml(prefix));
+        body.add(" ");
+        body.add(HtmlTree.CODE(new RawHtml(ch.getText(tag))));
+        body.add(".");
         Content result = HtmlTree.P(body);
         return result;
     }
@@ -275,7 +273,7 @@ public class TagletWriterImpl extends TagletWriter {
         ContentBuilder body = new ContentBuilder();
         for (DocTree dt : seeTags) {
             appendSeparatorIfNotEmpty(body);
-            body.addContent(htmlWriter.seeTagToContent(holder, dt));
+            body.add(htmlWriter.seeTagToContent(holder, dt));
         }
         if (utils.isVariableElement(holder) && ((VariableElement)holder).getConstantValue() != null &&
                 htmlWriter instanceof ClassWriterImpl) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TreeWriter.java
@@ -115,16 +115,16 @@ public class TreeWriter extends AbstractTreeWriter {
         HtmlTree htmlTree = (configuration.allowTag(HtmlTag.MAIN))
                 ? HtmlTree.MAIN()
                 : body;
-        htmlTree.addContent(div);
+        htmlTree.add(div);
         HtmlTree divTree = new HtmlTree(HtmlTag.DIV);
         divTree.setStyle(HtmlStyle.contentContainer);
         addTree(classtree.baseClasses(), "doclet.Class_Hierarchy", divTree);
         addTree(classtree.baseInterfaces(), "doclet.Interface_Hierarchy", divTree);
         addTree(classtree.baseAnnotationTypes(), "doclet.Annotation_Type_Hierarchy", divTree);
         addTree(classtree.baseEnums(), "doclet.Enum_Hierarchy", divTree, true);
-        htmlTree.addContent(divTree);
+        htmlTree.add(divTree);
         if (configuration.allowTag(HtmlTag.MAIN)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         if (configuration.allowTag(HtmlTag.FOOTER)) {
             htmlTree = HtmlTree.FOOTER();
@@ -132,10 +132,10 @@ public class TreeWriter extends AbstractTreeWriter {
             htmlTree = body;
         }
         navBar.setUserFooter(getUserHeaderFooter(false));
-        htmlTree.addContent(navBar.getContent(false));
+        htmlTree.add(navBar.getContent(false));
         addBottom(htmlTree);
         if (configuration.allowTag(HtmlTag.FOOTER)) {
-            body.addContent(htmlTree);
+            body.add(htmlTree);
         }
         printHtmlDocument(null, true, body);
     }
@@ -192,9 +192,9 @@ public class TreeWriter extends AbstractTreeWriter {
                 : bodyTree;
         addTop(htmlTree);
         navBar.setUserHeader(getUserHeaderFooter(true));
-        htmlTree.addContent(navBar.getContent(true));
+        htmlTree.add(navBar.getContent(true));
         if (configuration.allowTag(HtmlTag.HEADER)) {
-            bodyTree.addContent(htmlTree);
+            bodyTree.add(htmlTree);
         }
         return bodyTree;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TreeWriter.java
@@ -153,7 +153,7 @@ public class TreeWriter extends AbstractTreeWriter {
         if (!classesOnly) {
             Content span = HtmlTree.SPAN(HtmlStyle.packageHierarchyLabel,
                     contents.packageHierarchies);
-            contentTree.addContent(span);
+            contentTree.add(span);
             HtmlTree ul = new HtmlTree(HtmlTag.UL);
             ul.setStyle(HtmlStyle.horizontal);
             int i = 0;
@@ -170,12 +170,12 @@ public class TreeWriter extends AbstractTreeWriter {
                 Content li = HtmlTree.LI(links.createLink(link,
                         new StringContent(utils.getPackageName(pkg))));
                 if (i < packages.size() - 1) {
-                    li.addContent(", ");
+                    li.add(", ");
                 }
-                ul.addContent(li);
+                ul.add(li);
                 i++;
             }
-            contentTree.addContent(ul);
+            contentTree.add(ul);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Comment.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Comment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Comment extends Content {
      * @param content content that needs to be added
      * @throws UnsupportedOperationException always
      */
-    public void addContent(Content content) {
+    public void add(Content content) {
         throw new UnsupportedOperationException();
     }
 
@@ -71,7 +71,7 @@ public class Comment extends Content {
      * @throws UnsupportedOperationException always
      */
     @Override
-    public void addContent(CharSequence stringContent) {
+    public void add(CharSequence stringContent) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,12 +43,12 @@ public class ContentBuilder extends Content {
 
     public ContentBuilder(Content... contents) {
         for (Content c : contents) {
-            addContent(c);
+            add(c);
         }
     }
 
     @Override
-    public void addContent(Content content) {
+    public void add(Content content) {
         nullCheck(content);
         ensureMutableContents();
         if (content instanceof ContentBuilder) {
@@ -58,7 +58,7 @@ public class ContentBuilder extends Content {
     }
 
     @Override
-    public void addContent(CharSequence text) {
+    public void add(CharSequence text) {
         if (text.length() == 0)
             return;
         ensureMutableContents();
@@ -69,7 +69,7 @@ public class ContentBuilder extends Content {
         } else {
             contents.add(sc = new StringContent());
         }
-        sc.addContent(text);
+        sc.add(text);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/FixedStringContent.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/FixedStringContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class FixedStringContent extends Content {
      * @throws UnsupportedOperationException always
      */
     @Override
-    public void addContent(Content content) {
+    public void add(Content content) {
         throw new UnsupportedOperationException();
     }
 
@@ -71,7 +71,7 @@ public class FixedStringContent extends Content {
      * @throws UnsupportedOperationException always
      */
     @Override
-    public void addContent(CharSequence strContent) {
+    public void add(CharSequence strContent) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -324,13 +324,13 @@ public class Head {
     }
 
     private void addStylesheet(HtmlTree tree, DocPath stylesheet) {
-        tree.addContent(HtmlTree.LINK("stylesheet", "text/css",
+        tree.add(HtmlTree.LINK("stylesheet", "text/css",
                 pathToRoot.resolve(stylesheet).getPath(), "Style"));
     }
 
     private void addScripts(HtmlTree tree) {
         if (addDefaultScript) {
-            tree.addContent(HtmlTree.SCRIPT(pathToRoot.resolve(DocPaths.JAVASCRIPT).getPath()));
+            tree.add(HtmlTree.SCRIPT(pathToRoot.resolve(DocPaths.JAVASCRIPT).getPath()));
         }
         if (index) {
             if (pathToRoot != null && mainBodyScript != null) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -259,34 +259,34 @@ public class Head {
 
         HtmlTree tree = new HtmlTree(HtmlTag.HEAD);
         if (showGeneratedBy) {
-            tree.addContent(getGeneratedBy(showTimestamp, now));
+            tree.add(getGeneratedBy(showTimestamp, now));
         }
-        tree.addContent(HtmlTree.TITLE(title));
+        tree.add(HtmlTree.TITLE(title));
 
         if (charset != null) { // compatibility; should this be allowed?
-            tree.addContent(HtmlTree.META("Content-Type", "text/html", charset));
+            tree.add(HtmlTree.META("Content-Type", "text/html", charset));
         }
 
         if (showMetaCreated) {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-            tree.addContent(HtmlTree.META(
+            tree.add(HtmlTree.META(
                     (htmlVersion == HtmlVersion.HTML5) ? "dc.created" : "date",
                     dateFormat.format(now)));
         }
 
         for (String k : keywords) {
-            tree.addContent(HtmlTree.META("keywords", k));
+            tree.add(HtmlTree.META("keywords", k));
         }
 
         for (Content c : extraContent) {
-            tree.addContent(c);
+            tree.add(c);
         }
 
         if (canonicalLink != null) {
             HtmlTree link = new HtmlTree(HtmlTag.LINK);
-            link.addAttr(HtmlAttr.REL, "canonical");
-            link.addAttr(HtmlAttr.HREF, canonicalLink.getPath());
-            tree.addContent(link);
+            link.put(HtmlAttr.REL, "canonical");
+            link.put(HtmlAttr.HREF, canonicalLink.getPath());
+            tree.add(link);
         }
 
         addStylesheets(tree);
@@ -343,19 +343,19 @@ public class Head {
             }
             addJQueryFile(tree, DocPaths.JSZIP_MIN);
             addJQueryFile(tree, DocPaths.JSZIPUTILS_MIN);
-            tree.addContent(new RawHtml("<!--[if IE]>"));
+            tree.add(new RawHtml("<!--[if IE]>"));
             addJQueryFile(tree, DocPaths.JSZIPUTILS_IE_MIN);
-            tree.addContent(new RawHtml("<![endif]-->"));
+            tree.add(new RawHtml("<![endif]-->"));
             addJQueryFile(tree, DocPaths.JQUERY_JS);
             addJQueryFile(tree, DocPaths.JQUERY_UI_JS);
         }
         for (Script script : scripts) {
-            tree.addContent(script.asContent());
+            tree.add(script.asContent());
         }
     }
 
     private void addJQueryFile(HtmlTree tree, DocPath filePath) {
         DocPath jqueryFile = pathToRoot.resolve(DocPaths.JQUERY_FILES.resolve(filePath));
-        tree.addContent(HtmlTree.SCRIPT(jqueryFile.getPath()));
+        tree.add(HtmlTree.SCRIPT(jqueryFile.getPath()));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -308,11 +308,11 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree A(HtmlVersion htmlVersion, String attr, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.A);
-        htmltree.addAttr((htmlVersion == HtmlVersion.HTML4)
+        htmltree.put((htmlVersion == HtmlVersion.HTML4)
                 ? HtmlAttr.NAME
                 : HtmlAttr.ID,
                 nullCheck(attr));
-        htmltree.addContent(nullCheck(body));
+        htmltree.add(nullCheck(body));
         return htmltree;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class HtmlTree extends Content {
     public HtmlTree(HtmlTag tag, Content... contents) {
         this(tag);
         for (Content c: contents)
-            addContent(c);
+            add(c);
     }
 
     /**
@@ -87,7 +87,7 @@ public class HtmlTree extends Content {
     public HtmlTree(HtmlTag tag, List<Content> contents) {
         this(tag);
         for (Content c: contents)
-            addContent(c);
+            add(c);
     }
 
     /**
@@ -97,7 +97,7 @@ public class HtmlTree extends Content {
      * @param attrValue value of the attribute
      * @return this object
      */
-    public HtmlTree addAttr(HtmlAttr attrName, String attrValue) {
+    public HtmlTree put(HtmlAttr attrName, String attrValue) {
         if (attrs.isEmpty())
             attrs = new LinkedHashMap<>(3);
         attrs.put(nullCheck(attrName), escapeHtmlChars(attrValue));
@@ -112,7 +112,7 @@ public class HtmlTree extends Content {
      * @return this object
      */
     public HtmlTree setTitle(Content body) {
-        addAttr(HtmlAttr.TITLE, stripHtml(body));
+        put(HtmlAttr.TITLE, stripHtml(body));
         return this;
     }
 
@@ -123,7 +123,7 @@ public class HtmlTree extends Content {
      * @return this object
      */
     public HtmlTree setRole(Role role) {
-        addAttr(HtmlAttr.ROLE, role.toString());
+        put(HtmlAttr.ROLE, role.toString());
         return this;
     }
 
@@ -134,7 +134,7 @@ public class HtmlTree extends Content {
      * @return this object
      */
     public HtmlTree setStyle(HtmlStyle style) {
-        addAttr(HtmlAttr.CLASS, style.toString());
+        put(HtmlAttr.CLASS, style.toString());
         return this;
     }
 
@@ -144,10 +144,10 @@ public class HtmlTree extends Content {
      * @param tagContent tag content to be added
      */
     @Override
-    public void addContent(Content tagContent) {
+    public void add(Content tagContent) {
         if (tagContent instanceof ContentBuilder) {
             for (Content c: ((ContentBuilder)tagContent).contents) {
-                addContent(c);
+                add(c);
             }
         }
         else if (tagContent == HtmlTree.EMPTY || tagContent.isValid()) {
@@ -165,16 +165,16 @@ public class HtmlTree extends Content {
      * @param stringContent string content that needs to be added
      */
     @Override
-    public void addContent(CharSequence stringContent) {
+    public void add(CharSequence stringContent) {
         if (!content.isEmpty()) {
             Content lastContent = content.get(content.size() - 1);
             if (lastContent instanceof StringContent)
-                lastContent.addContent(stringContent);
+                lastContent.add(stringContent);
             else
-                addContent(new StringContent(stringContent));
+                add(new StringContent(stringContent));
         }
         else
-            addContent(new StringContent(stringContent));
+            add(new StringContent(stringContent));
     }
 
     /**
@@ -294,7 +294,7 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree A(String ref, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.A, nullCheck(body));
-        htmltree.addAttr(HtmlAttr.HREF, encodeURL(ref));
+        htmltree.put(HtmlAttr.HREF, encodeURL(ref));
         return htmltree;
     }
 
@@ -325,8 +325,8 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree A_ID(String id, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.A);
-        htmltree.addAttr(HtmlAttr.ID, nullCheck(id));
-        htmltree.addContent(nullCheck(body));
+        htmltree.put(HtmlAttr.ID, nullCheck(id));
+        htmltree.add(nullCheck(body));
         return htmltree;
     }
 
@@ -515,7 +515,7 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree HTML(String lang, Content head, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.HTML, nullCheck(head), nullCheck(body));
-        htmltree.addAttr(HtmlAttr.LANG, nullCheck(lang));
+        htmltree.put(HtmlAttr.LANG, nullCheck(lang));
         return htmltree;
     }
 
@@ -529,9 +529,9 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree IFRAME(String src, String name, String title) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.IFRAME);
-        htmltree.addAttr(HtmlAttr.SRC, nullCheck(src));
-        htmltree.addAttr(HtmlAttr.NAME, nullCheck(name));
-        htmltree.addAttr(HtmlAttr.TITLE, nullCheck(title));
+        htmltree.put(HtmlAttr.SRC, nullCheck(src));
+        htmltree.put(HtmlAttr.NAME, nullCheck(name));
+        htmltree.put(HtmlAttr.TITLE, nullCheck(title));
         return htmltree;
     }
 
@@ -545,10 +545,10 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree INPUT(String type, String id, String value) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.INPUT);
-        htmltree.addAttr(HtmlAttr.TYPE, nullCheck(type));
-        htmltree.addAttr(HtmlAttr.ID, nullCheck(id));
-        htmltree.addAttr(HtmlAttr.VALUE, nullCheck(value));
-        htmltree.addAttr(HtmlAttr.DISABLED, "disabled");
+        htmltree.put(HtmlAttr.TYPE, nullCheck(type));
+        htmltree.put(HtmlAttr.ID, nullCheck(id));
+        htmltree.put(HtmlAttr.VALUE, nullCheck(value));
+        htmltree.put(HtmlAttr.DISABLED, "disabled");
         return htmltree;
     }
 
@@ -561,7 +561,7 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree LABEL(String forLabel, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.LABEL, nullCheck(body));
-        htmltree.addAttr(HtmlAttr.FOR, nullCheck(forLabel));
+        htmltree.put(HtmlAttr.FOR, nullCheck(forLabel));
         return htmltree;
     }
 
@@ -600,10 +600,10 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree LINK(String rel, String type, String href, String title) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.LINK);
-        htmltree.addAttr(HtmlAttr.REL, nullCheck(rel));
-        htmltree.addAttr(HtmlAttr.TYPE, nullCheck(type));
-        htmltree.addAttr(HtmlAttr.HREF, nullCheck(href));
-        htmltree.addAttr(HtmlAttr.TITLE, nullCheck(title));
+        htmltree.put(HtmlAttr.REL, nullCheck(rel));
+        htmltree.put(HtmlAttr.TYPE, nullCheck(type));
+        htmltree.put(HtmlAttr.HREF, nullCheck(href));
+        htmltree.put(HtmlAttr.TITLE, nullCheck(title));
         return htmltree;
     }
 
@@ -656,8 +656,8 @@ public class HtmlTree extends Content {
     public static HtmlTree META(String httpEquiv, String content, String charSet) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.META);
         String contentCharset = content + "; charset=" + charSet;
-        htmltree.addAttr(HtmlAttr.HTTP_EQUIV, nullCheck(httpEquiv));
-        htmltree.addAttr(HtmlAttr.CONTENT, contentCharset);
+        htmltree.put(HtmlAttr.HTTP_EQUIV, nullCheck(httpEquiv));
+        htmltree.put(HtmlAttr.CONTENT, contentCharset);
         return htmltree;
     }
 
@@ -670,8 +670,8 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree META(String name, String content) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.META);
-        htmltree.addAttr(HtmlAttr.NAME, nullCheck(name));
-        htmltree.addAttr(HtmlAttr.CONTENT, nullCheck(content));
+        htmltree.put(HtmlAttr.NAME, nullCheck(name));
+        htmltree.put(HtmlAttr.CONTENT, nullCheck(content));
         return htmltree;
     }
 
@@ -729,8 +729,8 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree SCRIPT(String src) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.SCRIPT);
-        htmltree.addAttr(HtmlAttr.TYPE, "text/javascript");
-        htmltree.addAttr(HtmlAttr.SRC, nullCheck(src));
+        htmltree.put(HtmlAttr.TYPE, "text/javascript");
+        htmltree.put(HtmlAttr.SRC, nullCheck(src));
         return htmltree;
     }
 
@@ -799,7 +799,7 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree SPAN(String id, HtmlStyle styleClass, Content body) {
         HtmlTree htmltree = new HtmlTree(HtmlTag.SPAN, nullCheck(body));
-        htmltree.addAttr(HtmlAttr.ID, nullCheck(id));
+        htmltree.put(HtmlAttr.ID, nullCheck(id));
         if (styleClass != null)
             htmltree.setStyle(styleClass);
         return htmltree;
@@ -817,7 +817,7 @@ public class HtmlTree extends Content {
         HtmlTree htmltree = new HtmlTree(HtmlTag.TABLE, nullCheck(body));
         if (styleClass != null)
             htmltree.setStyle(styleClass);
-        htmltree.addAttr(HtmlAttr.SUMMARY, nullCheck(summary));
+        htmltree.put(HtmlAttr.SUMMARY, nullCheck(summary));
         return htmltree;
     }
 
@@ -872,7 +872,7 @@ public class HtmlTree extends Content {
         HtmlTree htmltree = new HtmlTree(HtmlTag.TH, nullCheck(body));
         if (styleClass != null)
             htmltree.setStyle(styleClass);
-        htmltree.addAttr(HtmlAttr.SCOPE, nullCheck(scope));
+        htmltree.put(HtmlAttr.SCOPE, nullCheck(scope));
         return htmltree;
     }
 
@@ -930,9 +930,9 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree UL(HtmlStyle styleClass, Content first, Content... more) {
         HtmlTree htmlTree = new HtmlTree(HtmlTag.UL);
-        htmlTree.addContent(nullCheck(first));
+        htmlTree.add(nullCheck(first));
         for (Content c : more) {
-            htmlTree.addContent(nullCheck(c));
+            htmlTree.add(nullCheck(c));
         }
         htmlTree.setStyle(nullCheck(styleClass));
         return htmlTree;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
@@ -241,10 +241,10 @@ public class Links {
     public Content createLink(DocLink link, Content label, String title, String target) {
         HtmlTree anchor = HtmlTree.A(link.relativizeAgainst(file).toString(), label);
         if (title != null && title.length() != 0) {
-            anchor.addAttr(HtmlAttr.TITLE, title);
+            anchor.put(HtmlAttr.TITLE, title);
         }
         if (target != null && target.length() != 0) {
-            anchor.addAttr(HtmlAttr.TARGET, target);
+            anchor.put(HtmlAttr.TARGET, target);
         }
         return anchor;
     }
@@ -287,10 +287,10 @@ public class Links {
         }
         HtmlTree l = HtmlTree.A(link.relativizeAgainst(file).toString(), body);
         if (title != null && title.length() != 0) {
-            l.addAttr(HtmlAttr.TITLE, title);
+            l.put(HtmlAttr.TITLE, title);
         }
         if (target != null && target.length() != 0) {
-            l.addAttr(HtmlAttr.TARGET, target);
+            l.put(HtmlAttr.TARGET, target);
         }
         if (isExternal) {
             l.setStyle(HtmlStyle.externalLink);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Navigation.java
@@ -448,8 +448,8 @@ public class Navigation {
                 }
                 if (!listContents.isEmpty()) {
                     Content li = HtmlTree.LI(contents.summaryLabel);
-                    li.addContent(Contents.SPACE);
-                    tree.addContent(li);
+                    li.add(Contents.SPACE);
+                    tree.add(li);
                     addListToNav(listContents, tree);
                 }
                 break;
@@ -480,8 +480,8 @@ public class Navigation {
                 }
                 if (!listContents.isEmpty()) {
                     Content li = HtmlTree.LI(contents.moduleSubNavLabel);
-                    li.addContent(Contents.SPACE);
-                    tree.addContent(li);
+                    li.add(Contents.SPACE);
+                    tree.add(li);
                     addListToNav(listContents, tree);
                 }
                 break;
@@ -684,8 +684,8 @@ public class Navigation {
                 }
                 if (!listContents.isEmpty()) {
                     Content li = HtmlTree.LI(contents.detailLabel);
-                    li.addContent(Contents.SPACE);
-                    tree.addContent(li);
+                    li.add(Contents.SPACE);
+                    tree.add(li);
                     addListToNav(listContents, tree);
                 }
                 break;
@@ -813,37 +813,37 @@ public class Navigation {
     }
 
     private void addContentToTree(Content tree, Content content) {
-        tree.addContent(HtmlTree.LI(content));
+        tree.add(HtmlTree.LI(content));
     }
 
     private void addListToNav(List<Content> listContents, Content tree) {
         int count = 0;
         for (Content liContent : listContents) {
             if (count < listContents.size() - 1) {
-                liContent.addContent(Contents.SPACE);
-                liContent.addContent("|");
-                liContent.addContent(Contents.SPACE);
+                liContent.add(Contents.SPACE);
+                liContent.add("|");
+                liContent.add(Contents.SPACE);
             }
-            tree.addContent(liContent);
+            tree.add(liContent);
             count++;
         }
     }
 
     private void addActivePageLink(Content tree, Content label, boolean display) {
         if (display) {
-            tree.addContent(HtmlTree.LI(HtmlStyle.navBarCell1Rev, label));
+            tree.add(HtmlTree.LI(HtmlStyle.navBarCell1Rev, label));
         }
     }
 
     private void addPageLabel(Content tree, Content label, boolean display) {
         if (display) {
-            tree.addContent(HtmlTree.LI(label));
+            tree.add(HtmlTree.LI(label));
         }
     }
 
     private void addOverviewLink(Content tree) {
         if (configuration.createoverview) {
-            tree.addContent(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.overviewSummary(configuration.frames)),
+            tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.overviewSummary(configuration.frames)),
                     contents.overviewLabel, "", "")));
         }
     }
@@ -853,7 +853,7 @@ public class Navigation {
             if (configuration.modules.size() == 1) {
                 ModuleElement mdle = configuration.modules.first();
                 boolean included = configuration.utils.isIncluded(mdle);
-                tree.addContent(HtmlTree.LI((included)
+                tree.add(HtmlTree.LI((included)
                         ? links.createLink(pathToRoot.resolve(configuration.docPaths.moduleSummary(mdle)), contents.moduleLabel, "", "")
                         : contents.moduleLabel));
             } else if (!configuration.modules.isEmpty()) {
@@ -864,7 +864,7 @@ public class Navigation {
 
     private void addModuleOfElementLink(Content tree) {
         if (configuration.showModules) {
-            tree.addContent(HtmlTree.LI(navLinkModule));
+            tree.add(HtmlTree.LI(navLinkModule));
         }
     }
 
@@ -881,16 +881,16 @@ public class Navigation {
                 }
             }
             if (included || packageElement == null) {
-                tree.addContent(HtmlTree.LI(links.createLink(
+                tree.add(HtmlTree.LI(links.createLink(
                         pathToRoot.resolve(configuration.docPaths.forPackage(packageElement).resolve(DocPaths.PACKAGE_SUMMARY)),
                         contents.packageLabel)));
             } else {
                 DocLink crossPkgLink = configuration.extern.getExternalLink(
                         packageElement, pathToRoot, DocPaths.PACKAGE_SUMMARY.getPath());
                 if (crossPkgLink != null) {
-                    tree.addContent(HtmlTree.LI(links.createLink(crossPkgLink, contents.packageLabel)));
+                    tree.add(HtmlTree.LI(links.createLink(crossPkgLink, contents.packageLabel)));
                 } else {
-                    tree.addContent(HtmlTree.LI(contents.packageLabel));
+                    tree.add(HtmlTree.LI(contents.packageLabel));
                 }
             }
         } else if (!configuration.packages.isEmpty()) {
@@ -899,12 +899,12 @@ public class Navigation {
     }
 
     private void addPackageOfElementLink(Content tree) {
-        tree.addContent(HtmlTree.LI(links.createLink(DocPath.parent.resolve(DocPaths.PACKAGE_SUMMARY),
+        tree.add(HtmlTree.LI(links.createLink(DocPath.parent.resolve(DocPaths.PACKAGE_SUMMARY),
                 contents.packageLabel)));
     }
 
     private void addPackageSummaryLink(Content tree) {
-        tree.addContent(HtmlTree.LI(links.createLink(DocPaths.PACKAGE_SUMMARY, contents.packageLabel)));
+        tree.add(HtmlTree.LI(links.createLink(DocPaths.PACKAGE_SUMMARY, contents.packageLabel)));
     }
 
     private void addTreeLink(Content tree) {
@@ -913,20 +913,20 @@ public class Navigation {
             DocPath docPath = packages.size() == 1 && configuration.getSpecifiedTypeElements().isEmpty()
                     ? pathToRoot.resolve(configuration.docPaths.forPackage(packages.get(0)).resolve(DocPaths.PACKAGE_TREE))
                     : pathToRoot.resolve(DocPaths.OVERVIEW_TREE);
-            tree.addContent(HtmlTree.LI(links.createLink(docPath, contents.treeLabel, "", "")));
+            tree.add(HtmlTree.LI(links.createLink(docPath, contents.treeLabel, "", "")));
         }
     }
 
     private void addDeprecatedLink(Content tree) {
         if (!(configuration.nodeprecated || configuration.nodeprecatedlist)) {
-            tree.addContent(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.DEPRECATED_LIST),
+            tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.DEPRECATED_LIST),
                     contents.deprecatedLabel, "", "")));
         }
     }
 
     private void addIndexLink(Content tree) {
         if (configuration.createindex) {
-            tree.addContent(HtmlTree.LI(links.createLink(pathToRoot.resolve(
+            tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(
                     (configuration.splitindex
                             ? DocPaths.INDEX_FILES.resolve(DocPaths.indexN(1))
                             : DocPaths.INDEX_ALL)),
@@ -944,7 +944,7 @@ public class Navigation {
                 DocFile file = DocFile.createFileForInput(configuration, helpfile);
                 helpfilenm = DocPath.create(file.getName());
             }
-            tree.addContent(HtmlTree.LI(links.createLink(pathToRoot.resolve(helpfilenm),
+            tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(helpfilenm),
                     contents.helpLabel, "", "")));
         }
     }
@@ -957,7 +957,7 @@ public class Navigation {
     private void addNavShowLists(Content tree) {
         DocLink dl = new DocLink(pathToRoot.resolve(DocPaths.INDEX), path.getPath(), null);
         Content framesContent = links.createLink(dl, contents.framesLabel, "", "_top");
-        tree.addContent(HtmlTree.LI(framesContent));
+        tree.add(HtmlTree.LI(framesContent));
     }
 
     /**
@@ -967,7 +967,7 @@ public class Navigation {
      */
     private void addNavHideLists(Content tree) {
         Content noFramesContent = links.createLink(path.basename(), contents.noFramesLabel, "", "_top");
-        tree.addContent(HtmlTree.LI(noFramesContent));
+        tree.add(HtmlTree.LI(noFramesContent));
     }
 
     private void addNavLinkClassIndex(Content tree) {
@@ -1019,29 +1019,29 @@ public class Navigation {
             HtmlTree navDiv = new HtmlTree(HtmlTag.DIV);
             if (top) {
                 queue = topBottomNavContents.get(Position.TOP);
-                fixedNavDiv.addContent(Position.TOP.startOfNav());
+                fixedNavDiv.add(Position.TOP.startOfNav());
                 navDiv.setStyle(HtmlStyle.topNav);
             } else {
                 queue = topBottomNavContents.get(Position.BOTTOM);
-                tree.addContent(Position.BOTTOM.startOfNav());
+                tree.add(Position.BOTTOM.startOfNav());
                 navDiv.setStyle(HtmlStyle.bottomNav);
             }
-            navDiv.addContent(queue.poll());
+            navDiv.add(queue.poll());
             HtmlTree skipLinkDiv = HtmlTree.DIV(HtmlStyle.skipNav, queue.poll());
-            navDiv.addContent(skipLinkDiv);
-            navDiv.addContent(queue.poll());
+            navDiv.add(skipLinkDiv);
+            navDiv.add(queue.poll());
             HtmlTree navList = new HtmlTree(HtmlTag.UL);
             navList.setStyle(HtmlStyle.navList);
-            navList.addAttr(HtmlAttr.TITLE, rowListTitle);
+            navList.put(HtmlAttr.TITLE, rowListTitle);
             fixedNavDiv.setStyle(HtmlStyle.fixedNav);
             addMainNavLinks(navList);
-            navDiv.addContent(navList);
+            navDiv.add(navList);
             Content aboutDiv = HtmlTree.DIV(HtmlStyle.aboutLanguage, top ? userHeader : userFooter);
-            navDiv.addContent(aboutDiv);
+            navDiv.add(aboutDiv);
             if (top) {
-                fixedNavDiv.addContent(navDiv);
+                fixedNavDiv.add(navDiv);
             } else {
-                tree.addContent(navDiv);
+                tree.add(navDiv);
             }
             HtmlTree subDiv = new HtmlTree(HtmlTag.DIV);
             subDiv.setStyle(HtmlStyle.subNav);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Navigation.java
@@ -974,7 +974,7 @@ public class Navigation {
         Content allClassesContent = links.createLink(pathToRoot.resolve(
                 DocPaths.AllClasses(configuration.frames)),
                 contents.allClassesLabel, "", "");
-        tree.addContent(HtmlTree.LI(allClassesContent));
+        tree.add(HtmlTree.LI(allClassesContent));
     }
 
     private void addSearch(Content tree) {
@@ -983,10 +983,10 @@ public class Navigation {
         HtmlTree inputText = HtmlTree.INPUT("text", searchValueId, searchValueId);
         HtmlTree inputReset = HtmlTree.INPUT(reset, reset, reset);
         HtmlTree liInput = HtmlTree.LI(HtmlTree.LABEL(searchValueId, searchLabel));
-        liInput.addContent(inputText);
-        liInput.addContent(inputReset);
+        liInput.add(inputText);
+        liInput.add(inputReset);
         HtmlTree ulSearch = HtmlTree.UL(HtmlStyle.navListSearch, liInput);
-        tree.addContent(ulSearch);
+        tree.add(ulSearch);
     }
 
     private void addAllClassesLinkScript(Content tree, boolean top) {
@@ -995,12 +995,12 @@ public class Navigation {
                 : Position.BOTTOM.allClassesLinkScript().asContent());
         Content div_noscript = HtmlTree.DIV(contents.noScriptMessage);
         Content noScript = HtmlTree.NOSCRIPT(div_noscript);
-        div.addContent(noScript);
-        tree.addContent(div);
+        div.add(noScript);
+        tree.add(div);
     }
 
     private void addFixedNavScript(Content tree) {
-        tree.addContent(FIXED_NAV_SCRIPT.asContent());
+        tree.add(FIXED_NAV_SCRIPT.asContent());
     }
 
     /**
@@ -1053,14 +1053,14 @@ public class Navigation {
                     addNavHideLists(ulFrames);
                 }
             }
-            subDiv.addContent(ulFrames);
+            subDiv.add(ulFrames);
             HtmlTree ulAllClasses = new HtmlTree(HtmlTag.UL);
             ulAllClasses.setStyle(HtmlStyle.navList);
-            ulAllClasses.addAttr(HtmlAttr.ID, top
+            ulAllClasses.put(HtmlAttr.ID, top
                     ? Position.TOP.allClassesLinkId()
                     : Position.BOTTOM.allClassesLinkId());
             addNavLinkClassIndex(ulAllClasses);
-            subDiv.addContent(ulAllClasses);
+            subDiv.add(ulAllClasses);
             if (top && configuration.createindex) {
                 addSearch(subDiv);
             }
@@ -1070,24 +1070,24 @@ public class Navigation {
             HtmlTree ulNavSummary = new HtmlTree(HtmlTag.UL);
             ulNavSummary.setStyle(HtmlStyle.subNavList);
             addSummaryLinks(ulNavSummary);
-            div.addContent(ulNavSummary);
+            div.add(ulNavSummary);
             // Add the detail links if present.
             HtmlTree ulNavDetail = new HtmlTree(HtmlTag.UL);
             ulNavDetail.setStyle(HtmlStyle.subNavList);
             addDetailLinks(ulNavDetail);
-            div.addContent(ulNavDetail);
-            subDiv.addContent(div);
-            subDiv.addContent(queue.poll());
+            div.add(ulNavDetail);
+            subDiv.add(div);
+            subDiv.add(queue.poll());
             if (top) {
-                fixedNavDiv.addContent(subDiv);
-                fixedNavDiv.addContent(Position.TOP.endOfNav());
-                tree.addContent(fixedNavDiv);
+                fixedNavDiv.add(subDiv);
+                fixedNavDiv.add(Position.TOP.endOfNav());
+                tree.add(fixedNavDiv);
                 HtmlTree paddingDiv = HtmlTree.DIV(HtmlStyle.navPadding, Contents.SPACE);
-                tree.addContent(paddingDiv);
+                tree.add(paddingDiv);
                 addFixedNavScript(tree);
             } else {
-                tree.addContent(subDiv);
-                tree.addContent(Position.BOTTOM.endOfNav());
+                tree.add(subDiv);
+                tree.add(Position.BOTTOM.endOfNav());
             }
             return tree;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/RawHtml.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/RawHtml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class RawHtml extends Content {
      * @param content content that needs to be added
      * @throws UnsupportedOperationException always
      */
-    public void addContent(Content content) {
+    public void add(Content content) {
         throw new UnsupportedOperationException();
     }
 
@@ -75,7 +75,7 @@ public class RawHtml extends Content {
      * @throws UnsupportedOperationException always
      */
     @Override
-    public void addContent(CharSequence stringContent) {
+    public void add(CharSequence stringContent) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Script.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Script.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,19 +108,19 @@ public class Script  {
         ScriptContent scriptContent = new ScriptContent(sb);
         HtmlTree tree = new HtmlTree(HtmlTag.SCRIPT) {
             @Override
-            public void addContent(CharSequence s) {
+            public void add(CharSequence s) {
                 throw new UnsupportedOperationException();
             }
             @Override
-            public void addContent(Content c) {
+            public void add(Content c) {
                 if (c != scriptContent) {
                     throw new IllegalArgumentException();
                 }
-                super.addContent(scriptContent);
+                super.add(scriptContent);
             }
         };
-        tree.addAttr(HtmlAttr.TYPE, "text/javascript");
-        tree.addContent(scriptContent);
+        tree.put(HtmlAttr.TYPE, "text/javascript");
+        tree.add(scriptContent);
         return tree;
     }
 
@@ -200,12 +200,12 @@ public class Script  {
         }
 
         @Override
-        public void addContent(Content content) {
+        public void add(Content content) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void addContent(CharSequence code) {
+        public void add(CharSequence code) {
             sb.append(code);
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/StringContent.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/StringContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class StringContent extends Content {
      * @throws UnsupportedOperationException always
      */
     @Override
-    public void addContent(Content content) {
+    public void add(Content content) {
         throw new UnsupportedOperationException();
     }
 
@@ -80,7 +80,7 @@ public class StringContent extends Content {
      * @param strContent string content to be added
      */
     @Override
-    public void addContent(CharSequence strContent) {
+    public void add(CharSequence strContent) {
         appendChars(strContent);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Table.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import javax.lang.model.element.Element;
 
 import jdk.javadoc.internal.doclets.formats.html.Contents;
 import jdk.javadoc.internal.doclets.toolkit.Content;
-import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 
 /**
  * A builder for HTML tables, such as the summary tables for various
@@ -406,7 +405,7 @@ public class Table {
 
         if (stripedStyles != null) {
             int rowIndex = bodyRows.size();
-            row.addAttr(HtmlAttr.CLASS, stripedStyles.get(rowIndex % 2).name());
+            row.put(HtmlAttr.CLASS, stripedStyles.get(rowIndex % 2).name());
         }
         int colIndex = 0;
         for (Content c : contents) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Table.java
@@ -400,7 +400,7 @@ public class Table {
 
         if (putIdFirst && tabMap != null) {
             int index = bodyRows.size();
-            row.addAttr(HtmlAttr.ID, (rowIdPrefix + index));
+            row.put(HtmlAttr.ID, (rowIdPrefix + index));
         }
 
         if (stripedStyles != null) {
@@ -415,7 +415,7 @@ public class Table {
             HtmlTree cell = (colIndex == rowScopeColumnIndex)
                     ? HtmlTree.TH(cellStyle, "row", c)
                     : HtmlTree.TD(cellStyle, c);
-            row.addContent(cell);
+            row.add(cell);
             colIndex++;
         }
         bodyRows.add(row);
@@ -423,7 +423,7 @@ public class Table {
         if (tabMap != null) {
             if (!putIdFirst) {
                 int index = bodyRows.size() - 1;
-                row.addAttr(HtmlAttr.ID, (rowIdPrefix + index));
+                row.put(HtmlAttr.ID, (rowIdPrefix + index));
             }
             int mask = 0;
             int maskBit = 1;
@@ -459,21 +459,21 @@ public class Table {
         HtmlTree table = new HtmlTree(HtmlTag.TABLE);
         table.setStyle(tableStyle);
         if (summary != null) {
-            table.addAttr(HtmlAttr.SUMMARY, summary);
+            table.put(HtmlAttr.SUMMARY, summary);
         }
         if (tabMap != null) {
             if (tabs.size() == 1) {
                 String tabName = tabs.iterator().next();
-                table.addContent(getCaption(new StringContent(tabName)));
+                table.add(getCaption(new StringContent(tabName)));
             } else {
                 ContentBuilder cb = new ContentBuilder();
                 int tabIndex = 0;
                 HtmlTree defaultTabSpan = new HtmlTree(HtmlTag.SPAN,
                             HtmlTree.SPAN(new StringContent(defaultTab)),
                             HtmlTree.SPAN(tabEnd, Contents.SPACE))
-                        .addAttr(HtmlAttr.ID, tabId.apply(tabIndex))
+                        .put(HtmlAttr.ID, tabId.apply(tabIndex))
                         .setStyle(activeTabStyle);
-                cb.addContent(defaultTabSpan);
+                cb.add(defaultTabSpan);
                 for (String tabName : tabMap.keySet()) {
                     tabIndex++;
                     if (tabs.contains(tabName)) {
@@ -481,23 +481,23 @@ public class Table {
                         HtmlTree link = HtmlTree.A(script, new StringContent(tabName));
                         HtmlTree tabSpan = new HtmlTree(HtmlTag.SPAN,
                                     HtmlTree.SPAN(link), HtmlTree.SPAN(tabEnd, Contents.SPACE))
-                                .addAttr(HtmlAttr.ID, tabId.apply(tabIndex))
+                                .put(HtmlAttr.ID, tabId.apply(tabIndex))
                                 .setStyle(tabStyle);
-                        cb.addContent(tabSpan);
+                        cb.add(tabSpan);
                     }
                 }
-                table.addContent(HtmlTree.CAPTION(cb));
+                table.add(HtmlTree.CAPTION(cb));
             }
         } else {
-            table.addContent(caption);
+            table.add(caption);
         }
-        table.addContent(header.toContent());
+        table.add(header.toContent());
         if (useTBody) {
             Content tbody = new HtmlTree(HtmlTag.TBODY);
-            bodyRows.forEach(row -> tbody.addContent(row));
-            table.addContent(tbody);
+            bodyRows.forEach(row -> tbody.add(row));
+            table.add(tbody);
         } else {
-            bodyRows.forEach(row -> table.addContent(row));
+            bodyRows.forEach(row -> table.add(row));
         }
         return table;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TableHeader.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TableHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ public class TableHeader {
                     : (i == 1) ? HtmlStyle.colSecond : null;
             Content cell = (style == null) ? HtmlTree.TH(scope, cellContent)
                     : HtmlTree.TH(style, scope, cellContent);
-            tr.addContent(cell);
+            tr.add(cell);
             i++;
         }
         return tr;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,14 +64,14 @@ public abstract class Content {
      *
      * @param content content that needs to be added
      */
-    public abstract void addContent(Content content);
+    public abstract void add(Content content);
 
     /**
      * Adds a string content to the existing content.
      *
      * @param stringContent the string content to be added
      */
-    public abstract void addContent(CharSequence stringContent);
+    public abstract void add(CharSequence stringContent);
 
     /**
      * Writes content to a writer.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeBuilder.java
@@ -156,7 +156,7 @@ public class AnnotationTypeBuilder extends AbstractBuilder {
         buildAnnotationTypeDescription(annotationInfoTree);
         buildAnnotationTypeTagInfo(annotationInfoTree);
 
-        annotationContentTree.addContent(writer.getAnnotationInfo(annotationInfoTree));
+        annotationContentTree.add(writer.getAnnotationInfo(annotationInfoTree));
     }
 
     /**
@@ -205,7 +205,7 @@ public class AnnotationTypeBuilder extends AbstractBuilder {
     protected void buildMemberSummary(Content annotationContentTree) throws DocletException {
         Content memberSummaryTree = writer.getMemberTreeHeader();
         builderFactory.getMemberSummaryBuilder(writer).build(memberSummaryTree);
-        annotationContentTree.addContent(writer.getMemberSummaryTree(memberSummaryTree));
+        annotationContentTree.add(writer.getMemberSummaryTree(memberSummaryTree));
     }
 
     /**
@@ -223,7 +223,7 @@ public class AnnotationTypeBuilder extends AbstractBuilder {
         buildAnnotationTypeOptionalMemberDetails(memberDetailsTree);
 
         if (memberDetailsTree.isValid()) {
-            annotationContentTree.addContent(writer.getMemberDetailsTree(memberDetailsTree));
+            annotationContentTree.add(writer.getMemberDetailsTree(memberDetailsTree));
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeFieldBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeFieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,9 +153,9 @@ public class AnnotationTypeFieldBuilder extends AbstractMemberBuilder {
                 buildMemberComments(annotationDocTree);
                 buildTagInfo(annotationDocTree);
 
-                detailsTree.addContent(writer.getAnnotationDoc(
+                detailsTree.add(writer.getAnnotationDoc(
                         annotationDocTree, currentMember == lastElement));
-                memberDetailsTree.addContent(writer.getAnnotationDetails(detailsTree));
+                memberDetailsTree.add(writer.getAnnotationDetails(detailsTree));
             }
         }
     }
@@ -166,7 +166,7 @@ public class AnnotationTypeFieldBuilder extends AbstractMemberBuilder {
      * @param annotationDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content annotationDocTree) {
-        annotationDocTree.addContent(
+        annotationDocTree.add(
                 writer.getSignature(currentMember));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeRequiredMemberBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AnnotationTypeRequiredMemberBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,9 +152,9 @@ public class AnnotationTypeRequiredMemberBuilder extends AbstractMemberBuilder {
 
                 buildAnnotationTypeMemberChildren(annotationDocTree);
 
-                detailsTree.addContent(writer.getAnnotationDoc(
+                detailsTree.add(writer.getAnnotationDoc(
                         annotationDocTree, currentMember == lastMember));
-                memberDetailsTree.addContent(writer.getAnnotationDetails(detailsTree));
+                memberDetailsTree.add(writer.getAnnotationDetails(detailsTree));
             }
         }
     }
@@ -172,7 +172,7 @@ public class AnnotationTypeRequiredMemberBuilder extends AbstractMemberBuilder {
      * @param annotationDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content annotationDocTree) {
-        annotationDocTree.addContent(writer.getSignature(currentMember));
+        annotationDocTree.add(writer.getSignature(currentMember));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
@@ -181,7 +181,7 @@ public class ClassBuilder extends AbstractBuilder {
         buildClassDescription(classInfoTree);
         buildClassTagInfo(classInfoTree);
 
-        classContentTree.addContent(writer.getClassInfo(classInfoTree));
+        classContentTree.add(writer.getClassInfo(classInfoTree));
     }
 
     /**
@@ -322,7 +322,7 @@ public class ClassBuilder extends AbstractBuilder {
     protected void buildMemberSummary(Content classContentTree) throws DocletException {
         Content memberSummaryTree = writer.getMemberTreeHeader();
         builderFactory.getMemberSummaryBuilder(writer).build(memberSummaryTree);
-        classContentTree.addContent(writer.getMemberSummaryTree(memberSummaryTree));
+        classContentTree.add(writer.getMemberSummaryTree(memberSummaryTree));
     }
 
     /**
@@ -340,7 +340,7 @@ public class ClassBuilder extends AbstractBuilder {
         buildConstructorDetails(memberDetailsTree);
         buildMethodDetails(memberDetailsTree);
 
-        classContentTree.addContent(writer.getMemberDetailsTree(memberDetailsTree));
+        classContentTree.add(writer.getMemberDetailsTree(memberDetailsTree));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ConstructorBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ConstructorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,10 +148,10 @@ public class ConstructorBuilder extends AbstractMemberBuilder {
                 buildConstructorComments(constructorDocTree);
                 buildTagInfo(constructorDocTree);
 
-                constructorDetailsTree.addContent(writer.getConstructorDoc(constructorDocTree,
+                constructorDetailsTree.add(writer.getConstructorDoc(constructorDocTree,
                         currentConstructor == lastElement));
             }
-            memberDetailsTree.addContent(
+            memberDetailsTree.add(
                     writer.getConstructorDetails(constructorDetailsTree));
         }
     }
@@ -162,7 +162,7 @@ public class ConstructorBuilder extends AbstractMemberBuilder {
      * @param constructorDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content constructorDocTree) {
-        constructorDocTree.addContent(writer.getSignature(currentConstructor));
+        constructorDocTree.add(writer.getSignature(currentConstructor));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/EnumConstantBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/EnumConstantBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,10 +136,10 @@ public class EnumConstantBuilder extends AbstractMemberBuilder {
                 buildEnumConstantComments(enumConstantsTree);
                 buildTagInfo(enumConstantsTree);
 
-                enumConstantsDetailsTree.addContent(writer.getEnumConstants(
+                enumConstantsDetailsTree.add(writer.getEnumConstants(
                         enumConstantsTree, currentElement == lastElement));
             }
-            memberDetailsTree.addContent(
+            memberDetailsTree.add(
                     writer.getEnumConstantsDetails(enumConstantsDetailsTree));
         }
     }
@@ -150,7 +150,7 @@ public class EnumConstantBuilder extends AbstractMemberBuilder {
      * @param enumConstantsTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content enumConstantsTree) {
-        enumConstantsTree.addContent(writer.getSignature(currentElement));
+        enumConstantsTree.add(writer.getSignature(currentElement));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/FieldBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/FieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,10 +137,10 @@ public class FieldBuilder extends AbstractMemberBuilder {
                 buildFieldComments(fieldDocTree);
                 buildTagInfo(fieldDocTree);
 
-                fieldDetailsTree.addContent(writer.getFieldDoc(
+                fieldDetailsTree.add(writer.getFieldDoc(
                         fieldDocTree, currentElement == lastElement));
             }
-            memberDetailsTree.addContent(
+            memberDetailsTree.add(
                     writer.getFieldDetails(fieldDetailsTree));
         }
     }
@@ -151,7 +151,7 @@ public class FieldBuilder extends AbstractMemberBuilder {
      * @param fieldDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content fieldDocTree) {
-        fieldDocTree.addContent(writer.getSignature(currentElement));
+        fieldDocTree.add(writer.getSignature(currentElement));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -464,7 +464,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
                 Content inheritedTree = writer.getInheritedSummaryHeader(inheritedClass);
                 Content linksTree = writer.getInheritedSummaryLinksTree();
                 addSummaryFootNote(inheritedClass, inheritedMembers, linksTree, writer);
-                inheritedTree.addContent(linksTree);
+                inheritedTree.add(linksTree);
                 summaryTreeList.add(writer.getMemberTree(inheritedTree));
             }
         }
@@ -497,7 +497,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
             buildInheritedSummary(writer, kind, summaryTreeList);
         if (!summaryTreeList.isEmpty()) {
             Content memberTree = writer.getMemberSummaryHeader(typeElement, memberSummaryTree);
-            summaryTreeList.stream().forEach(memberTree::addContent);
+            summaryTreeList.stream().forEach(memberTree::add);
             writer.addMemberTree(memberSummaryTree, memberTree);
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MethodBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MethodBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,10 +139,10 @@ public class MethodBuilder extends AbstractMemberBuilder {
                 buildMethodComments(methodDocTree);
                 buildTagInfo(methodDocTree);
 
-                methodDetailsTree.addContent(writer.getMethodDoc(
+                methodDetailsTree.add(writer.getMethodDoc(
                         methodDocTree, currentMethod == lastElement));
             }
-            memberDetailsTree.addContent(writer.getMethodDetails(methodDetailsTree));
+            memberDetailsTree.add(writer.getMethodDetails(methodDetailsTree));
         }
     }
 
@@ -152,7 +152,7 @@ public class MethodBuilder extends AbstractMemberBuilder {
      * @param methodDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content methodDocTree) {
-        methodDocTree.addContent(writer.getSignature(currentMethod));
+        methodDocTree.add(writer.getSignature(currentMethod));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ModuleSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ModuleSummaryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class ModuleSummaryBuilder extends AbstractBuilder {
         buildModulesSummary(summaryContentTree);
         buildServicesSummary(summaryContentTree);
 
-        moduleContentTree.addContent(moduleWriter.getSummaryTree(summaryContentTree));
+        moduleContentTree.add(moduleWriter.getSummaryTree(summaryContentTree));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,7 +163,7 @@ public class PackageSummaryBuilder extends AbstractBuilder {
         buildErrorSummary(summaryContentTree);
         buildAnnotationTypeSummary(summaryContentTree);
 
-        packageContentTree.addContent(summaryContentTree);
+        packageContentTree.add(summaryContentTree);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PropertyBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PropertyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.DocletException;
 import jdk.javadoc.internal.doclets.toolkit.PropertyWriter;
-import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 
 import static jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable.Kind.*;
 
@@ -138,10 +137,10 @@ public class PropertyBuilder extends AbstractMemberBuilder {
                 buildPropertyComments(propertyDocTree);
                 buildTagInfo(propertyDocTree);
 
-                propertyDetailsTree.addContent(writer.getPropertyDoc(
+                propertyDetailsTree.add(writer.getPropertyDoc(
                         propertyDocTree, currentProperty == lastElement));
             }
-            memberDetailsTree.addContent(
+            memberDetailsTree.add(
                     writer.getPropertyDetails(propertyDetailsTree));
         }
     }
@@ -152,7 +151,7 @@ public class PropertyBuilder extends AbstractMemberBuilder {
      * @param propertyDocTree the content tree to which the documentation will be added
      */
     protected void buildSignature(Content propertyDocTree) {
-        propertyDocTree.addContent(writer.getSignature(currentProperty));
+        propertyDocTree.add(writer.getSignature(currentProperty));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -170,7 +170,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
 
             buildPackageSerializedForm(serializedSummariesTree);
         }
-        serializedTree.addContent(writer.getSerializedContent(
+        serializedTree.add(writer.getSerializedContent(
                 serializedSummariesTree));
     }
 
@@ -205,7 +205,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
      * @param packageSerializedTree content tree to which the documentation will be added
      */
     protected void buildPackageHeader(Content packageSerializedTree) {
-        packageSerializedTree.addContent(writer.getPackageHeader(
+        packageSerializedTree.add(writer.getPackageHeader(
                 utils.getPackageName(currentPackage)));
     }
 
@@ -232,10 +232,10 @@ public class SerializedFormBuilder extends AbstractBuilder {
                 buildSerialUIDInfo(classTree);
                 buildClassContent(classTree);
 
-                classSerializedTree.addContent(classTree);
+                classSerializedTree.add(classTree);
             }
         }
-        packageSerializedTree.addContent(classSerializedTree);
+        packageSerializedTree.add(classSerializedTree);
     }
 
     /**
@@ -254,7 +254,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
                 break;
             }
         }
-        classTree.addContent(serialUidTree);
+        classTree.add(serialUidTree);
     }
 
     /**
@@ -270,7 +270,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
         buildFieldHeader(classContentTree);
         buildSerializableFields(classContentTree);
 
-        classTree.addContent(classContentTree);
+        classTree.add(classContentTree);
     }
 
     /**
@@ -511,7 +511,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
             fieldWriter.addMemberHeader(te, fieldType, "",
                     tag.getName().getName().toString(), fieldsContentTree);
             fieldWriter.addMemberDescription(field, tag, fieldsContentTree);
-            serializableFieldsTree.addContent(fieldsContentTree);
+            serializableFieldsTree.add(fieldsContentTree);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -292,18 +292,18 @@ public class SerializedFormBuilder extends AbstractBuilder {
                 buildDeprecatedMethodInfo(methodsContentTree);
                 buildMethodInfo(methodsContentTree);
 
-                serializableMethodTree.addContent(methodsContentTree);
+                serializableMethodTree.add(methodsContentTree);
             }
         }
         if (!utils.serializationMethods(currentTypeElement).isEmpty()) {
-            classContentTree.addContent(methodWriter.getSerializableMethods(
+            classContentTree.add(methodWriter.getSerializableMethods(
                     configuration.getText("doclet.Serialized_Form_methods"),
                     serializableMethodTree));
             if (utils.isSerializable(currentTypeElement) && !utils.isExternalizable(currentTypeElement)) {
                 if (utils.serializationMethods(currentTypeElement).isEmpty()) {
                     Content noCustomizationMsg = methodWriter.getNoCustomizationMsg(
                             configuration.getText("doclet.Serializable_no_customization"));
-                    classContentTree.addContent(methodWriter.getSerializableMethods(
+                    classContentTree.add(methodWriter.getSerializableMethods(
                     configuration.getText("doclet.Serialized_Form_methods"),
                     noCustomizationMsg));
                 }
@@ -402,8 +402,8 @@ public class SerializedFormBuilder extends AbstractBuilder {
                     fieldWriter.addMemberDescription(ve, fieldsOverviewContentTree);
                     fieldWriter.addMemberTags(ve, fieldsOverviewContentTree);
                 }
-                serializableFieldsTree.addContent(fieldsOverviewContentTree);
-                classContentTree.addContent(fieldWriter.getSerializableFields(
+                serializableFieldsTree.add(fieldsOverviewContentTree);
+                classContentTree.add(fieldWriter.getSerializableFields(
                         configuration.getText("doclet.Serialized_Form_class"),
                         serializableFieldsTree));
             }
@@ -431,12 +431,12 @@ public class SerializedFormBuilder extends AbstractBuilder {
                     buildFieldDeprecationInfo(fieldsContentTree);
                     buildFieldInfo(fieldsContentTree);
 
-                    serializableFieldsTree.addContent(fieldsContentTree);
+                    serializableFieldsTree.add(fieldsContentTree);
                 } else {
                     buildSerialFieldTagsInfo(serializableFieldsTree);
                 }
             }
-            classContentTree.addContent(fieldWriter.getSerializableFields(
+            classContentTree.add(fieldWriter.getSerializableFields(
                     configuration.getText("doclet.Serialized_Form_fields"),
                     serializableFieldsTree));
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             ExecutableElement member = (ExecutableElement) holder;
             Content output = getTagletOutput(false, member, writer,
                 member.getTypeParameters(), utils.getTypeParamTrees(member));
-            output.addContent(getTagletOutput(true, member, writer,
+            output.add(getTagletOutput(true, member, writer,
                 member.getParameters(), utils.getParamTrees(member)));
             return output;
         } else {
@@ -160,7 +160,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         Content result = writer.getOutputInstance();
         Set<String> alreadyDocumented = new HashSet<>();
         if (!paramTags.isEmpty()) {
-            result.addContent(
+            result.add(
                 processParamTags(holder, isParameters, paramTags,
                 getRankMap(writer.configuration().utils, formalParameters), writer, alreadyDocumented)
             );
@@ -168,7 +168,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         if (alreadyDocumented.size() != formalParameters.size()) {
             //Some parameters are missing corresponding @param tags.
             //Try to inherit them.
-            result.addContent(getInheritedTagletOutput(isParameters, holder,
+            result.add(getInheritedTagletOutput(isParameters, holder,
                 writer, formalParameters, alreadyDocumented));
         }
         return result;
@@ -204,7 +204,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                             inheritedDoc.holderTag,
                             lname,
                             alreadyDocumented.isEmpty());
-                    result.addContent(content);
+                    result.add(content);
                 }
                 alreadyDocumented.add(String.valueOf(i));
             }
@@ -256,7 +256,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                                     : "doclet.Type_Parameters_dup_warn",
                             paramName);
                 }
-                result.addContent(processParamTag(e, isParams, writer, dt,
+                result.add(processParamTag(e, isParams, writer, dt,
                         ch.getParameterName(dt), alreadyDocumented.isEmpty()));
                 alreadyDocumented.add(rank);
             }
@@ -284,9 +284,9 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         String header = writer.configuration().getText(
             isParams ? "doclet.Parameters" : "doclet.TypeParameters");
         if (isFirstParam) {
-            result.addContent(writer.getParamHeader(header));
+            result.add(writer.getParamHeader(header));
         }
-        result.addContent(writer.paramTagOutput(e, paramTag, name));
+        result.add(writer.paramTagOutput(e, paramTag, name));
         return result;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -250,7 +250,7 @@ public abstract class TagletWriter {
             }
             if (currentOutput != null) {
                 tagletManager.seenCustomTag(taglet.getName());
-                output.addContent(currentOutput);
+                output.add(currentOutput);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,9 +104,9 @@ public class ThrowsTaglet extends BaseTaglet
                 !alreadyDocumented.contains(utils.getSimpleName(klass)) &&
                 !alreadyDocumented.contains(utils.getFullyQualifiedName(klass))) {
                 if (alreadyDocumented.isEmpty()) {
-                    result.addContent(writer.getThrowsHeader());
+                    result.add(writer.getThrowsHeader());
                 }
-                result.addContent(writer.throwsTagOutput(declaredExceptionType));
+                result.add(writer.throwsTagOutput(declaredExceptionType));
                 alreadyDocumented.add(utils.getSimpleName(klass));
             }
         }
@@ -140,7 +140,7 @@ public class ThrowsTaglet extends BaseTaglet
                     declaredExceptionTags.put(inheritedDoc.tagList, (ExecutableElement)inheritedDoc.holder);
                 }
             }
-            result.addContent(throwsTagsOutput(declaredExceptionTags, writer, alreadyDocumented, false));
+            result.add(throwsTagsOutput(declaredExceptionTags, writer, alreadyDocumented, false));
         }
         return result;
     }
@@ -156,11 +156,11 @@ public class ThrowsTaglet extends BaseTaglet
         Content result = writer.getOutputInstance();
         HashSet<String> alreadyDocumented = new HashSet<>();
         if (!tagsMap.isEmpty()) {
-            result.addContent(throwsTagsOutput(tagsMap, writer, alreadyDocumented, true));
+            result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, true));
         }
-        result.addContent(inheritThrowsDocumentation(holder,
+        result.add(inheritThrowsDocumentation(holder,
             execHolder.getThrownTypes(), alreadyDocumented, writer));
-        result.addContent(linkToUndocumentedDeclaredExceptions(
+        result.add(linkToUndocumentedDeclaredExceptions(
             execHolder.getThrownTypes(), alreadyDocumented, writer));
         return result;
     }
@@ -192,9 +192,9 @@ public class ThrowsTaglet extends BaseTaglet
                         continue;
                     }
                     if (alreadyDocumented.isEmpty()) {
-                        result.addContent(writer.getThrowsHeader());
+                        result.add(writer.getThrowsHeader());
                     }
-                    result.addContent(writer.throwsTagOutput(e, dt));
+                    result.add(writer.throwsTagOutput(e, dt));
                     alreadyDocumented.add(te != null
                             ? utils.getFullyQualifiedName(te)
                             : excName);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ public class UserTaglet implements Taglet {
      */
     public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer){
         Content output = writer.getOutputInstance();
-        output.addContent(new RawHtml(userTaglet.toString(Collections.singletonList(tag), element)));
+        output.add(new RawHtml(userTaglet.toString(Collections.singletonList(tag), element)));
         return output;
     }
 
@@ -146,7 +146,7 @@ public class UserTaglet implements Taglet {
         if (!tags.isEmpty()) {
             String tagString = userTaglet.toString(tags, holder);
             if (tagString != null) {
-                output.addContent(new RawHtml(tagString));
+                output.add(new RawHtml(tagString));
             }
         }
         return output;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public abstract class LinkFactory {
                 // handles primitives, no types and error types
                 @Override
                 protected Content defaultAction(TypeMirror type, LinkInfo linkInfo) {
-                    link.addContent(utils.getTypeName(type, false));
+                    link.add(utils.getTypeName(type, false));
                     return link;
                 }
 
@@ -96,14 +96,14 @@ public abstract class LinkFactory {
                     currentDepth--;
                     if (utils.isAnnotated(type)) {
                         linkInfo.type = type;
-                        link.addContent(" ");
-                        link.addContent(getTypeAnnotationLinks(linkInfo));
+                        link.add(" ");
+                        link.add(getTypeAnnotationLinks(linkInfo));
                     }
                     // use vararg if required
                     if (linkInfo.isVarArg && currentDepth == 0) {
-                        link.addContent("...");
+                        link.add("...");
                     } else {
-                        link.addContent("[]");
+                        link.add("[]");
                     }
                     return link;
                 }
@@ -111,25 +111,25 @@ public abstract class LinkFactory {
                 @Override
                 public Content visitWildcard(WildcardType type, LinkInfo linkInfo) {
                     linkInfo.isTypeBound = true;
-                    link.addContent("?");
+                    link.add("?");
                     TypeMirror extendsBound = type.getExtendsBound();
                     if (extendsBound != null) {
-                        link.addContent(" extends ");
+                        link.add(" extends ");
                         setBoundsLinkInfo(linkInfo, extendsBound);
-                        link.addContent(getLink(linkInfo));
+                        link.add(getLink(linkInfo));
                     }
                     TypeMirror superBound = type.getSuperBound();
                     if (superBound != null) {
-                        link.addContent(" super ");
+                        link.add(" super ");
                         setBoundsLinkInfo(linkInfo, superBound);
-                        link.addContent(getLink(linkInfo));
+                        link.add(getLink(linkInfo));
                     }
                     return link;
                 }
 
                 @Override
                 public Content visitTypeVariable(TypeVariable type, LinkInfo linkInfo) {
-                    link.addContent(getTypeAnnotationLinks(linkInfo));
+                    link.add(getTypeAnnotationLinks(linkInfo));
                     linkInfo.isTypeBound = true;
                     TypeVariable typevariable = (utils.isArrayType(type))
                             ? (TypeVariable) componentType
@@ -138,12 +138,12 @@ public abstract class LinkFactory {
                     if ((!linkInfo.excludeTypeParameterLinks) && utils.isTypeElement(owner)) {
                         linkInfo.typeElement = (TypeElement) owner;
                         Content label = newContent();
-                        label.addContent(utils.getTypeName(type, false));
+                        label.add(utils.getTypeName(type, false));
                         linkInfo.label = label;
-                        link.addContent(getClassLink(linkInfo));
+                        link.add(getClassLink(linkInfo));
                     } else {
                         // No need to link method type parameters.
-                        link.addContent(utils.getTypeName(typevariable, false));
+                        link.add(utils.getTypeName(typevariable, false));
                     }
 
                     if (!linkInfo.excludeTypeBounds) {
@@ -159,9 +159,9 @@ public abstract class LinkFactory {
                                     !utils.isAnnotated(bound)) {
                                 continue;
                             }
-                            link.addContent(more ? " & " : " extends ");
+                            link.add(more ? " & " : " extends ");
                             setBoundsLinkInfo(linkInfo, bound);
-                            link.addContent(getLink(linkInfo));
+                            link.add(getLink(linkInfo));
                             more = true;
                         }
                     }
@@ -173,16 +173,16 @@ public abstract class LinkFactory {
                     if (linkInfo.isTypeBound && linkInfo.excludeTypeBoundsLinks) {
                         // Since we are excluding type parameter links, we should not
                         // be linking to the type bound.
-                        link.addContent(utils.getTypeName(type, false));
-                        link.addContent(getTypeParameterLinks(linkInfo));
+                        link.add(utils.getTypeName(type, false));
+                        link.add(getTypeParameterLinks(linkInfo));
                         return link;
                     } else {
                         link = newContent();
-                        link.addContent(getTypeAnnotationLinks(linkInfo));
+                        link.add(getTypeAnnotationLinks(linkInfo));
                         linkInfo.typeElement = utils.asTypeElement(type);
-                        link.addContent(getClassLink(linkInfo));
+                        link.add(getClassLink(linkInfo));
                         if (linkInfo.includeTypeAsSepLink) {
-                            link.addContent(getTypeParameterLinks(linkInfo, false));
+                            link.add(getTypeParameterLinks(linkInfo, false));
                         }
                     }
                     return link;
@@ -191,9 +191,9 @@ public abstract class LinkFactory {
             return linkVisitor.visit(linkInfo.type, linkInfo);
         } else if (linkInfo.typeElement != null) {
             Content link = newContent();
-            link.addContent(getClassLink(linkInfo));
+            link.add(getClassLink(linkInfo));
             if (linkInfo.includeTypeAsSepLink) {
-                link.addContent(getTypeParameterLinks(linkInfo, false));
+                link.add(getTypeParameterLinks(linkInfo, false));
             }
             return link;
         } else {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -145,11 +145,11 @@ public abstract class LinkInfo {
             return label;
         } else if (isLinkable()) {
             Content tlabel = newContent();
-            tlabel.addContent(configuration.utils.getSimpleName(typeElement));
+            tlabel.add(configuration.utils.getSimpleName(typeElement));
             return tlabel;
         } else {
             Content tlabel = newContent();
-            tlabel.addContent(configuration.getClassName(typeElement));
+            tlabel.add(configuration.getClassName(typeElement));
             return tlabel;
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
@@ -107,41 +107,41 @@ public class TestHtmlDocument extends JavadocTester {
                 "subclasses, subinterfaces, nested classes, nested interfaces," +
                 "inheriting from other packages, constructors, fields," +
                 "methods, and so forth. ");
-        p.addContent(bodyContent);
+        p.add(bodyContent);
         StringContent anchorContent = new StringContent("Click Here");
-        p.addContent(HtmlTree.A("testLink.html", anchorContent));
+        p.add(HtmlTree.A("testLink.html", anchorContent));
         StringContent pContent = new StringContent(" to <test> out a link.");
-        p.addContent(pContent);
-        body.addContent(p);
+        p.add(pContent);
+        body.add(p);
         HtmlTree p1 = new HtmlTree(HtmlTag.P);
         // Test another version of A tag.
         HtmlTree anchor = new HtmlTree(HtmlTag.A);
-        anchor.addAttr(HtmlAttr.HREF, "testLink.html");
-        anchor.addAttr(HtmlAttr.ID, "Another version of a tag");
-        p1.addContent(anchor);
-        body.addContent(p1);
+        anchor.put(HtmlAttr.HREF, "testLink.html");
+        anchor.put(HtmlAttr.ID, "Another version of a tag");
+        p1.add(anchor);
+        body.add(p1);
         // Test for empty tags.
         HtmlTree dl = new HtmlTree(HtmlTag.DL);
-        html.addContent(dl);
+        html.add(dl);
         // Test for empty nested tags.
         HtmlTree dlTree = new HtmlTree(HtmlTag.DL);
-        dlTree.addContent(new HtmlTree(HtmlTag.DT));
-        dlTree.addContent(new HtmlTree (HtmlTag.DD));
-        html.addContent(dlTree);
+        dlTree.add(new HtmlTree(HtmlTag.DT));
+        dlTree.add(new HtmlTree (HtmlTag.DD));
+        html.add(dlTree);
         HtmlTree dlDisplay = new HtmlTree(HtmlTag.DL);
-        dlDisplay.addContent(new HtmlTree(HtmlTag.DT));
+        dlDisplay.add(new HtmlTree(HtmlTag.DT));
         HtmlTree dd = new HtmlTree (HtmlTag.DD);
         StringContent ddContent = new StringContent("Test DD");
-        dd.addContent(ddContent);
-        dlDisplay.addContent(dd);
-        body.addContent(dlDisplay);
+        dd.add(ddContent);
+        dlDisplay.add(dd);
+        body.add(dlDisplay);
         StringContent emptyString = new StringContent("");
-        body.addContent(emptyString);
+        body.add(emptyString);
         Comment emptyComment = new Comment("");
-        body.addContent(emptyComment);
+        body.add(emptyComment);
         HtmlTree hr = new HtmlTree(HtmlTag.HR);
-        body.addContent(hr);
-        html.addContent(body);
+        body.add(hr);
+        html.add(body);
         HtmlDocument htmlDoc = new HtmlDocument(htmlDocType, html);
         return htmlDoc.toString();
     }

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
@@ -75,31 +75,31 @@ public class TestHtmlDocument extends JavadocTester {
         HtmlTree title = new HtmlTree(HtmlTag.TITLE);
         // String content within the document
         StringContent titleContent = new StringContent("Markup test");
-        title.addContent(titleContent);
-        head.addContent(title);
+        title.add(titleContent);
+        head.add(title);
         // Test META tag
         HtmlTree meta = new HtmlTree(HtmlTag.META);
-        meta.addAttr(HtmlAttr.NAME, "keywords");
-        meta.addAttr(HtmlAttr.CONTENT, "testContent");
-        head.addContent(meta);
+        meta.put(HtmlAttr.NAME, "keywords");
+        meta.put(HtmlAttr.CONTENT, "testContent");
+        head.add(meta);
         // Test invalid META tag
         HtmlTree invmeta = new HtmlTree(HtmlTag.META);
-        head.addContent(invmeta);
+        head.add(invmeta);
         // Test LINK tag
         HtmlTree link = new HtmlTree(HtmlTag.LINK);
-        link.addAttr(HtmlAttr.REL, "testRel");
-        link.addAttr(HtmlAttr.HREF, "testLink.html");
-        head.addContent(link);
+        link.put(HtmlAttr.REL, "testRel");
+        link.put(HtmlAttr.HREF, "testLink.html");
+        head.add(link);
         // Test invalid LINK tag
         HtmlTree invlink = new HtmlTree(HtmlTag.LINK);
-        head.addContent(invlink);
-        html.addContent(head);
+        head.add(invlink);
+        html.add(head);
         // Comment within the document
         Comment bodyMarker = new Comment("======== START OF BODY ========");
-        html.addContent(bodyMarker);
+        html.add(bodyMarker);
         HtmlTree body = new HtmlTree(HtmlTag.BODY);
         Comment pMarker = new Comment("======== START OF PARAGRAPH ========");
-        body.addContent(pMarker);
+        body.add(pMarker);
         HtmlTree p = new HtmlTree(HtmlTag.P);
         StringContent bodyContent = new StringContent(
                 "This document is generated from sample source code and HTML " +


### PR DESCRIPTION
Backport of [JDK-8220202](https://bugs.openjdk.org/browse/JDK-8220202)
- This PR contains 2 commits
- Commit 1: is the git apply from the original commit
- Commit 2: is trying to aplly the rejected changes. Although it contains many files, well it only contains 3 types of changes:
  - Change type A. Change method name from `addContent` to `add`
  - Change type B. Change method name from `addAttr` to `put`
  - Change type C. Add missing `import` to fix compile error

Testing
- Local: Test passed
  - `TestHtmlDocument.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-22`
  - Automated jtreg test: jtreg_langtools
  - `jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java`: SUCCESSFUL GitHub 📊⏲ - [761 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8220202](https://bugs.openjdk.org/browse/JDK-8220202) needs maintainer approval

### Issue
 * [JDK-8220202](https://bugs.openjdk.org/browse/JDK-8220202): Simplify/standardize method naming for HtmlTree (**Enhancement** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2674/head:pull/2674` \
`$ git checkout pull/2674`

Update a local copy of the PR: \
`$ git checkout pull/2674` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2674`

View PR using the GUI difftool: \
`$ git pr show -t 2674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2674.diff">https://git.openjdk.org/jdk11u-dev/pull/2674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2674#issuecomment-2067874893)