### PR TITLE
8293563: [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -174,7 +174,7 @@ serviceability/sa/ClhsdbJdis.java 8193639 solaris-all
 serviceability/sa/ClhsdbJhisto.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/ClhsdbJstack.java 8193639 solaris-all
 serviceability/sa/ClhsdbLongConstant.java 8193639 solaris-all
-serviceability/sa/ClhsdbPmap.java 8269982,8294316,8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbPmap.java 8294316,8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-aarch64,macosx-x64
 serviceability/sa/ClhsdbPrintAll.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintAs.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintStatics.java 8193639 solaris-all
@@ -202,8 +202,8 @@ serviceability/sa/TestInstanceKlassSize.java 8193639 solaris-all
 serviceability/sa/TestInstanceKlassSizeForInterface.java 8193639 solaris-all
 serviceability/sa/TestIntConstant.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/TestJhsdbJstackLock.java 8193639 solaris-all
-serviceability/sa/TestJmapCore.java 8269982,8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8269982,8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCore.java 8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
 serviceability/sa/TestPrintMdo.java 8193639 solaris-all
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8191270 generic-all
 serviceability/sa/TestType.java 8193639 solaris-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -174,7 +174,7 @@ serviceability/sa/ClhsdbJdis.java 8193639 solaris-all
 serviceability/sa/ClhsdbJhisto.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/ClhsdbJstack.java 8193639 solaris-all
 serviceability/sa/ClhsdbLongConstant.java 8193639 solaris-all
-serviceability/sa/ClhsdbPmap.java 8294316,8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbPmap.java 8294316,8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-x64
 serviceability/sa/ClhsdbPrintAll.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintAs.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintStatics.java 8193639 solaris-all
@@ -202,8 +202,8 @@ serviceability/sa/TestInstanceKlassSize.java 8193639 solaris-all
 serviceability/sa/TestInstanceKlassSizeForInterface.java 8193639 solaris-all
 serviceability/sa/TestIntConstant.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/TestJhsdbJstackLock.java 8193639 solaris-all
-serviceability/sa/TestJmapCore.java 8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8294316,8193639,8267433 solaris-all,macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCore.java 8294316,8193639,8267433 solaris-all,macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8294316,8193639,8267433 solaris-all,macosx-x64
 serviceability/sa/TestPrintMdo.java 8193639 solaris-all
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8191270 generic-all
 serviceability/sa/TestType.java 8193639 solaris-all

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public class ClhsdbCDSCore {
                 "-Xshare:auto",
                 "-XX:+ProfileInterpreter",
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                CoreUtils.getAlwaysPretouchArg(true),
                 CrashApp.class.getName()
             };
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -85,9 +85,9 @@ public class ClhsdbFindPC {
             theApp = new LingeredAppWithTrivialMain();
             theApp.setForceCrash(withCore);
             if (withXcomp) {
-                LingeredApp.startApp(List.of("-Xcomp"), theApp);
+                LingeredApp.startApp(List.of("-Xcomp", CoreUtils.getAlwaysPretouchArg(withCore)), theApp);
             } else {
-                LingeredApp.startApp(List.of("-Xint"), theApp);
+                LingeredApp.startApp(List.of("-Xint", CoreUtils.getAlwaysPretouchArg(withCore)), theApp);
             }
             System.out.print("Started LingeredApp ");
             if (withXcomp) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.util.CoreUtils;
 import jtreg.SkippedException;
 
 /**
@@ -46,7 +47,7 @@ public class ClhsdbPmap {
         LingeredApp theApp = null;
         try {
             ClhsdbLauncher test = new ClhsdbLauncher();
-            theApp = LingeredApp.startApp();
+            theApp = LingeredApp.startApp(List.of(CoreUtils.getAlwaysPretouchArg(false)));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             List<String> cmds = List.of("pmap");

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.util.CoreUtils;
 import jtreg.SkippedException;
 
 /**
@@ -45,7 +46,7 @@ public class ClhsdbPstack {
         LingeredApp theApp = null;
         try {
             ClhsdbLauncher test = new ClhsdbLauncher();
-            theApp = LingeredApp.startApp();
+            theApp = LingeredApp.startApp(List.of(CoreUtils.getAlwaysPretouchArg(false)));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             List<String> cmds = List.of("pstack -v");

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,7 @@ public class TestJmapCore {
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError", "-XX:-TransmitErrorReport",
                 // The test loads lots of small classes to exhaust Metaspace, skip method
                 // dependency verification to improve performance in debug builds.
+                CoreUtils.getAlwaysPretouchArg(true),
                 Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "--show-version",
                 TestJmapCore.class.getName(), type);
 

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -230,4 +230,14 @@ public class CoreUtils {
         }
     }
 
+    public static String getAlwaysPretouchArg(boolean withCore) {
+        // macosx-aarch64 has an issue where sometimes the java heap will not be dumped to the
+        // core file. Using -XX:+AlwaysPreTouch fixes the problem.
+        if (withCore && Platform.isOSX() && Platform.isAArch64()) {
+            return "-XX:+AlwaysPreTouch";
+        } else {
+            return "-XX:-AlwaysPreTouch";
+        }
+    }
+
 }


### PR DESCRIPTION
The backport of [JDK-8248194](https://bugs.openjdk.org/browse/JDK-8248194) introduced the testing of core files in test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java. This can cause issues which we are seeing on MacOS arm64. With this backport, these seem to be gone.

The fix does not exactly fit into the 11u-dev codebase, so I had to make several adpatations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563) needs maintainer approval

### Issue
 * [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563): [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2698/head:pull/2698` \
`$ git checkout pull/2698`

Update a local copy of the PR: \
`$ git checkout pull/2698` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2698`

View PR using the GUI difftool: \
`$ git pr show -t 2698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2698.diff">https://git.openjdk.org/jdk11u-dev/pull/2698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2698#issuecomment-2095394686)