### PR TITLE
8333353: Delete extra empty line in CodeBlob.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
@@ -120,7 +120,6 @@ public class CodeBlob extends VMObject {
   }
 
   /** OopMap for frame; can return null if none available */
-
   public ImmutableOopMapSet getOopMaps() {
     Address value = oopMapsField.getValue(addr);
     if (value == null) {


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [91101f0d](https://github.com/openjdk/jdk/commit/91101f0d4fc8e06d0d74e06361db6ac87efeeb8e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

Trivial fix, delete an extra empty line, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8333353](https://bugs.openjdk.org/browse/JDK-8333353) needs maintainer approval

### Issue
 * [JDK-8333353](https://bugs.openjdk.org/browse/JDK-8333353): Delete extra empty line in CodeBlob.java (**Bug** - P5 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2739/head:pull/2739` \
`$ git checkout pull/2739`

Update a local copy of the PR: \
`$ git checkout pull/2739` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2739`

View PR using the GUI difftool: \
`$ git pr show -t 2739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2739.diff">https://git.openjdk.org/jdk11u-dev/pull/2739.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2739#issuecomment-2144627811)