### PR TITLE
8236917: TestInstanceKlassSize.java fails with "The size computed by SA for java.lang.Object does not match"

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -93,7 +93,7 @@ public class TestInstanceKlassSize {
         try {
             List<String> vmArgs = new ArrayList<String>();
             vmArgs.add("-XX:+UsePerfData");
-            vmArgs.addAll(Utils.getVmOptions());
+            vmArgs.addAll(Arrays.asList(Utils.getTestJavaOpts()));
             app = LingeredApp.startApp(vmArgs);
             System.out.println ("Started LingeredApp with pid " + app.getPid());
         } catch (Exception ex) {

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -38,6 +38,7 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.Utils;
+import java.util.Arrays;
 
 /**
  * @test

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -23,6 +23,7 @@
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 
 import sun.jvm.hotspot.HotSpotAgent;
 import sun.jvm.hotspot.utilities.SystemDictionaryHelper;
@@ -38,7 +39,6 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.Utils;
-import java.util.Arrays;
 
 /**
  * @test

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -22,8 +22,8 @@
  */
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 
 import sun.jvm.hotspot.HotSpotAgent;
 import sun.jvm.hotspot.utilities.SystemDictionaryHelper;

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -154,9 +154,7 @@ public class TestInstanceKlassSizeForInterface {
 
         if (args == null || args.length == 0) {
             try {
-                List<String> vmArgs = new ArrayList<String>();
-                vmArgs.addAll(Utils.getVmOptions());
-
+                List<String> vmArgs = Arrays.asList(Utils.getTestJavaOpts());
                 theApp = new LingeredAppWithInterface();
                 LingeredApp.startApp(vmArgs, theApp);
                 createAnotherToAttach(instanceKlassNames,


### PR DESCRIPTION
backport of c0dce25756911ce49e7d8b034d5f12a25fc3c81d
8236917: TestInstanceKlassSize.java fails with "The size computed by SA for java.lang.Object does not match"
1. Clean backport from tip
2. validated the modified test case

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8236917](https://bugs.openjdk.org/browse/JDK-8236917) needs maintainer approval

### Issue
 * [JDK-8236917](https://bugs.openjdk.org/browse/JDK-8236917): TestInstanceKlassSize.java fails with "The size computed by SA for java.lang.Object does not match" (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2712/head:pull/2712` \
`$ git checkout pull/2712`

Update a local copy of the PR: \
`$ git checkout pull/2712` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2712`

View PR using the GUI difftool: \
`$ git pr show -t 2712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2712.diff">https://git.openjdk.org/jdk11u-dev/pull/2712.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2712#issuecomment-2116111725)