### PR TITLE
8305825: getBounds API returns wrong value resulting in multiple Regression Test Failures on Ubuntu 23.04

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
@@ -1369,6 +1369,9 @@ final class XWM
               case UNITY_COMPIZ_WM:
                   res = new Insets(28, 1, 1, 1);
                   break;
+              case MUTTER_WM:
+                  res = new Insets(37, 0, 0, 0);
+                  break;
               case MOTIF_WM:
               case OPENLOOK_WM:
               default:
@@ -1380,6 +1383,7 @@ final class XWM
         }
         return res;
     }
+
     /*
      * Some buggy WMs ignore window gravity when processing
      * ConfigureRequest and position window as if the gravity is Static.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -143,6 +143,7 @@ java/awt/Frame/UnfocusableMaximizedFrameResizablity/UnfocusableMaximizedFrameRes
 java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java 7080150 macosx-all
 java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all
 java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java 8198626 macosx-all
+java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java 8321303 linux-all
 java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
 java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 linux-all,windows-all,macosx-all
@@ -665,6 +666,7 @@ javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,win
 javax/swing/JComponent/7154030/bug7154030.java 7190978 generic-all
 javax/swing/JComboBox/ConsumedKeyTest/ConsumedKeyTest.java 8067986 generic-all
 javax/swing/JComponent/6683775/bug6683775.java 8172337 generic-all
+javax/swing/JFrame/MaximizeWindowTest.java 8321289 linux-all
 javax/swing/JComboBox/6236162/bug6236162.java 8028707 windows-all,macosx-all
 javax/swing/JButton/8151303/PressedIconTest.java 8198689 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentCanvas.java 8081476 windows-all,macosx-all

--- a/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,12 +54,11 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 public class NestedModalDialogTest {
-    private static Frame frame;
+    private static StartFrame frame;
     private static IntermediateDialog interDiag;
     private static TextDialog txtDiag;
 
     // Global variables so the robot thread can locate things.
-    private static Button[] robot_button = new Button[2];
     private static TextField robot_text = null;
     private static Robot robot = null;
 
@@ -78,6 +77,9 @@ public class NestedModalDialogTest {
     }
 
     private static void clickOnComp(Component comp) {
+        robot.waitForIdle();
+        robot.delay(1000);
+
         Rectangle bounds = new Rectangle(comp.getLocationOnScreen(), comp.getSize());
         robot.mouseMove(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
         robot.waitForIdle();
@@ -94,11 +96,11 @@ public class NestedModalDialogTest {
             // launch first frame with firstButton
             frame = new StartFrame();
             blockTillDisplayed(frame);
-            clickOnComp(robot_button[0]);
+            clickOnComp(frame.button);
 
             // Dialog must be created and onscreen before we proceed.
             blockTillDisplayed(interDiag);
-            clickOnComp(robot_button[1]);
+            clickOnComp(interDiag.button);
 
             // Again, the Dialog must be created and onscreen before we proceed.
             blockTillDisplayed(robot_text);
@@ -144,6 +146,8 @@ public class NestedModalDialogTest {
      */
     class StartFrame extends Frame {
 
+        public volatile Button button;
+
         /**
          * Constructs a new instance.
          */
@@ -168,7 +172,7 @@ public class NestedModalDialogTest {
             pan.add(but);
             add(pan);
             setVisible(true);
-            robot_button[0] = but;
+            button = but;
         }
     }
 
@@ -177,6 +181,7 @@ public class NestedModalDialogTest {
     class IntermediateDialog extends Dialog {
 
         Dialog m_parent;
+        public volatile Button button;
 
         public IntermediateDialog(Frame parent) {
             super(parent, "Intermediate Modal", true /*Modal*/);
@@ -193,9 +198,7 @@ public class NestedModalDialogTest {
             pan.add(but);
             add(pan);
             pack();
-
-            // The robot needs to know about us, so set global
-            robot_button[1] = but;
+            button = but;
         }
     }
 
@@ -215,12 +218,12 @@ public class NestedModalDialogTest {
         }
     }
 
-    public static void main(String[] args) throws RuntimeException, Exception {
+    public static void main(String[] args) throws Exception {
         try {
             new NestedModalDialogTest().testModalDialogs();
         } catch (Exception e) {
             throw new RuntimeException("NestedModalDialogTest object creation "
-                    + "failed");
+                    + "failed", e);
         }
     }
 }

--- a/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
+++ b/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,7 @@ public class OwnedWindowFocusIMECrashTest {
         window.setVisible(true);
 
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         test();
 

--- a/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
+++ b/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,7 @@ public class MultiResolutionSplashTest {
     static void testFocus() throws Exception {
 
         Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(50);
 
         Frame frame = new Frame();
@@ -130,6 +131,7 @@ public class MultiResolutionSplashTest {
         frame.add(textField);
         frame.setVisible(true);
         robot.waitForIdle();
+        robot.delay(1000);
 
         robot.keyPress(KeyEvent.VK_A);
         robot.keyRelease(KeyEvent.VK_A);

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,7 @@ public class DefaultButtonTest {
 
     public void runTest() throws Exception {
         Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(100);
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             try {
@@ -100,6 +101,8 @@ public class DefaultButtonTest {
                     createUI();
                 });
                 robot.waitForIdle();
+                robot.delay(1000);
+
                 robot.keyPress(KeyEvent.VK_ENTER);
                 robot.keyRelease(KeyEvent.VK_ENTER);
                 robot.waitForIdle();

--- a/test/jdk/javax/swing/JTree/8003400/Test8003400.java
+++ b/test/jdk/javax/swing/JTree/8003400/Test8003400.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,10 @@ public class Test8003400 {
 
                 Robot robot = new Robot();
                 robot.setAutoDelay(100);
+                robot.setAutoWaitForIdle(true);
+                robot.waitForIdle();
+                robot.delay(500);
+
                 SwingUtilities.invokeAndWait(() -> {
                     point = tree.getLocationOnScreen();
                     rect = tree.getBounds();


### PR DESCRIPTION
Backport of [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825). Version from 17u applies cleanly except ProblemList update which is integrated manually and recognized as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825) needs maintainer approval

### Issue
 * [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825): getBounds API returns wrong value resulting in multiple Regression Test Failures on Ubuntu 23.04 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2745/head:pull/2745` \
`$ git checkout pull/2745`

Update a local copy of the PR: \
`$ git checkout pull/2745` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2745`

View PR using the GUI difftool: \
`$ git pr show -t 2745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2745.diff">https://git.openjdk.org/jdk11u-dev/pull/2745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2745#issuecomment-2150397122)