### PR TITLE
8327040: Problemlist ActionListenerCalledTwiceTest.java test failing in macos14

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -655,6 +655,7 @@ javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,solaris-all,
 
 # This test fails on macOS 14
 javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
+javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8316151 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8327040](https://bugs.openjdk.org/browse/JDK-8327040) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327040](https://bugs.openjdk.org/browse/JDK-8327040): Problemlist ActionListenerCalledTwiceTest.java test failing in macos14 (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2724/head:pull/2724` \
`$ git checkout pull/2724`

Update a local copy of the PR: \
`$ git checkout pull/2724` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2724`

View PR using the GUI difftool: \
`$ git pr show -t 2724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2724.diff">https://git.openjdk.org/jdk11u-dev/pull/2724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2724#issuecomment-2128723134)