### PR TITLE
8307788: vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large001/large001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large001/large001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@
  * @comment generate and compile nsk.share.gc.newclass.* classes
  * @run driver nsk.share.gc.GenClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc*
  *      gc.gctests.LargeObjects.large001.large001

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@
  * @comment generate and compile nsk.share.gc.newclass.* classes
  * @run driver nsk.share.gc.GenClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:-UseGCOverheadLimit
  *      gc.gctests.LargeObjects.large001.large001
  *      -largeClassesPath classes

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@
  * @comment generate and compile nsk.share.gc.newclass.* classes
  * @run driver nsk.share.gc.GenClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:-UseGCOverheadLimit
  *      gc.gctests.LargeObjects.large001.large001
  *      -largeClassesPath classes

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@
  * @comment generate and compile nsk.share.gc.newclass.* classes
  * @run driver nsk.share.gc.GenClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:-UseGCOverheadLimit
  *      gc.gctests.LargeObjects.large001.large001
  *      -largeClassesPath classes

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@
  * @comment generate and compile nsk.share.gc.newclass.* classes
  * @run driver nsk.share.gc.GenClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:-UseGCOverheadLimit
  *      gc.gctests.LargeObjects.large001.large001
  *      -largeClassesPath classes


### PR DESCRIPTION
I backport this for parity with 11.0.24-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8307788](https://bugs.openjdk.org/browse/JDK-8307788) needs maintainer approval

### Issue
 * [JDK-8307788](https://bugs.openjdk.org/browse/JDK-8307788): vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java timed out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2726/head:pull/2726` \
`$ git checkout pull/2726`

Update a local copy of the PR: \
`$ git checkout pull/2726` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2726`

View PR using the GUI difftool: \
`$ git pr show -t 2726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2726.diff">https://git.openjdk.org/jdk11u-dev/pull/2726.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2726#issuecomment-2132888803)