### PR TITLE
8333839: [11u] LingeredAppTest.java fails Can't find source file: LingeredApp.java

### DIFF
--- a/test/lib-test/jdk/test/lib/apps/LingeredAppTest.java
+++ b/test/lib-test/jdk/test/lib/apps/LingeredAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @summary Unit test for LingeredApp
- * @compile LingeredAppTest.java
- * @compile LingeredApp.java
- * @run main LingeredAppTest
+ * @library /test/lib
+ * @build jdk.test.lib.apps.LingeredAppTest jdk.test.lib.apps.LingeredApp
+ * @run main jdk.test.lib.apps.LingeredAppTest
  */
 
 package jdk.test.lib.apps;

--- a/test/lib-test/jdk/test/lib/apps/LingeredAppTest.java
+++ b/test/lib-test/jdk/test/lib/apps/LingeredAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,
  The testcase `test/lib-test/jdk/test/lib/apps/LingeredAppTest.java` fails as `Parse Exception: Can't find source file: LingeredApp.java`. This PR fix the testcase bug, the change has been verified, no risk.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333839](https://bugs.openjdk.org/browse/JDK-8333839) needs maintainer approval

### Issue
 * [JDK-8333839](https://bugs.openjdk.org/browse/JDK-8333839): [11u] LingeredAppTest.java fails Can't find source file: LingeredApp.java (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2752/head:pull/2752` \
`$ git checkout pull/2752`

Update a local copy of the PR: \
`$ git checkout pull/2752` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2752`

View PR using the GUI difftool: \
`$ git pr show -t 2752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2752.diff">https://git.openjdk.org/jdk11u-dev/pull/2752.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2752#issuecomment-2155995252)