### PR TITLE
8326521: JFR: CompilerPhase event test fails on windows 32 bit

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
@@ -45,6 +45,7 @@ import sun.hotspot.WhiteBox;
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  *     sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:-NeverActAsServerClassMachine
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerPhase::dummyMethod
  *     -XX:+SegmentedCodeCache -Xbootclasspath/a:.


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jdk/commit/96530bcc07514c3eda40fd6ffa74f197fe541dea

On some systems (such as windows 32 bit) Hotspot only uses the C1 compiler in by design. The CompilerPhase JFR events are only emitted from C2 code. So the test TestCompilerPhase fails on some systems because it cannot generate the necessary CompilerPhase JFR events .

This backport prevents `NeverActAsServerClassMachine` from being set during the test TestCompilerPhase, so that it isn't restricted to C1. It should help resolve some test failures for Adoptium (see https://github.com/adoptium/aqa-tests/issues/3045).

Testing: running test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8326521](https://bugs.openjdk.org/browse/JDK-8326521) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326521](https://bugs.openjdk.org/browse/JDK-8326521): JFR: CompilerPhase event test fails on windows 32 bit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2710/head:pull/2710` \
`$ git checkout pull/2710`

Update a local copy of the PR: \
`$ git checkout pull/2710` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2710`

View PR using the GUI difftool: \
`$ git pr show -t 2710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2710.diff">https://git.openjdk.org/jdk11u-dev/pull/2710.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2710#issuecomment-2108507402)