### PR TITLE
8293887: AArch64 build failure with GCC 12 due to maybe-uninitialized warning in libfdlibm k_rem_pio2.c

### DIFF
--- a/make/lib/CoreLibraries.gmk
+++ b/make/lib/CoreLibraries.gmk
@@ -59,6 +59,7 @@ $(eval $(call SetupNativeCompilation, BUILD_LIBFDLIBM, \
     CFLAGS_windows_debug := -DLOGGING, \
     CFLAGS_aix := -qfloat=nomaf, \
     DISABLED_WARNINGS_gcc := sign-compare misleading-indentation array-bounds, \
+    DISABLED_WARNINGS_gcc_k_rem_pio2.c := maybe-uninitialized, \
     DISABLED_WARNINGS_microsoft := 4146 4244 4018, \
     ARFLAGS := $(ARFLAGS), \
     OBJECT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libfdlibm, \


### PR DESCRIPTION
Hi all,
  This is backport of [JDK-8293887](https://bugs.openjdk.org/browse/JDK-8293887). It's not clean backport, because the file `make/lib/CoreLibraries.gmk` has been moved to `make/modules/java.base/lib/CoreLibraries.gmk`

Thanks!


Make test list:

- [x] linux x64 gcc10
- [x] linux x64 gcc13
- [x] linux aarch64 gcc10
- [x] linux aarch64 gcc13
- [x] linux riscv64 gcc13


[make-linux-aarch64-gcc10.log](https://github.com/openjdk/jdk11u-dev/files/15295807/make-linux-aarch64-gcc10.log)
[make-linux-aarch64-gcc13.log](https://github.com/openjdk/jdk11u-dev/files/15295808/make-linux-aarch64-gcc13.log)
[make-linux-x64-gcc10.log](https://github.com/openjdk/jdk11u-dev/files/15295809/make-linux-x64-gcc10.log)
[make-linux-x64-gcc13.log](https://github.com/openjdk/jdk11u-dev/files/15295810/make-linux-x64-gcc13.log)
[make-linux-riscv64-gcc13.log](https://github.com/openjdk/jdk11u-dev/files/15295880/make-linux-riscv64-gcc13.log)

linux riscv64 gcc13 build jdk11u-dev failure because other reasons, the `k_rem_pio2.c` file not longer compile fail after this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8293887](https://bugs.openjdk.org/browse/JDK-8293887) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293887](https://bugs.openjdk.org/browse/JDK-8293887): AArch64 build failure with GCC 12 due to maybe-uninitialized warning in libfdlibm k_rem_pio2.c (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2709/head:pull/2709` \
`$ git checkout pull/2709`

Update a local copy of the PR: \
`$ git checkout pull/2709` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2709`

View PR using the GUI difftool: \
`$ git pr show -t 2709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2709.diff">https://git.openjdk.org/jdk11u-dev/pull/2709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2709#issuecomment-2107544380)