### PR TITLE
8311666: Disabled tests in test/jdk/sun/java2d/marlin

### DIFF
--- a/test/jdk/sun/java2d/marlin/ScaleTest.java
+++ b/test/jdk/sun/java2d/marlin/ScaleTest.java
@@ -21,12 +21,16 @@
  * questions.
  */
 
+/* @test
+ * @summary Circle is rendered in C shape
+ * @bug 6829659 8311666
+ */
+
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import javax.imageio.ImageIO;
-
 
 public class ScaleTest {
   public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/java2d/marlin/StrokeShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/StrokeShapeTest.java
@@ -20,6 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/* @test
+ * @summary StrokeShapeTest: createStrokedShape() behaves differently
+ * @bug 6829678 8311666
+ */
+
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.GeneralPath;

--- a/test/jdk/sun/java2d/marlin/ThinLineTest.java
+++ b/test/jdk/sun/java2d/marlin/ThinLineTest.java
@@ -20,6 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/* @test
+ * @summary ThinLineTest: A line < 1 pixel disappears.
+ * @bug 6829673 8311666
+ */
+
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b285ed72](https://github.com/openjdk/jdk/commit/b285ed72aebe2d802fa9c071372cea6c09870b9a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Liam Miller-Cushon on 10 Jul 2023 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8311666](https://bugs.openjdk.org/browse/JDK-8311666) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311666](https://bugs.openjdk.org/browse/JDK-8311666): Disabled tests in test/jdk/sun/java2d/marlin (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2725/head:pull/2725` \
`$ git checkout pull/2725`

Update a local copy of the PR: \
`$ git checkout pull/2725` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2725`

View PR using the GUI difftool: \
`$ git pr show -t 2725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2725.diff">https://git.openjdk.org/jdk11u-dev/pull/2725.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2725#issuecomment-2136299855)