### PR TITLE
8240226: DeflateIn_InflateOut.java test incorrectly assumes size of compressed file

### DIFF
--- a/test/jdk/java/util/zip/DeflateIn_InflateOut.java
+++ b/test/jdk/java/util/zip/DeflateIn_InflateOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,6 @@ public class DeflateIn_InflateOut {
     private static InflaterOutputStream ios;
 
     private static void reset() {
-        new Random(new Date().getTime()).nextBytes(data);
-
         bais = new ByteArrayInputStream(data);
         dis = new DeflaterInputStream(bais);
 
@@ -218,6 +216,8 @@ public class DeflateIn_InflateOut {
 
 
     public static void realMain(String[] args) throws Throwable {
+        new Random(new Date().getTime()).nextBytes(data);
+
         ArrayReadWrite();
 
         ArrayReadByteWrite();


### PR DESCRIPTION
A backport of https://bugs.openjdk.org/browse/JDK-8240226 

JDK-8240226 contains a small fix to `DeflateIn_InflateOut.java` that makes the test pass when `--with-zlib=system` and the system zlib library is zlib-cloudflare. 

This fix is also required for the test to pass in Fedora 40 with the (system wide default) ZLib-ng library.

Tested with both DEBUG and RELEASE builds in Fedora 40.

Let me know if updating the copyright year is required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8240226](https://bugs.openjdk.org/browse/JDK-8240226) needs maintainer approval

### Issue
 * [JDK-8240226](https://bugs.openjdk.org/browse/JDK-8240226): DeflateIn_InflateOut.java test incorrectly assumes size of compressed file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2719/head:pull/2719` \
`$ git checkout pull/2719`

Update a local copy of the PR: \
`$ git checkout pull/2719` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2719`

View PR using the GUI difftool: \
`$ git pr show -t 2719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2719.diff">https://git.openjdk.org/jdk11u-dev/pull/2719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2719#issuecomment-2137747864)