### PR TITLE
8268906: gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum

### DIFF
--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -136,8 +136,8 @@ public class TestOldGenCollectionUsage {
         if (newCollectionCount <= collectionCount) {
             throw new RuntimeException("No new collection");
         }
-        if (newCollectionTime <= collectionTime) {
-            throw new RuntimeException("Collector has not run some more");
+        if (newCollectionTime < collectionTime) {
+            throw new RuntimeException("Collection time ran backwards");
         }
 
         System.out.println("Test passed.");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a0f32cb1](https://github.com/openjdk/jdk/commit/a0f32cb1406e4957e84befd9b68444adb662bd13) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 30 Jun 2021 and was reviewed by Kim Barrett, Albert Mingkun Yang and Leo Korinth.

The related failure was caught by dragonwell's CI. So we want to fix the intermittent failure. Only change the testcase, the risk is low.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8268906](https://bugs.openjdk.org/browse/JDK-8268906) needs maintainer approval

### Issue
 * [JDK-8268906](https://bugs.openjdk.org/browse/JDK-8268906): gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2747/head:pull/2747` \
`$ git checkout pull/2747`

Update a local copy of the PR: \
`$ git checkout pull/2747` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2747`

View PR using the GUI difftool: \
`$ git pr show -t 2747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2747.diff">https://git.openjdk.org/jdk11u-dev/pull/2747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2747#issuecomment-2154335970)