### PR TITLE
8294137: Review running times of java.math tests

### DIFF
--- a/test/jdk/java/math/BigInteger/BigIntegerTest.java
+++ b/test/jdk/java/math/BigInteger/BigIntegerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1212,6 +1212,17 @@ public class BigIntegerTest {
      *
      */
     public static void main(String[] args) throws Exception {
+        // subset zero indicates to run all subsets
+        int subset = Integer.valueOf(System.getProperty("subset",
+            String.valueOf(1 + random.nextInt(3))));
+        if (subset < 0 || subset > 3) {
+            throw new RuntimeException("Unknown subset " + subset);
+        }
+        if (subset == 0)
+            System.out.println("Testing all subsets");
+        else
+            System.out.println("Testing subset " + subset);
+
         // Some variables for sizing test numbers in bits
         int order1 = ORDER_MEDIUM;
         int order2 = ORDER_SMALL;
@@ -1227,52 +1238,57 @@ public class BigIntegerTest {
         if (args.length >3)
             order4 = (int)((Integer.parseInt(args[3]))* 3.333);
 
-        constructor();
+        if (subset == 0 || subset == 1) {
+            constructor();
 
-        prime();
-        nextProbablePrime();
+            prime();
+            nextProbablePrime();
 
-        arithmetic(order1);   // small numbers
-        arithmetic(order3);   // Karatsuba range
-        arithmetic(order4);   // Toom-Cook / Burnikel-Ziegler range
+            arithmetic(order1);   // small numbers
+            arithmetic(order3);   // Karatsuba range
+            arithmetic(order4);   // Toom-Cook / Burnikel-Ziegler range
 
-        divideAndRemainder(order1);   // small numbers
-        divideAndRemainder(order3);   // Karatsuba range
-        divideAndRemainder(order4);   // Toom-Cook / Burnikel-Ziegler range
+            divideAndRemainder(order1);   // small numbers
+            divideAndRemainder(order3);   // Karatsuba range
+            divideAndRemainder(order4);   // Toom-Cook / Burnikel-Ziegler range
 
-        pow(order1);
-        pow(order3);
-        pow(order4);
+            pow(order1);
+            pow(order3);
+            pow(order4);
 
-        square(ORDER_MEDIUM);
-        square(ORDER_KARATSUBA_SQUARE);
-        square(ORDER_TOOM_COOK_SQUARE);
+            square(ORDER_MEDIUM);
+            square(ORDER_KARATSUBA_SQUARE);
+            square(ORDER_TOOM_COOK_SQUARE);
 
-        squareRoot();
-        squareRootAndRemainder();
+            squareRoot();
+            squareRootAndRemainder();
 
-        bitCount();
-        bitLength();
-        bitOps(order1);
-        bitwise(order1);
+            bitCount();
+            bitLength();
+            bitOps(order1);
+            bitwise(order1);
 
-        shift(order1);
+            shift(order1);
 
-        byteArrayConv(order1);
+            byteArrayConv(order1);
 
-        modInv(order1);   // small numbers
-        modInv(order3);   // Karatsuba range
-        modInv(order4);   // Toom-Cook / Burnikel-Ziegler range
+            modInv(order1);   // small numbers
+            modInv(order3);   // Karatsuba range
+        }
+        if (subset == 0 || subset == 2) {
+            modInv(order4);   // Toom-Cook / Burnikel-Ziegler range
 
-        modExp(order1, order2);
-        modExp2(order1);
+            modExp(order1, order2);
+            modExp2(order1);
+        }
+        if (subset == 0 || subset == 3) {
+            stringConv();
+            serialize();
 
-        stringConv();
-        serialize();
-
-        multiplyLarge();
-        squareLarge();
-        divideLarge();
+            multiplyLarge();
+            squareLarge();
+            divideLarge();
+        }
 
         if (failure)
             throw new RuntimeException("Failure in BigIntegerTest.");

--- a/test/jdk/java/math/BigInteger/LargeValueExceptions.java
+++ b/test/jdk/java/math/BigInteger/LargeValueExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  */
 import java.math.BigInteger;
 import static java.math.BigInteger.ONE;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 //
@@ -61,6 +63,13 @@ public class LargeValueExceptions {
 
     // Half BigInteger.MAX_MAG_LENGTH
     private static final int MAX_INTS_HALF = MAX_INTS / 2;
+
+    // Print the run time of each sub-test in milliseconds
+    @AfterMethod
+    public void getRunTime(ITestResult tr) {
+        long time = tr.getEndMillis() - tr.getStartMillis();
+        System.out.printf("Run time: %d ms%n", time);
+    }
 
     // --- squaring ---
 

--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ public class SymmetricRangeTests {
 
     private static final BigInteger MAX_VALUE = makeMaxValue();
     private static final BigInteger MIN_VALUE = MAX_VALUE.negate();
+
+    private static final Random RANDOM = RandomFactory.getRandom();
 
     private static BigInteger makeMaxValue() {
         byte[] ba = new byte[1 << 28];
@@ -117,8 +119,7 @@ public class SymmetricRangeTests {
         System.out.println("Testing overflow in BitSieve.sieveSingle");
         int bitLength = (5 << 27) - 1;
         try {
-            Random random = RandomFactory.getRandom();
-            BigInteger actual = new BigInteger(bitLength, 0, random);
+            BigInteger actual = new BigInteger(bitLength, 0, RANDOM);
             throw new RuntimeException("new BigInteger(bitLength, 0, null).bitLength()=" + actual.bitLength());
         } catch (ArithmeticException e) {
             // expected
@@ -621,45 +622,64 @@ public class SymmetricRangeTests {
     }
 
     public static void main(String... args) {
-        testOverflowInMakePositive();
-        testBug8021204();
-        testOverflowInBitSieve();
-        testAdd();
-        testSubtract();
-        testMultiply();
-        testDivide();
-        testDivideAndRemainder();
-        testBug9005933();
-        testRemainder();
-        testPow();
-        testGcd();
-        testAbs();
-        testNegate();
-        testMod();
-        testModPow();
-//        testModInverse();
-        testShiftLeft();
-        testShiftRight();
-        testAnd();
-        testOr();
-        testXor();
-        testNot();
-        testSetBit();
-        testClearBit();
-        testFlipBit();
-        testGetLowestSetBit();
-        testBitLength();
-        testBitCount();
-        testToString();
-        testToByteArrayWithConstructor();
-        testIntValue();
-        testLongValue();
-        testFloatValue();
-        testDoubleValue();
-        testSerialization();
-        testLongValueExact();
-        testIntValueExact();
-        testShortValueExact();
-        testByteValueExact();
+        // subset zero indicates to run all subsets
+        int subset = Integer.valueOf(System.getProperty("subset",
+            String.valueOf(1 + RANDOM.nextInt(4))));
+        if (subset < 0 || subset > 4) {
+            throw new RuntimeException("Unknown subset " + subset);
+        }
+        if (subset == 0)
+            System.out.println("Testing all subsets");
+        else
+            System.out.println("Testing subset " + subset);
+
+        if (subset == 0 || subset == 1) {
+            testOverflowInMakePositive();
+            testBug8021204();
+            testOverflowInBitSieve();
+            testAdd();
+            testSubtract();
+        }
+        if (subset == 0 || subset == 2) {
+            testMultiply();
+            testDivide();
+            testDivideAndRemainder();
+            testBug9005933();
+        }
+        if (subset == 0 || subset == 3) {
+            testRemainder();
+            testPow();
+            testGcd();
+            testAbs();
+            testNegate();
+            testMod();
+            testModPow();
+            //        testModInverse();
+            testShiftLeft();
+            testShiftRight();
+            testAnd();
+            testOr();
+            testXor();
+            testNot();
+            testSetBit();
+            testClearBit();
+            testFlipBit();
+            testGetLowestSetBit();
+            testBitLength();
+            testBitCount();
+        }
+        if (subset == 0 || subset == 4) {
+            testToString();
+            testToByteArrayWithConstructor();
+            testIntValue();
+            testLongValue();
+            testFloatValue();
+            testDoubleValue();
+            testSerialization();
+            testLongValueExact();
+            testIntValueExact();
+            testShortValueExact();
+            testByteValueExact();
+        }
     }
 }


### PR DESCRIPTION
Backport of [JDK-8294137](https://bugs.openjdk.org/browse/JDK-8294137)

Testing
- Local: Test passed
  - `BigIntegerTest.java`: Test results: passed: 1
  - `LargeValueExceptions.java`: Test results: passed: 1
  - `SymmetricRangeTests.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-28`
  - Automated jtreg test: jtreg_jdk_tier1
  - java/math/BigInteger/BigIntegerTest.java: SUCCESSFUL GitHub 📊⏲ - [63,694 msec]
  - java/math/BigInteger/LargeValueExceptions.java: SUCCESSFUL GitHub 📊⏲ - [10,753 msec]
  - java/math/BigInteger/largeMemory/SymmetricRangeTests.java: SUCCESSFUL GitHub 📊⏲ - [79,390 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8294137](https://bugs.openjdk.org/browse/JDK-8294137) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294137](https://bugs.openjdk.org/browse/JDK-8294137): Review running times of java.math tests (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2689/head:pull/2689` \
`$ git checkout pull/2689`

Update a local copy of the PR: \
`$ git checkout pull/2689` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2689`

View PR using the GUI difftool: \
`$ git pr show -t 2689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2689.diff">https://git.openjdk.org/jdk11u-dev/pull/2689.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2689#issuecomment-2080169728)