### PR TITLE
8305079: Remove finalize() from compiler/c2/Test719030

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7190310.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7190310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,16 +39,12 @@ package compiler.c2;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.lang.ref.Cleaner;
 
 public class Test7190310 {
     private static Object str = new Object() {
         public String toString() {
             return "The Object";
-        }
-
-        protected void finalize() throws Throwable {
-            System.out.println("The Object is being finalized");
-            super.finalize();
         }
     };
     private final static ReferenceQueue<Object> rq =
@@ -58,6 +54,7 @@ public class Test7190310 {
 
     public static void main(String[] args)
             throws InterruptedException {
+        Cleaner.create().register(str, () -> System.out.println("The Object is being finalized"));
         Thread reader = new Thread() {
             public void run() {
                 while (wr.get() != null) {


### PR DESCRIPTION
Backport of [JDK-8305079](https://bugs.openjdk.org/browse/JDK-8305079)

Testing
- Local: Test passed on MacOS 14.5
  - `Test7190310.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_hotspot_tier1`: compiler/c2/Test7190310.java: SUCCESSFUL GitHub 📊⏲ - [2,918 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305079](https://bugs.openjdk.org/browse/JDK-8305079) needs maintainer approval

### Issue
 * [JDK-8305079](https://bugs.openjdk.org/browse/JDK-8305079): Remove finalize() from compiler/c2/Test719030 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2773/head:pull/2773` \
`$ git checkout pull/2773`

Update a local copy of the PR: \
`$ git checkout pull/2773` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2773`

View PR using the GUI difftool: \
`$ git pr show -t 2773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2773.diff">https://git.openjdk.org/jdk11u-dev/pull/2773.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2773#issuecomment-2167186043)