### PR TITLE
8326201: [S390] Need to bailout cleanly if creation of stubs fails when code cache is out of space

### DIFF
--- a/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_CodeStubs_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -440,6 +440,7 @@ void ArrayCopyStub::emit_code(LIR_Assembler* ce) {
          "must be aligned");
 
   ce->emit_static_call_stub();
+  CHECK_BAILOUT();
 
   // Prepend each BRASL with a nop.
   __ relocate(relocInfo::static_call_type);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2017, SAP SE. All rights reserved.
+// Copyright (c) 2017, 2024 SAP SE. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1430,6 +1430,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer &cbuf) {
 
   address base = __ start_a_stub(size_exception_handler());
   if (base == NULL) {
+    ciEnv::current()->record_failure("CodeCache is full");
     return 0;          // CodeBuffer::expand failed
   }
 
@@ -1451,6 +1452,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   address        base = __ start_a_stub(size_deopt_handler());
 
   if (base == NULL) {
+    ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d5f3d5c8](https://github.com/openjdk/jdk/commit/d5f3d5c8cc347ae384dea25b1a55ed57204d1af3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 21 Feb 2024 and was reviewed by Lutz Schmidt and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326201](https://bugs.openjdk.org/browse/JDK-8326201) needs maintainer approval

### Issue
 * [JDK-8326201](https://bugs.openjdk.org/browse/JDK-8326201): [S390] Need to bailout cleanly if creation of stubs fails when code cache is out of space (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2704/head:pull/2704` \
`$ git checkout pull/2704`

Update a local copy of the PR: \
`$ git checkout pull/2704` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2704`

View PR using the GUI difftool: \
`$ git pr show -t 2704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2704.diff">https://git.openjdk.org/jdk11u-dev/pull/2704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2704#issuecomment-2107860811)