### PR TITLE
8331750: [11u] JDK-8259530 is not backported correctly to 11u

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -661,7 +661,7 @@ public class HtmlConfiguration extends BaseConfiguration {
                     return true;
                 }
             },
-            new Option(resources, "--legal-notices", 1) {
+            new XOption(resources, "--legal-notices", 1) {
                 @Override
                 public boolean process(String opt,  List<String> args) {
                     legalnotices = args.get(0);


### PR DESCRIPTION
This bug fix addresses the issue reported in https://github.com/openjdk/jdk11u-dev/pull/1805#issuecomment-2082702728. 
I have confirmed that the fix passes the following tests:
- test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
- All langtool tests

Could someone please review the fix?

Thanks,
Kimura Yukihiro