### PR TITLE
8306031: Update IANA Language Subtag Registry to Version 2023-04-13

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-03-22
+File-Date: 2023-04-13
 %%
 Type: language
 Subtag: aa
@@ -42986,7 +42986,7 @@ Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
 Deprecated: 2023-03-17
-Preferred-Value: apc
+Preferred-Value: ajp
 Prefix: ar
 Macrolanguage: ar
 %%

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761
+ *      8258795 8267038 8287180 8302512 8304761 8306031
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-03-22) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-04-13) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */
@@ -44,7 +44,7 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
         + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
         + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";


### PR DESCRIPTION
This PR contains a backport of
https://git.openjdk.org/jdk/commit/00b1eacad6ae2d5ea5afb1de506768e9ab960743
Patch is not clean, because this class EquivMapsGenerator.java includes the toList() method but jdk11 not have.
Other than these the rest of the code is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306031](https://bugs.openjdk.org/browse/JDK-8306031) needs maintainer approval

### Issue
 * [JDK-8306031](https://bugs.openjdk.org/browse/JDK-8306031): Update IANA Language Subtag Registry to Version 2023-04-13 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2678/head:pull/2678` \
`$ git checkout pull/2678`

Update a local copy of the PR: \
`$ git checkout pull/2678` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2678`

View PR using the GUI difftool: \
`$ git pr show -t 2678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2678.diff">https://git.openjdk.org/jdk11u-dev/pull/2678.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2678#issuecomment-2071894308)