### PR TITLE
8315889: Open source several Swing HTMLDocument  related tests

### DIFF
--- a/test/jdk/javax/swing/text/html/HTMLDocument/bug4226914.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/bug4226914.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import javax.swing.JEditorPane;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+/*
+ * @test
+ * @bug 4226914
+ * @summary Tests if HTMLDocument streaming is broken
+ */
+
+public class bug4226914 {
+
+    public static void main(String[] args) throws Exception {
+        ObjectOutputStream oos = null;
+        try {
+            JEditorPane jtp = new JEditorPane("text/html", "<html></html>");
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            oos = new ObjectOutputStream(baos);
+            oos.writeObject(jtp.getDocument());
+            oos.flush();
+            baos.toByteArray();
+        } finally {
+            if (oos != null) {
+                oos.close();
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLDocument/bug4251593.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/bug4251593.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.ActionEvent;
+import javax.swing.Action;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+
+/*
+ * @test
+ * @bug 4251593
+ * @summary Tests that hyperlinks can be inserted into JTextPane
+ *          via InsertHTMLTextAction.
+ */
+
+public class bug4251593 {
+    private static JTextPane editor;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            editor = new JTextPane();
+            editor.setContentType("text/html");
+            editor.setEditable(true);
+
+            int beforeLen = editor.getDocument().getLength();
+
+            String href = "<a HREF=\"https://java.sun.com\">javasoft </a>";
+            Action a = new HTMLEditorKit.InsertHTMLTextAction("Tester", href, HTML.Tag.BODY, HTML.Tag.A);
+            a.actionPerformed(new ActionEvent(editor, 0, null));
+
+            int afterLen = editor.getDocument().getLength();
+            try {
+                Thread.sleep(300);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            if ((afterLen - beforeLen) < 8) {
+                throw new RuntimeException("Test Failed: link not inserted!!");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLDocument/bug4687405.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/bug4687405.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.View;
+import javax.swing.text.html.CSS;
+import javax.swing.text.html.HTMLEditorKit;
+
+/*
+ * @test
+ * @bug 4687405
+ * @summary  Tests if HTMLDocument very first paragraph doesn't have top margin.
+ */
+
+public class bug4687405 {
+    private static JEditorPane jep;
+    private static volatile boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(bug4687405::createHTMLEditor);
+        Thread.sleep(200);
+
+        SwingUtilities.invokeAndWait(bug4687405::testEditorPane);
+        Thread.sleep(500);
+
+        if (!passed) {
+            throw new RuntimeException("Test failed!!" +
+                    " Top margin present in HTMLDocument");
+        }
+    }
+
+    public static void createHTMLEditor() {
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+    }
+
+    private static void testEditorPane() {
+        View v = jep.getUI().getRootView(jep);
+        while (!(v instanceof javax.swing.text.html.ParagraphView)) {
+            int n = v.getViewCount();
+            v = v.getView(n - 1);
+        }
+        AttributeSet attrs = v.getAttributes();
+        String marginTop = attrs.getAttribute(CSS.Attribute.MARGIN_TOP).toString();
+        // MARGIN_TOP of the very first paragraph of the default html
+        // document should be 0.
+        passed = "0".equals(marginTop);
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4213373.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4213373.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.text.html.HTMLEditorKit;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/*
+ * @test
+ * @bug 4213373
+ * @summary  Serialization bug on HTMLEditorKit.
+ */
+
+public class bug4213373 {
+
+    public static void main(String[] args) throws Exception {
+        HTMLEditorKit ekr = null;
+        ObjectOutputStream oos = null;
+        ObjectInputStream ois = null;
+
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            HTMLEditorKit ekw = new HTMLEditorKit();
+            oos = new ObjectOutputStream(baos);
+            oos.writeObject(ekw);
+            byte[] buf = baos.toByteArray();
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+            ois = new ObjectInputStream(bais);
+            ekr = (HTMLEditorKit) ois.readObject();
+        } finally {
+           if (oos != null) {
+               oos.close();
+           }
+           if (ois != null) {
+                ois.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8315889](https://bugs.openjdk.org/browse/JDK-8315889)

Testing
- Local: Test passed
  - `bug4226914.java`: Test results: passed: 1
  - `bug4251593.java`: Test results: passed: 1
  - `bug4687405.java`: Test results: passed: 1
  - `bug4213373.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-28`
  - Automated jtreg test: jtreg_jdk_tier4
  - javax/swing/text/html/HTMLDocument/bug4226914.java: SUCCESSFUL GitHub 📊⏲ - [11,588 msec]
  - javax/swing/text/html/HTMLDocument/bug4251593.java: SUCCESSFUL GitHub 📊⏲ - [11,735 msec]
  - javax/swing/text/html/HTMLDocument/bug4687405.java: SUCCESSFUL GitHub 📊⏲ - [11,841 msec]
  - javax/swing/text/html/HTMLEditorKit/bug4213373.java: SUCCESSFUL GitHub 📊⏲ - [9,509 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315889](https://bugs.openjdk.org/browse/JDK-8315889) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315889](https://bugs.openjdk.org/browse/JDK-8315889): Open source several Swing HTMLDocument  related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2690/head:pull/2690` \
`$ git checkout pull/2690`

Update a local copy of the PR: \
`$ git checkout pull/2690` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2690`

View PR using the GUI difftool: \
`$ git pr show -t 2690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2690.diff">https://git.openjdk.org/jdk11u-dev/pull/2690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2690#issuecomment-2080203886)