### PR TITLE
8042380: Test javax/swing/JFileChooser/4524490/bug4524490.java fails with InvocationTargetException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -684,7 +684,6 @@ javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/6607130/bug6607130.java 8196091 windows-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
-javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
 javax/swing/JList/6462008/bug6462008.java 7156347 generic-all

--- a/test/jdk/javax/swing/JFileChooser/4524490/bug4524490.java
+++ b/test/jdk/javax/swing/JFileChooser/4524490/bug4524490.java
@@ -45,7 +45,7 @@ public class bug4524490 {
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8042380](https://bugs.openjdk.org/browse/JDK-8042380) needs maintainer approval

### Issue
 * [JDK-8042380](https://bugs.openjdk.org/browse/JDK-8042380): Test javax/swing/JFileChooser/4524490/bug4524490.java fails with InvocationTargetException (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2705/head:pull/2705` \
`$ git checkout pull/2705`

Update a local copy of the PR: \
`$ git checkout pull/2705` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2705`

View PR using the GUI difftool: \
`$ git pr show -t 2705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2705.diff">https://git.openjdk.org/jdk11u-dev/pull/2705.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2705#issuecomment-2102060637)