### PR TITLE
8320945: problemlist tests failing on latest Windows 11 update

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -566,7 +566,7 @@ java/nio/file/WatchService/Basic.java                           7158947 solaris-
 java/nio/file/WatchService/MayFlies.java                        7158947 solaris-all Solaris 11
 java/nio/file/WatchService/LotsOfCancels.java                   8188039 solaris-all Solaris 11
 java/nio/file/WatchService/LotsOfEvents.java                    7158947 solaris-all Solaris 11
-
+java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################
 
@@ -686,6 +686,7 @@ javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
 javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
+javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
 javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
 javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320945](https://bugs.openjdk.org/browse/JDK-8320945) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320945](https://bugs.openjdk.org/browse/JDK-8320945): problemlist tests failing on latest Windows 11 update (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2734/head:pull/2734` \
`$ git checkout pull/2734`

Update a local copy of the PR: \
`$ git checkout pull/2734` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2734`

View PR using the GUI difftool: \
`$ git pr show -t 2734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2734.diff">https://git.openjdk.org/jdk11u-dev/pull/2734.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2734#issuecomment-2144344993)