### PR TITLE
8293862: javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null'

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1077,10 +1077,10 @@ final class Win32ShellFolder2 extends ShellFolder {
                             long hIcon = extractIcon(getParentIShellFolder(),
                                     getRelativePIDL(), getLargeIcon, false);
                             // E_PENDING: loading can take time so get the default
-                            if(hIcon <= 0) {
+                            if (hIcon == E_PENDING || hIcon == 0) {
                                 hIcon = extractIcon(getParentIShellFolder(),
                                          getRelativePIDL(), getLargeIcon, true);
-                                if(hIcon <= 0) {
+                                if (hIcon == 0) {
                                     if (isDirectory()) {
                                         return getShell32Icon(4, getLargeIcon);
                                     } else {
@@ -1329,6 +1329,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         final Image resolutionVariant;
 
         public MultiResolutionIconImage(int baseSize, Image resolutionVariant) {
+            assert resolutionVariant != null : "Null icon passed as the base image for MRI";
             this.baseSize = baseSize;
             this.resolutionVariant = resolutionVariant;
         }

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1141,6 +1141,14 @@ final class Win32ShellFolder2 extends ShellFolder {
     }
 
     /**
+     * The data is not available yet.
+     * @see
+     * <a href="https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes-1">COM
+     * Error Codes</a>.
+     */
+    private static final long E_PENDING = 0x8000000AL;
+
+    /**
      * Returns the canonical form of this abstract pathname.  Equivalent to
      * <code>new&nbsp;Win32ShellFolder2(getParentFile(), this.{@link java.io.File#getCanonicalPath}())</code>.
      *

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -935,7 +935,7 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
         return 0;
     }
 
-    HICON hIcon = NULL;
+    HICON hIcon;
 
     HRESULT hres;
     IExtractIconW* pIcon;

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -957,10 +957,14 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
                 } else {
                     fn_DestroyIcon((HICON)hIconLarge);
                 }
+            } else {
+                hIcon = NULL;
             }
         } else if (hres == E_PENDING) {
             pIcon->Release();
-            return E_PENDING;
+            return (unsigned) E_PENDING;
+        } else {
+            hIcon = NULL;
         }
         pIcon->Release();
     }

--- a/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
+++ b/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8046391
+ * @bug 8046391 8293862
  * @requires (os.family == "windows")
  * @summary JFileChooser hangs if displayed in Windows L&F
  * @author Alexey Ivanov


### PR DESCRIPTION
Backport of [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862)
- This PR is `unclean`. This PR has two commits
- commit 1. is the `git patch` result from the original commit 
- commit 2. is the manual merge of the following .rej files

`.rej` details

- `src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java.rej`
  - This diff has been applied to this PR in the `commit 2`

```diff
@@ -1165,10 +1173,10 @@
                             getRelativePIDL(), s, false);
 
                     // E_PENDING: loading can take time so get the default
-                    if (hIcon <= 0) {
+                    if (hIcon == E_PENDING || hIcon == 0) {
                         hIcon = extractIcon(getParentIShellFolder(),
                                 getRelativePIDL(), s, true);
-                        if (hIcon <= 0) {
+                        if (hIcon == 0) {
                             if (isDirectory()) {
                                 newIcon = getShell32Icon(FOLDER_ICON_ID, size);
                             } else {
@@ -1405,11 +1413,14 @@
         final Map<Integer, Image> resolutionVariants = new HashMap<>();
 
         public MultiResolutionIconImage(int baseSize, Map<Integer, Image> resolutionVariants) {
+            assert !resolutionVariants.containsValue(null)
+                   : "There are null icons in the MRI variants map";
             this.baseSize = baseSize;
             this.resolutionVariants.putAll(resolutionVariants);
         }
 
         public MultiResolutionIconImage(int baseSize, Image image) {
+            assert image != null : "Null icon passed as the base image for MRI";
             this.baseSize = baseSize;
             this.resolutionVariants.put(baseSize, image);
         }
```

- `src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp.rej`
  - This diff has been applied to this PR in the `commit 2`

```diff
@@ -956,15 +956,21 @@
                 iconSize = (16 << 16) + size;
             }
             hres = pIcon->Extract(szBuf, index, &hIcon, &hIconSmall, iconSize);
-            if (size < 24) {
-                fn_DestroyIcon((HICON)hIcon);
-                hIcon = hIconSmall;
+            if (SUCCEEDED(hres)) {
+                if (size < 24) {
+                    fn_DestroyIcon((HICON)hIcon);
+                    hIcon = hIconSmall;
+                } else {
+                    fn_DestroyIcon((HICON)hIconSmall);
+                }
             } else {
-                fn_DestroyIcon((HICON)hIconSmall);
+                hIcon = NULL;
             }
         } else if (hres == E_PENDING) {
             pIcon->Release();
-            return E_PENDING;
+            return (unsigned) E_PENDING;
+        } else {
+            hIcon = NULL;
         }
         pIcon->Release();
     }
```

- `test/jdk/ProblemList.txt.rej`
  - This diff has been ignored because these lines does not exist in `jdk11u-dev` code base

```diff
@@ -671,8 +671,6 @@
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
-javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
-javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
 java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64
```

Testing
- Local test on Windows: 
  - `bug8046391.java`: Test results: `passed: 1` 

> Processor	12th Gen Intel(R) Core(TM) i7-12800H   2.40 GHz
> Installed RAM	64.0 GB (63.7 GB usable)
> System type	64-bit operating system, x64-based processor
> 
> Edition: Windows 11 Enterprise
> Version: 23H2
> Installed on: 5/10/2023
> OS build: 22631.3155
> Experience: Windows Feature Experience Pack 1000.22684.1000.0

- Pipeline: 
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Executable files are not allowed (file: src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp)

### Issue
 * [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862): javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null' (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2770/head:pull/2770` \
`$ git checkout pull/2770`

Update a local copy of the PR: \
`$ git checkout pull/2770` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2770`

View PR using the GUI difftool: \
`$ git pr show -t 2770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2770.diff">https://git.openjdk.org/jdk11u-dev/pull/2770.diff</a>

</details>
