### PR TITLE
8329013: StackOverflowError when starting Apache Tomcat with signed jar

### DIFF
--- a/src/java.base/share/classes/jdk/internal/event/EventHelper.java
+++ b/src/java.base/share/classes/jdk/internal/event/EventHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package jdk.internal.event;
 
 import jdk.internal.misc.JavaUtilJarAccess;
 import jdk.internal.misc.SharedSecrets;
+import jdk.internal.misc.ThreadTracker;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;

--- a/src/java.base/share/classes/jdk/internal/event/EventHelper.java
+++ b/src/java.base/share/classes/jdk/internal/event/EventHelper.java
@@ -130,6 +130,18 @@ public final class EventHelper {
         }
     }
 
+    private static class ThreadTrackHolder {
+        static final ThreadTracker TRACKER = new ThreadTracker();
+    }
+
+    private static Object tryBeginLookup() {
+        return ThreadTrackHolder.TRACKER.tryBegin();
+    }
+
+    private static void endLookup(Object key) {
+        ThreadTrackHolder.TRACKER.end(key);
+    }
+
     /**
      * Helper to determine if security events are being logged
      * at a preconfigured logging level. The configuration value
@@ -138,14 +150,20 @@ public final class EventHelper {
      * @return boolean indicating whether an event should be logged
      */
     public static boolean isLoggingSecurity() {
-        // Avoid a bootstrap issue where the commitEvent attempts to
-        // trigger early loading of System Logger but where
-        // the verification process still has JarFiles locked
-        if (securityLogger == null && !JUJA.isInitializing()) {
-            LOGGER_HANDLE.compareAndSet( null, System.getLogger(SECURITY_LOGGER_NAME));
-            loggingSecurity = securityLogger.isLoggable(LOG_LEVEL);
+        Object key;
+        // Avoid bootstrap issues where
+        // * commitEvent triggers early loading of System Logger but where
+        //   the verification process still has JarFiles locked
+        // * the loading of the logging libraries involves recursive
+        //   calls to security libraries triggering recursion
+        if (securityLogger == null && !JUJA.isInitializing() && (key = tryBeginLookup()) != null) {
+            try {
+                LOGGER_HANDLE.compareAndSet(null, System.getLogger(SECURITY_LOGGER_NAME));
+                loggingSecurity = securityLogger.isLoggable(LOG_LEVEL);
+            } finally {
+                endLookup(key);
+            }
         }
         return loggingSecurity;
     }
-
 }

--- a/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
+++ b/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.misc;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks threads to help detect reentrancy without using ThreadLocal variables.
+ * A thread invokes the {@code begin} or {@code tryBegin} methods at the start
+ * of a block, and the {@code end} method at the end of a block.
+ */
+public class ThreadTracker {
+
+    /**
+     * A reference to a Thread that is suitable for use as a key in a collection.
+     * The hashCode/equals methods do not invoke the Thread hashCode/equals method
+     * as they may run arbitrary code and/or leak references to Thread objects.
+     */
+    private record ThreadRef(Thread thread) {
+        @Override
+        public int hashCode() {
+            return Long.hashCode(thread.threadId());
+        }
+        @Override
+        public boolean equals(Object obj) {
+            return (obj instanceof ThreadRef other)
+                    && this.thread == other.thread;
+        }
+    }
+
+    private final Set<ThreadRef> threads = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Adds the current thread to thread set if not already in the set.
+     * Returns a key to remove the thread or {@code null} if already in the set.
+     */
+    public Object tryBegin() {
+        var threadRef = new ThreadRef(Thread.currentThread());
+        return threads.add(threadRef) ? threadRef : null;
+    }
+
+    /**
+     * Adds the current thread to thread set if not already in the set.
+     * Returns a key to remove the thread.
+     */
+    public Object begin() {
+        var threadRef = new ThreadRef(Thread.currentThread());
+        boolean added = threads.add(threadRef);
+        assert added;
+        return threadRef;
+    }
+
+    /**
+     * Removes the thread identified by the key from the thread set.
+     */
+    public void end(Object key) {
+        var threadRef = (ThreadRef) key;
+        assert threadRef.thread() == Thread.currentThread();
+        boolean removed = threads.remove(threadRef);
+        assert removed;
+    }
+
+    /**
+     * Returns true if the given thread is tracked.
+     */
+    public boolean contains(Thread thread) {
+        var threadRef = new ThreadRef(thread);
+        return threads.contains(threadRef);
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
+++ b/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
@@ -39,7 +39,7 @@ public class ThreadTracker {
      * The hashCode/equals methods do not invoke the Thread hashCode/equals method
      * as they may run arbitrary code and/or leak references to Thread objects.
      */
-    private class ThreadRef {
+    private final class ThreadRef {
         private final Thread thread;
 
         ThreadRef(Thread thread) {

--- a/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
+++ b/src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java
@@ -39,15 +39,25 @@ public class ThreadTracker {
      * The hashCode/equals methods do not invoke the Thread hashCode/equals method
      * as they may run arbitrary code and/or leak references to Thread objects.
      */
-    private record ThreadRef(Thread thread) {
+    private class ThreadRef {
+        private final Thread thread;
+
+        ThreadRef(Thread thread) {
+            this.thread = thread;
+        }
+
+        Thread thread() {
+            return this.thread;
+        }
+
         @Override
         public int hashCode() {
-            return Long.hashCode(thread.threadId());
+            return Long.hashCode(thread.getId());
         }
         @Override
         public boolean equals(Object obj) {
-            return (obj instanceof ThreadRef other)
-                    && this.thread == other.thread;
+            return (obj instanceof ThreadRef)
+                    && this.thread == ((ThreadRef)obj).thread;
         }
     }
 

--- a/test/jdk/jdk/security/logging/RecursiveEventHelper.java
+++ b/test/jdk/jdk/security/logging/RecursiveEventHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.logging.*;
+
+import jdk.internal.event.EventHelper;
+
+/*
+ * @test
+ * @bug 8329013
+ * @summary StackOverflowError when starting Apache Tomcat with signed jar
+ * @modules java.base/jdk.internal.event:+open
+ * @run main/othervm -Xmx32m -Djava.util.logging.manager=RecursiveEventHelper RecursiveEventHelper
+ */
+public class RecursiveEventHelper extends LogManager {
+    // an extra check to ensure the custom manager is in use
+    static volatile boolean customMethodCalled;
+
+    public static void main(String[] args) throws Exception {
+        String classname = System.getProperty("java.util.logging.manager");
+        if (!classname.equals("RecursiveEventHelper")) {
+            throw new RuntimeException("java.util.logging.manager not set");
+        }
+
+        // this call will trigger initialization of logging framework
+        // which will call into our custom LogManager and use the
+        // custom getProperty method below. EventHelper.isLoggingSecurity()
+        // is also on the code path of original report and triggers
+        // similar recursion.
+        System.getLogger("testLogger");
+        if (!customMethodCalled) {
+            throw new RuntimeException("Method not called");
+        }
+    }
+
+    @Override
+    public String getProperty(String p) {
+        // this call mimics issue reported in initial bug report where
+        // opening of a signed jar during System logger initialization triggered
+        // a recursive call (via EventHelper.isLoggingSecurity) back into
+        // logger API
+        EventHelper.isLoggingSecurity();
+        customMethodCalled = true;
+        return super.getProperty(p);
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8329013](https://bugs.openjdk.org/browse/JDK-8329013)
- This PR contains two commits
- commit 1:
  - is the original git apply
  - and the `src/java.base/share/classes/jdk/internal/misc/ThreadTracker.java` file needed by this PR
    - The `ThreadTracker.java` class was added by https://github.com/openjdk/jdk/commit/9583e3657e43cc1c6f2101a64534564db2a9bd84 , which is pretty big for `Virtual Threads` ([JDK-8284161](https://bugs.openjdk.org/browse/JDK-8284161)) and we have no intention to back port this change to Java 11 right now
    - So here we simply copy the current code of `ThreadTracker.java` to `jdk11u-dev`
- commit 2:
  - Manual merge of `src/java.base/share/classes/jdk/internal/event/EventHelper.java` based on the `EventHelper.java.rej` file. The change to this file can be `considered as clean`.
  - Fix java 11 compile error for `ThreadTracker.java`
- commit 3: The Inner Class `ThreadRef` for the original `Record` type should be `final`

Testing
- Local: Test passed
  - `RecursiveEventHelper.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-28`
  - Automated jtreg test: jtreg_jdk_tier2
  - `jdk/security/logging/RecursiveEventHelper.java`: SUCCESSFUL GitHub 📊⏲ - [2,152 msec]
- Testing Machine with commit 3: SAP nightlies passed on `2024-05-04`
  - Automated jtreg test: jtreg_jdk_tier2
  - jdk/security/logging/RecursiveEventHelper.java: SUCCESSFUL GitHub 📊⏲ - [2,301 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329013](https://bugs.openjdk.org/browse/JDK-8329013) needs maintainer approval

### Issue
 * [JDK-8329013](https://bugs.openjdk.org/browse/JDK-8329013): StackOverflowError when starting Apache Tomcat with signed jar (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2687/head:pull/2687` \
`$ git checkout pull/2687`

Update a local copy of the PR: \
`$ git checkout pull/2687` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2687`

View PR using the GUI difftool: \
`$ git pr show -t 2687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2687.diff">https://git.openjdk.org/jdk11u-dev/pull/2687.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2687#issuecomment-2080084463)