### PR TITLE
8205076: [17u] Inet6AddressImpl.c: `lookupIfLocalHost` accesses `int InetAddress.preferIPv6Address` as a boolean

### DIFF
--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
@@ -170,7 +170,7 @@ lookupIfLocalhost(JNIEnv *env, const char *hostname, jboolean includeV6)
     result = (*env)->NewObjectArray(env, arraySize, ia_class, NULL);
     if (!result) goto done;
 
-    if ((*env)->GetStaticBooleanField(env, ia_class, ia_preferIPv6AddressID)) {
+    if ((*env)->GetStaticIntField(env, ia_class, ia_preferIPv6AddressID) == java_net_InetAddress_PREFER_IPV6_VALUE) {
         i = includeLoopback ? addrs6 : (addrs6 - numV6Loopbacks);
         j = 0;
     } else {


### PR DESCRIPTION
This is a 11u and 17u -specific bug, see JBS and its comments for more details. I think we can fix this by explicitly checking against the `PREFER_IPV6_VALUE`, like post JDK 18 code does.

It is a bit weird to backport the issue with `[17u]` in title, but I think it is the cleanest way to make sure we backport the same fix 17u already ships with.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `DcmdMBeanTestCheckJni.java` now passes
 - [x] macos-aarch64-server-fastdebug, `jdk_net`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8205076](https://bugs.openjdk.org/browse/JDK-8205076) needs maintainer approval

### Issue
 * [JDK-8205076](https://bugs.openjdk.org/browse/JDK-8205076): [17u] Inet6AddressImpl.c: `lookupIfLocalHost` accesses `int InetAddress.preferIPv6Address` as a boolean (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2769/head:pull/2769` \
`$ git checkout pull/2769`

Update a local copy of the PR: \
`$ git checkout pull/2769` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2769`

View PR using the GUI difftool: \
`$ git pr show -t 2769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2769.diff">https://git.openjdk.org/jdk11u-dev/pull/2769.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2769#issuecomment-2165809877)