### PR TITLE
7124313: [macosx] Swing Popups should overlap taskbar

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -692,7 +692,6 @@ javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
 javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
 javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
-javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JPopupMenu/6675802/bug6675802.java 8196097 windows-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
@@ -852,4 +851,3 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/oldobject/TestLargeRootSet.java                   8205651    generic-all
 
 ############################################################################
-

--- a/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
+++ b/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,26 @@
  * @test
  * @key headful
  * @bug 6580930 7184956
+ * @requires (os.family != "mac")
  * @summary Swing Popups should overlap taskbar
- * @author Alexander Potochkin
  * @library ../../../../lib/testlibrary
  * @build ExtendedRobot
  * @run main bug6580930
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Insets;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 
 public class bug6580930 {
     private static ExtendedRobot robot;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [532a6ec7](https://github.com/openjdk/jdk/commit/532a6ec7e3a048624b380b38b4611533a7caae18) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 7 Jul 2022 and was reviewed by Sergey Bylokhov and Dmitry Markov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-7124313](https://bugs.openjdk.org/browse/JDK-7124313) needs maintainer approval

### Issue
 * [JDK-7124313](https://bugs.openjdk.org/browse/JDK-7124313): [macosx] Swing Popups should overlap taskbar (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2753/head:pull/2753` \
`$ git checkout pull/2753`

Update a local copy of the PR: \
`$ git checkout pull/2753` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2753`

View PR using the GUI difftool: \
`$ git pr show -t 2753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2753.diff">https://git.openjdk.org/jdk11u-dev/pull/2753.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2753#issuecomment-2159407712)