### PR TITLE
8223737: HostsFileNameService doesn't handle IPv6 literal addresses correctly

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Arrays;
 
 import jdk.internal.misc.JavaNetInetAddressAccess;
 import jdk.internal.misc.SharedSecrets;
@@ -1115,22 +1116,6 @@ class InetAddress implements java.io.Serializable {
                 }
             }
             return hostAddr;
-        }
-
-        /**
-         * IP Address to host mapping
-         * use first host alias in list
-         */
-        private String extractHost(String hostEntry, String addrString) {
-            String[] mapping = hostEntry.split("\\s+");
-            String host = null;
-
-            if (mapping.length >= 2) {
-                if (mapping[0].equalsIgnoreCase(addrString)) {
-                    host = mapping[1];
-                }
-            }
-            return host;
         }
     }
 

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -991,7 +991,6 @@ class InetAddress implements java.io.Serializable {
             String hostEntry;
             String host = null;
 
-            String addrString = addrToString(addr);
             try (Scanner hostsFileScanner = new Scanner(new File(hostsFile),
                                                         UTF_8.INSTANCE))
             {
@@ -999,23 +998,23 @@ class InetAddress implements java.io.Serializable {
                     hostEntry = hostsFileScanner.nextLine();
                     if (!hostEntry.startsWith("#")) {
                         hostEntry = removeComments(hostEntry);
-                        if (hostEntry.contains(addrString)) {
-                            host = extractHost(hostEntry, addrString);
-                            if (host != null) {
-                                break;
-                            }
+                        String[] mapping = hostEntry.split("\\s+");
+                        if (mapping.length >= 2 &&
+                            Arrays.equals(addr, createAddressByteArray(mapping[0]))) {
+                            host = mapping[1];
+                            break;
                         }
                     }
                 }
             } catch (IOException e) {
                 throw new UnknownHostException("Unable to resolve address "
-                        + addrString + " as hosts file " + hostsFile
+                        + Arrays.toString(addr) + " as hosts file " + hostsFile
                         + " not found ");
             }
 
             if ((host == null) || (host.equals("")) || (host.equals(" "))) {
                 throw new UnknownHostException("Requested address "
-                        + addrString
+                        + Arrays.toString(addr)
                         + " resolves to an invalid entry in hosts file "
                         + hostsFile);
             }

--- a/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
+++ b/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
@@ -56,19 +56,28 @@ public class InternalNameServiceWithHostsFileTest {
         byte[] expectedIpv6LocalhostAddress = { 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 1 };
 
-        try {
-            // 10.2.3.4  testHost.testDomain
-            testHostsMapping(expectedIpv4Address, "testHost.testDomain");
-            // ::1     ip6-localhost ip6-loopback
-            testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
-            // fe00::0 ip6-localnet
-            testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
-            // fe80::1 link-local-host
-            testHostsMapping(expectedIpv6Address, "link-local-host");
+        // 10.2.3.4  testHost.testDomain
+        testHostsMapping(expectedIpv4Address, "testHost.testDomain");
+        // ::1     ip6-localhost ip6-loopback
+        testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
+        // fe00::0 ip6-localnet
+        testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
+        // fe80::1 link-local-host
+        testHostsMapping(expectedIpv6Address, "link-local-host");
 
-        } catch (UnknownHostException uhEx) {
-            System.out.println("UHE unexpected caught == " + uhEx.getMessage());
-        }
+        testReverseLookup("10.2.3.4", "testHost.testDomain");
+
+        testReverseLookup("::1", "ip6-localhost");
+        testReverseLookup("0:0:0:0:0:0:0:1", "ip6-localhost");
+        testReverseLookup("0000:0000:0000:0000:0000:0000:0000:0001", "ip6-localhost");
+
+        testReverseLookup("fe00::0", "ip6-localnet");
+        testReverseLookup("fe00:0:0:0:0:0:0:0", "ip6-localnet");
+        testReverseLookup("fe00:0000:0000:0000:0000:0000:0000:0000", "ip6-localnet");
+
+        testReverseLookup("fe80::1", "link-local-host");
+        testReverseLookup("fe80:000:0:00:0:000:00:1", "link-local-host");
+        testReverseLookup("fe80:0000:0000:0000:0000:0000:0000:0001", "link-local-host");
     }
 
     private static void testHostsMapping(byte[] expectedIpAddress, String hostName)
@@ -93,5 +102,16 @@ public class InternalNameServiceWithHostsFileTest {
                 + Arrays.toString(rawIpAddress)
                 + " equal to expected address == "
                 + Arrays.toString(expectedIpAddress));
+    }
+
+    private static void testReverseLookup(String numericHost, String expectedName)
+            throws UnknownHostException {
+        String lookupResult = InetAddress.getByName(numericHost).getHostName();
+        if (!expectedName.equals(lookupResult)) {
+            throw new RuntimeException(
+                String.format(
+                    "reverse lookup of \"%s\" is \"%s\", should be \"%s\"\n",
+                    numericHost, lookupResult, expectedName));
+        }
     }
 }


### PR DESCRIPTION
Backport of [JDK-8223737](https://bugs.openjdk.org/browse/JDK-8223737), dependency of [JDK-8314517](https://bugs.openjdk.org/browse/JDK-8314517)

Testing
- Local: Test passed on `MacOS 14.4.1`
  - `InternalNameServiceWithHostsFileTest.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-27`
  - Automated jtreg test: jtreg_jdk_tier2
  - `java/net/InetAddress/InternalNameServiceWithHostsFileTest.java`: SUCCESSFUL GitHub 📊⏲ - [2,513 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8223737](https://bugs.openjdk.org/browse/JDK-8223737) needs maintainer approval

### Issue
 * [JDK-8223737](https://bugs.openjdk.org/browse/JDK-8223737): HostsFileNameService doesn't handle IPv6 literal addresses correctly (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2683/head:pull/2683` \
`$ git checkout pull/2683`

Update a local copy of the PR: \
`$ git checkout pull/2683` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2683`

View PR using the GUI difftool: \
`$ git pr show -t 2683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2683.diff">https://git.openjdk.org/jdk11u-dev/pull/2683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2683#issuecomment-2078379529)