### PR TITLE
8331643: [11u]: Bump GHA bootstrap JDK to 11.0.23

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,13 +29,13 @@ GTEST_VERSION=1.8.1
 JTREG_VERSION=7.3.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.18_10.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=4a29efda1d702b8ff38e554cf932051f40ec70006caed5c4857a8cbc7a0b7db7
+LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.23_9.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.18_10.zip
-WINDOWS_X64_BOOT_JDK_SHA256=0cfa5991a8e372b3f8eacacbb2a336663ead0cc6ec9c9ab6cd53206602fb0062
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.23_9.zip
+WINDOWS_X64_BOOT_JDK_SHA256=d7a9f8ceee9a5785dcbbcbec20a07b1366efec59ba652ef7e03f6f7d10f52b85
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.18_10.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=75d79315d7265cc4b89fd9e844161ff90798bc6482ace8c1ac75f862a5b3b565
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.23_9.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=4dbd21d9a0311d321f5886eda50c3086026ed61d02e1a85f7b8c2e9ad557bf03


### PR DESCRIPTION
From time to time the GHA bootstrap JDK in the update releases should be bumped. So let's take the current verion 11.0.23 from Temurin.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331643](https://bugs.openjdk.org/browse/JDK-8331643) needs maintainer approval

### Issue
 * [JDK-8331643](https://bugs.openjdk.org/browse/JDK-8331643): [11u]: Bump GHA bootstrap JDK to 11.0.23 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2697/head:pull/2697` \
`$ git checkout pull/2697`

Update a local copy of the PR: \
`$ git checkout pull/2697` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2697`

View PR using the GUI difftool: \
`$ git pr show -t 2697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2697.diff">https://git.openjdk.org/jdk11u-dev/pull/2697.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2697#issuecomment-2092657723)