### PR TITLE
8253700: spurious "extends Throwable" at end of Optional.orElseThrow method declaration

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -322,7 +322,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                 buf.append(",");
             }
             TypeMirror t = parameters.get(i).asType();
-            SimpleTypeVisitor9<Boolean, Void> stv = new SimpleTypeVisitor9<Boolean, Void>() {
+            SimpleTypeVisitor9<Boolean, Void> stv = new SimpleTypeVisitor9<>() {
                 boolean foundTypeVariable = false;
 
                 @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -275,13 +275,13 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
             htmltree.add(indent);
             htmltree.add("throws ");
             indent = makeSpace(indentSize + 1);
-            Content link = writer.getLink(new LinkInfoImpl(configuration, MEMBER, exceptions.get(0)));
+            Content link = writer.getLink(new LinkInfoImpl(configuration, THROWS_TYPE, exceptions.get(0)));
             htmltree.add(link);
             for(int i = 1; i < exceptions.size(); i++) {
                 htmltree.add(",");
                 htmltree.add(DocletConstants.NL);
                 htmltree.add(indent);
-                Content exceptionLink = writer.getLink(new LinkInfoImpl(configuration, MEMBER,
+                Content exceptionLink = writer.getLink(new LinkInfoImpl(configuration, THROWS_TYPE,
                         exceptions.get(i)));
                 htmltree.add(exceptionLink);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -398,9 +398,8 @@ public class LinkInfoImpl extends LinkInfo {
 
             case RETURN_TYPE:
             case SUMMARY_RETURN_TYPE:
-                excludeTypeBounds = true;
-                break;
             case EXECUTABLE_MEMBER_PARAM:
+            case THROWS_TYPE:
                 excludeTypeBounds = true;
                 break;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -213,9 +213,19 @@ public class LinkInfoImpl extends LinkInfo {
         PROPERTY_COPY,
 
         /**
-         * A receiver type
+         * A receiver type.
          */
-        RECEIVER_TYPE
+        RECEIVER_TYPE,
+
+        /**
+         * A record component within a class signature.
+         */
+        RECORD_COMPONENT,
+
+        /**
+         * A type thrown from a method.
+         */
+        THROWS_TYPE
     }
 
     public final HtmlConfiguration configuration;

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+  * @test
+  * @bug 8253700
+  * @summary spurious "extends Throwable" at end of method declaration
+  * throws section.  Make sure that the link is below a Throws heading.
+  * @library /tools/lib ../../lib
+  * @modules jdk.javadoc/jdk.javadoc.internal.tool
+  * @build javadoc.tester.* toolbox.ToolBox
+  * @run main TestThrows
+  */
+
+ import java.io.IOException;
+ import java.nio.file.Path;
+
+ import toolbox.ToolBox;
+
+ import javadoc.tester.JavadocTester;
+
+ public class TestThrows extends JavadocTester {
+
+     public static void main(String... args) throws Exception {
+         TestThrows tester = new TestThrows();
+         tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+     }
+
+     private final ToolBox tb = new ToolBox();
+
+     @Test
+     public void testThrowsWithBound(Path base) throws IOException {
+         Path src = base.resolve("src");
+         tb.writeJavaFiles(src,
+                 """
+                     /**
+                      * This is interface C.
+                      */
+                     public interface C {
+                         /**
+                          * Method m.
+                          * @param <T> the throwable
+                          * @throws T if a specific error occurs
+                          * @throws Exception if an exception occurs
+                          */
+                         <T extends Throwable> void m() throws T, Exception;
+                     }
+                     """);
+
+         javadoc("-d", base.resolve("out").toString(),
+                 src.resolve("C.java").toString());
+         checkExit(Exit.OK);
+
+         checkOutput("C.html", true,
+                 """
+                     <div class="member-signature"><span class="type-parameters">&lt;T extends java\
+                     .lang.Throwable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<sp\
+                     an class="member-name">m</span>()
+                                                     throws <span class="exceptions">T,
+                     java.lang.Exception</span></div>
+                     """,
+                 """
+                     <dl class="notes">
+                     <dt>Type Parameters:</dt>
+                     <dd><code>T</code> - the throwable</dd>
+                     <dt>Throws:</dt>
+                     <dd><code>T</code> - if a specific error occurs</dd>
+                     <dd><code>java.lang.Exception</code> - if an exception occurs</dd>
+                     </dl>
+                     """);
+     }
+}

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -65,7 +65,7 @@
                      "}"
                      ));
 
-         javadoc("-d", base.resolve("out").toString(),
+         javadoc("-encoding", "utf-8", "-d", base.resolve("out").toString(),
                  src.resolve("C.java").toString());
          checkExit(Exit.OK);
 

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -70,12 +70,9 @@
          checkExit(Exit.OK);
 
          checkOutput("C.html", true,
-                 String.join(System.lineSeparator(),
                      "<pre class=\"methodSignature\">&lt;T extends java.lang.Throwable&gt;&nbsp;void&nbsp;m()",
                      "                                throws T,",
-                     "                                       java.lang.Exception</pre>"
-                     ),
-                 String.join(System.lineSeparator(),
+                     "                                       java.lang.Exception</pre>",
                      "<dl>",
                      "<dt><span class=\"paramLabel\">Type Parameters:</span></dt>",
                      "<dd><code>T</code> - the throwable</dd>",
@@ -84,6 +81,6 @@
                      "<dd><code>java.lang.Exception</code> - if an exception occurs</dd>",
                      "<dd><code>T extends java.lang.Throwable</code></dd>",
                      "</dl>"
-                     ));
+                     );
      }
 }

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -26,9 +26,9 @@
   * @bug 8253700
   * @summary spurious "extends Throwable" at end of method declaration
   * throws section.  Make sure that the link is below a Throws heading.
-  * @library /tools/lib ../../lib
+  * @library /tools/lib ../lib
   * @modules jdk.javadoc/jdk.javadoc.internal.tool
-  * @build javadoc.tester.* toolbox.ToolBox
+  * @build JavadocTester toolbox.ToolBox
   * @run main TestThrows
   */
 
@@ -36,8 +36,6 @@
  import java.nio.file.Path;
 
  import toolbox.ToolBox;
-
- import javadoc.tester.JavadocTester;
 
  public class TestThrows extends JavadocTester {
 
@@ -52,41 +50,40 @@
      public void testThrowsWithBound(Path base) throws IOException {
          Path src = base.resolve("src");
          tb.writeJavaFiles(src,
-                 """
-                     /**
-                      * This is interface C.
-                      */
-                     public interface C {
-                         /**
-                          * Method m.
-                          * @param <T> the throwable
-                          * @throws T if a specific error occurs
-                          * @throws Exception if an exception occurs
-                          */
-                         <T extends Throwable> void m() throws T, Exception;
-                     }
-                     """);
+                String.join(System.lineSeparator(),
+                     "/**",
+                     " * This is interface C.",
+                     " */",
+                     "public interface C {",
+                     "    /**",
+                     "     * Method m.",
+                     "     * @param <T> the throwable",
+                     "     * @throws T if a specific error occurs",
+                     "     * @throws Exception if an exception occurs",
+                     "     */",
+                     "    <T extends Throwable> void m() throws T, Exception;",
+                     "}"
+                     ));
 
          javadoc("-d", base.resolve("out").toString(),
                  src.resolve("C.java").toString());
          checkExit(Exit.OK);
 
          checkOutput("C.html", true,
-                 """
-                     <div class="member-signature"><span class="type-parameters">&lt;T extends java\
-                     .lang.Throwable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<sp\
-                     an class="member-name">m</span>()
-                                                     throws <span class="exceptions">T,
-                     java.lang.Exception</span></div>
-                     """,
-                 """
-                     <dl class="notes">
-                     <dt>Type Parameters:</dt>
-                     <dd><code>T</code> - the throwable</dd>
-                     <dt>Throws:</dt>
-                     <dd><code>T</code> - if a specific error occurs</dd>
-                     <dd><code>java.lang.Exception</code> - if an exception occurs</dd>
-                     </dl>
-                     """);
+                 String.join(System.lineSeparator(),
+                     "<pre class=\"methodSignature\">&lt;T extends java.lang.Throwable&gt;&nbsp;void&nbsp;m()",
+                     "                                throws T,",
+                     "                                       java.lang.Exception</pre>"
+                     ),
+                 String.join(System.lineSeparator(),
+                     "<dl>",
+                     "<dt><span class=\"paramLabel\">Type Parameters:</span></dt>",
+                     "<dd><code>T</code> - the throwable</dd>",
+                     "<dt><span class=\"throwsLabel\">Throws:</span></dt>",
+                     "<dd><code>T</code> - if a specific error occurs</dd>",
+                     "<dd><code>java.lang.Exception</code> - if an exception occurs</dd>",
+                     "<dd><code>T extends java.lang.Throwable</code></dd>",
+                     "</dl>"
+                     ));
      }
 }


### PR DESCRIPTION
This is backprot for parity with `11.0.24-oracle`

----

Backport of [JDK-8253700](https://bugs.openjdk.org/browse/JDK-8253700)
- This is an **unclean** backport, contains two commits
- Commit 1. is generated by `git patch` command, is a clean apply of the original commit
- Commit 2. contains
  - a, Manual merge of the following `.rej` files
  - b. Manually fixed the `TestThrows.java` on Java 11 compile error, and fixed the test case to match the `javadoc` 11 output

`.rej` files
- `src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java.rej`
  - This file has been manually merged into the `commit 2`

```diff
@@ -51,6 +51,7 @@
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER;
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER_TYPE_PARAMS;
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.RECEIVER_TYPE;
+import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.THROWS_TYPE;
 
 /**
  * Print method and constructor info.
@@ -254,19 +255,16 @@
      */
     protected Content getExceptions(ExecutableElement member) {
         List<? extends TypeMirror> exceptions = utils.asInstantiatedMethodType(typeElement, member).getThrownTypes();
-        Content htmltree = new ContentBuilder();
-        if (!exceptions.isEmpty()) {
-            Content link = writer.getLink(new LinkInfoImpl(configuration, MEMBER, exceptions.get(0)));
-            htmltree.add(link);
-            for (int i = 1; i < exceptions.size(); i++) {
-                htmltree.add(",");
-                htmltree.add(DocletConstants.NL);
-                Content exceptionLink = writer.getLink(new LinkInfoImpl(configuration, MEMBER,
-                        exceptions.get(i)));
-                htmltree.add(exceptionLink);
+        Content htmlTree = new ContentBuilder();
+        for (TypeMirror t : exceptions) {
+            if (!htmlTree.isEmpty()) {
+                htmlTree.add(",");
+                htmlTree.add(DocletConstants.NL);
             }
+            Content link = writer.getLink(new LinkInfoImpl(configuration, THROWS_TYPE, t));
+            htmlTree.add(link);
         }
-        return htmltree;
+        return htmlTree;
     }
 
     protected TypeElement implementsMethodInIntfac(ExecutableElement method,
```

- `src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java.rej`
  - This file has been manually merged into the `commit 2`

```diff
@@ -208,14 +208,19 @@
         PROPERTY_COPY,
 
         /**
-         * A receiver type
+         * A receiver type.
          */
         RECEIVER_TYPE,
 
         /**
-         * A record component within a class signature
+         * A record component within a class signature.
          */
-        RECORD_COMPONENT
+        RECORD_COMPONENT,
+
+        /**
+         * A type thrown from a method.
+         */
+        THROWS_TYPE
     }
 
     public final HtmlConfiguration configuration;
```

Testing
- &#x1F49A; Local: Test passed on MacOS 14.5
  - `TestThrows.java`: Test results: passed: 1
- &#x1F49A; Pipeline: `All checks have passed`
- &#x1F49A; Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_langtools`: jdk/javadoc/doclet/testThrows/TestThrows.java: SUCCESSFUL GitHub 📊⏲ - [3,604 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8253700](https://bugs.openjdk.org/browse/JDK-8253700) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8253700: spurious "extends Throwable" at end of Optional.orElseThrow method declaration`

### Issue
 * [JDK-8253700](https://bugs.openjdk.org/browse/JDK-8253700): spurious "extends Throwable" at end of Optional.orElseThrow method declaration (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2772/head:pull/2772` \
`$ git checkout pull/2772`

Update a local copy of the PR: \
`$ git checkout pull/2772` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2772`

View PR using the GUI difftool: \
`$ git pr show -t 2772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2772.diff">https://git.openjdk.org/jdk11u-dev/pull/2772.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2772#issuecomment-2167051032)