### PR TITLE
8323635: Test gc/g1/TestHumongousAllocConcurrentStart.java fails with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocInitialMark.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocInitialMark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package gc.g1;
  * @bug 7168848
  * @summary G1: humongous object allocations should initiate marking cycles when necessary
  * @requires vm.gc.G1
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -54,7 +55,7 @@ public class TestHumongousAllocInitialMark {
             "-Xlog:gc",
             HumongousObjectAllocator.class.getName());
 
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
         output.shouldContain("Pause Young (Concurrent Start) (G1 Humongous Allocation)");
         output.shouldNotContain("Full GC");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.
This PR contains a backport of
https://github.com/openjdk/jdk/commit/5045839cb2095105a5c6c9eebc633a78b1e3213e
Patch is not clean, this file test/hotspot/jtreg/gc/g1/TestHumongousAllocInitialMark.java has changed by the commit
https://github.com/openjdk/jdk/commit/d52a995f35de26c2cc4074297a75141e4a363e1b
, I ignored this commits and only change code for this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8323635](https://bugs.openjdk.org/browse/JDK-8323635) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323635](https://bugs.openjdk.org/browse/JDK-8323635): Test gc/g1/TestHumongousAllocConcurrentStart.java fails with -XX:TieredStopAtLevel=3 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2717/head:pull/2717` \
`$ git checkout pull/2717`

Update a local copy of the PR: \
`$ git checkout pull/2717` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2717`

View PR using the GUI difftool: \
`$ git pr show -t 2717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2717.diff">https://git.openjdk.org/jdk11u-dev/pull/2717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2717#issuecomment-2119952105)