### PR TITLE
8313702: Update IANA Language Subtag Registry to Version 2023-08-02

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-05-11
+File-Date: 2023-08-02
 %%
 Type: language
 Subtag: aa
@@ -47642,6 +47642,15 @@ Added: 2007-07-05
 Prefix: sl-rozaj
 Comments: The dialect of San Giorgio/Bila is one of the four major local
   dialects of Resian
+%%
+Type: variant
+Subtag: blasl
+Description: Black American Sign Language dialect
+Added: 2023-07-31
+Prefix: ase
+Prefix: sgn-ase
+Comments: Black American Sign Language (BASL) or Black Sign Variation
+  (BSV) is a dialect of American Sign Language (ASL)
 %%
 Type: variant
 Subtag: bohoric

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761 8306031 8308021
+ *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-05-11) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-08-02) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313702](https://bugs.openjdk.org/browse/JDK-8313702) needs maintainer approval

### Issue
 * [JDK-8313702](https://bugs.openjdk.org/browse/JDK-8313702): Update IANA Language Subtag Registry to Version 2023-08-02 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2700/head:pull/2700` \
`$ git checkout pull/2700`

Update a local copy of the PR: \
`$ git checkout pull/2700` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2700`

View PR using the GUI difftool: \
`$ git pr show -t 2700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2700.diff">https://git.openjdk.org/jdk11u-dev/pull/2700.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2700#issuecomment-2095569237)