### PR TITLE
8283349: Robustness improvements to java/util/prefs/AddNodeChangeListener.jar

### DIFF
--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,75 +34,88 @@ import java.util.prefs.*;
 public class AddNodeChangeListener {
 
     private static final int SLEEP_ITRS = 10;
+    private static final String N2_STR = "N2";
     private static boolean failed = false;
     private static Preferences userRoot, N2;
     private static NodeChangeListenerAdd ncla;
 
     public static void main(String[] args)
              throws BackingStoreException, InterruptedException {
-        userRoot = Preferences.userRoot();
-        ncla = new NodeChangeListenerAdd();
-        userRoot.addNodeChangeListener(ncla);
-        //Should initiate a node added event
-        addNode();
-        // Should not initiate a node added event
-        addNode();
-        //Should initate a child removed event
-        removeNode();
+        try {
+            userRoot = Preferences.userRoot();
+            // Make sure test node is not present before test
+            clearPrefs();
 
-        if (failed) {
-            throw new RuntimeException("Failed");
+            ncla = new NodeChangeListenerAdd();
+            userRoot.addNodeChangeListener(ncla);
+            //Should initiate a node added event
+            addNode();
+            // Should not initiate a node added event
+            addNode();
+            //Should initate a child removed event
+            removeNode();
+
+            if (failed) {
+                throw new RuntimeException("Failed");
+            }
+        } finally {
+            // Make sure test node is not present after the test
+            clearPrefs();
         }
     }
 
     private static void addNode()
             throws BackingStoreException, InterruptedException {
-        N2 = userRoot.node("N2");
+        N2 = userRoot.node(N2_STR);
         userRoot.flush();
-        int passItr = -1;
-
-        for (int i = 0; i < SLEEP_ITRS; i++) {
-            System.out.print("addNode sleep iteration " + i + "...");
-            Thread.sleep(3000);
-            System.out.println("done.");
-            if (ncla.getAddNumber() == 1) {
-                passItr = i;
-                break;
-            }
-        }
-        checkPassItr(passItr, "addNode()");
+        checkAndSleep(1, "addNode");
     }
 
     private static void removeNode()
             throws BackingStoreException, InterruptedException {
         N2.removeNode();
         userRoot.flush();
-        int passItr = -1;
+        checkAndSleep(0, "removeNode");
+    }
 
+    /* Check for the expected value in the listener (1 after addNode(), 0 after removeNode()).
+     * Sleep a few extra times in a loop, if needed, for debugging purposes, to
+     * see if the event gets delivered late.
+     */
+    private static void checkAndSleep(int expectedListenerVal, String methodName) throws InterruptedException {
+        int expectedItr = -1; // iteration in which the expected value was retrieved from the listener, or -1 if never
         for (int i = 0; i < SLEEP_ITRS; i++) {
-            System.out.print("removeNode sleep iteration " + i + "...");
+            System.out.print(methodName + " sleep iteration " + i + "...");
             Thread.sleep(3000);
             System.out.println("done.");
-            if (ncla.getAddNumber() == 0) {
-                passItr = i;
+            if (ncla.getAddNumber() == expectedListenerVal) {
+                expectedItr = i;
                 break;
             }
         }
-        checkPassItr(passItr, "removeNode()");
-    }
 
-    /* If the listener wasn't notified on iteration 0, throw a RuntimeException
-     * with some contextual information
-     */
-    private static void checkPassItr(int itr, String methodName) {
-        if (itr == 0) {
+        if (expectedItr == 0) {
             System.out.println(methodName + " test passed");
         } else {
             failed = true;
-            if (itr == -1) {
-                throw new RuntimeException("Failed in " + methodName + " - change listener never notified");
+            if (expectedItr == -1) {
+                System.out.println("Failed in " + methodName + " - change listener never notified");
             } else {
-                throw new RuntimeException("Failed in " + methodName + " - listener notified on iteration " + itr);
+                System.out.println("Failed in " + methodName + " - listener notified on iteration " + expectedItr);
+            }
+        }
+    }
+
+    /* Check if the node already exists in userRoot, and remove it if so. */
+    private static void clearPrefs() throws BackingStoreException {
+        if (userRoot.nodeExists(N2_STR)) {
+            System.out.println("Node " + N2_STR + " already/still exists; clearing");
+            Preferences clearNode = userRoot.node(N2_STR);
+            userRoot.flush();
+            clearNode.removeNode();
+            userRoot.flush();
+            if (userRoot.nodeExists(N2_STR)) {
+                throw new RuntimeException("Unable to clear pre-existing node." + (failed ? " Also, the test failed" : ""));
             }
         }
     }


### PR DESCRIPTION
Backport of [JDK-8283349](https://bugs.openjdk.org/browse/JDK-8283349)

Testing
- Local: Test passed
  - `AddNodeChangeListener.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies SKIPPED on `2024-05-02`
  - Automated jtreg test: jtreg_jdk_tier1
  - `java/util/prefs/AddNodeChangeListener.java`: SKIPPED[Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8283349](https://bugs.openjdk.org/browse/JDK-8283349) needs maintainer approval

### Issue
 * [JDK-8283349](https://bugs.openjdk.org/browse/JDK-8283349): Robustness improvements to java/util/prefs/AddNodeChangeListener.jar (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2695/head:pull/2695` \
`$ git checkout pull/2695`

Update a local copy of the PR: \
`$ git checkout pull/2695` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2695`

View PR using the GUI difftool: \
`$ git pr show -t 2695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2695.diff">https://git.openjdk.org/jdk11u-dev/pull/2695.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2695#issuecomment-2086641622)