### PR TITLE
8297082: Remove sun/tools/jhsdb/BasicLauncherTest.java from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -823,9 +823,8 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 # svc_tools
 
 sun/tools/jstat/jstatClassloadOutput1.sh                        8173942 generic-all
-sun/tools/jhsdb/BasicLauncherTest.java                          8193639,8211767 linux-ppc64,linux-ppc64le,solaris-all
+sun/tools/jhsdb/BasicLauncherTest.java                          8193639 solaris-all
 sun/tools/jhsdb/HeapDumpTest.java                               8193639 solaris-all
-
 
 ############################################################################
 


### PR DESCRIPTION
Remove an obsolete problem list entry for ppc. Change had to be fitted into jdk11u, since lists diverge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297082](https://bugs.openjdk.org/browse/JDK-8297082) needs maintainer approval

### Issue
 * [JDK-8297082](https://bugs.openjdk.org/browse/JDK-8297082): Remove sun/tools/jhsdb/BasicLauncherTest.java from problem list (**Sub-task** - P5 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2706/head:pull/2706` \
`$ git checkout pull/2706`

Update a local copy of the PR: \
`$ git checkout pull/2706` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2706`

View PR using the GUI difftool: \
`$ git pr show -t 2706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2706.diff">https://git.openjdk.org/jdk11u-dev/pull/2706.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2706#issuecomment-2104457028)