### PR TITLE
8324733: [macos14] Problem list tests which fail due to macOS bug described in JDK-8322653

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -477,12 +477,15 @@ java/awt/event/KeyEvent/DeadKey/DeadKeyMacOSXInputText.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/deadKeyMacOSX.java 8233568 macosx-all
 java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java 8238720 windows-all
 java/awt/PopupMenu/PopupMenuLocation.java 8238720 windows-all
-java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720 windows-all
-java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720 windows-all
+java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720,8324782 windows-all,macosx-all
+java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720,8324782 windows-all,macosx-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java 8238720 windows-all
 
 # Several tests which fail sometimes on macos11
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
+
+# This test fails on macOS 14
+java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
 ############################################################################
 
@@ -654,6 +657,9 @@ javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,solaris-all,
 ############################################################################
 
 # jdk_imageio
+
+# This test fails on macOS 14
+javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
Backport of [JDK-8324733](https://bugs.openjdk.org/browse/JDK-8324733)
- Manually merged the `ProblemList.txt` file
- This file can be `considered as Clean`
  - the only difference with the original commit is the base line number are different
  - contents are exactly the same

Testing
- Local: Test passed
  - confirmed these 3 tests are failing on MacOS 14.4.1
  - BTW the `SelectNewItemTest.java` does not exist in `jdk11u-dev` yet
- Pipeline: 
- Testing Machine: Not Applicable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324733](https://bugs.openjdk.org/browse/JDK-8324733) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324733](https://bugs.openjdk.org/browse/JDK-8324733): [macos14] Problem list tests which fail due to macOS bug described in JDK-8322653 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2692/head:pull/2692` \
`$ git checkout pull/2692`

Update a local copy of the PR: \
`$ git checkout pull/2692` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2692`

View PR using the GUI difftool: \
`$ git pr show -t 2692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2692.diff">https://git.openjdk.org/jdk11u-dev/pull/2692.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2692#issuecomment-2080313438)