### PR TITLE
8276819: javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free

### DIFF
--- a/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
+++ b/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
@@ -34,6 +34,9 @@ import javax.print.PrintServiceLookup;
  * @test
  * @bug 8273831
  * @summary Tests custom class loader cleanup
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main/timeout=60/othervm -mx32m FlushCustomClassLoader
  */
 public final class FlushCustomClassLoader {
 
@@ -42,12 +45,8 @@ public final class FlushCustomClassLoader {
 
         int attempt = 0;
         while (loader.get() != null) {
-            if (++attempt > 10) {
-                throw new RuntimeException("Too many attempts: " + attempt);
-            }
-            System.gc();
-            Thread.sleep(1000);
-            System.out.println("Not freed, attempt: " + attempt);
+            Util.generateOOME();
+            System.out.println("Not freed, attempt: " + attempt++);
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7c2c5858](https://github.com/openjdk/jdk/commit/7c2c58587d4eda5523331eae45e7d897252dc097) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 12 Dec 2021 and was reviewed by Prasanta Sadhukhan and Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276819](https://bugs.openjdk.org/browse/JDK-8276819) needs maintainer approval

### Issue
 * [JDK-8276819](https://bugs.openjdk.org/browse/JDK-8276819): javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2729/head:pull/2729` \
`$ git checkout pull/2729`

Update a local copy of the PR: \
`$ git checkout pull/2729` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2729`

View PR using the GUI difftool: \
`$ git pr show -t 2729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2729.diff">https://git.openjdk.org/jdk11u-dev/pull/2729.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2729#issuecomment-2140878178)