### PR TITLE
8306432: Open source several AWT Text Component related tests

### DIFF
--- a/test/jdk/java/awt/TextComponent/CorrectSetCaretPositionDuringInitPeerTest.java
+++ b/test/jdk/java/awt/TextComponent/CorrectSetCaretPositionDuringInitPeerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5100200
+  @summary IAE in X11 text field peer code
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.TextField;
+
+public class CorrectSetCaretPositionDuringInitPeerTest
+{
+    static TextField tf;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try{
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Caret Position test");
+                tf = new TextField("Very very very long string");
+                tf.setSelectionStart(10);
+                tf.setText("Short"); // now TextField.length() less than 10
+                frame.add(tf);
+
+                frame.pack();
+                frame.setVisible(true);
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/TextComponent/DeselectionDuringDoSelectionNonVisibleTest.java
+++ b/test/jdk/java/awt/TextComponent/DeselectionDuringDoSelectionNonVisibleTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5100950 8199723
+  @summary textarea.getSelectedText() returns the de-selected text, on XToolkit
+  @key headful
+  @requires (os.family == "mac") | (os.family == "windows")
+*/
+
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.TextField;
+
+public class DeselectionDuringDoSelectionNonVisibleTest {
+    static TextField tf1;
+    static TextField tf2;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Deselection test");
+                tf1 = new TextField("Text Field 1");
+                tf2 = new TextField("Text Field 2");
+                frame.add(tf1);
+                frame.add(tf2);
+                frame.setLayout(new FlowLayout());
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+
+            boolean isWin = System.getProperty("os.name").startsWith("Win");
+            System.out.println("is Windows OS? " + isWin);
+
+            Thread.sleep(500);
+            tf1.requestFocus();
+
+            Thread.sleep(500);
+            if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != tf1) {
+                throw new RuntimeException("Test failed (TextField1 isn't focus owner).");
+            }
+            tf1.selectAll();
+            Thread.sleep(500);
+
+            tf2.requestFocus();
+            Thread.sleep(500);
+
+            if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != tf2) {
+                throw new RuntimeException("Test failed (TextField2 isn't focus owner).");
+            }
+            tf2.selectAll();
+            Thread.sleep(500);
+
+            String selectedText = tf1.getSelectedText();
+            String text = tf1.getText();
+
+            System.out.println("tf1.getText()=" + text);
+            System.out.println("tf1.getSelectedText()=" + selectedText);
+
+            // Motif behaviour: After the selection of the second text, the first selected
+            // text is unselected
+            if (!selectedText.equals("") && !isWin) {
+                throw new RuntimeException("Test failed (TextField1 isn't deselected).");
+            }
+
+            // Windows behaviour: After the selection of the second text, the first selected
+            // text is only not highlighted
+            if (!selectedText.equals(text) && isWin) {
+                throw new RuntimeException("Test failed (TextField1 is deselected).");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/TextComponent/GetCaretPosOutOfBoundsTest.java
+++ b/test/jdk/java/awt/TextComponent/GetCaretPosOutOfBoundsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4995931
+  @summary java.awt.TextComponent caret position should be within the text bounds
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.TextField;
+
+public class GetCaretPosOutOfBoundsTest {
+    static TextField tf;
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            tf = new TextField("1234567890");
+            tf.setCaretPosition(100);
+            int pos = tf.getCaretPosition();
+            if (pos > 10) {
+                throw new RuntimeException("Wrong caret position:" + pos + " instead of 10");
+            }
+            tf.setText("12345");
+            if (tf.getCaretPosition() > 5) {
+                throw new RuntimeException("Wrong caret position:" + pos + " instead of 5");
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/TextComponent/InitialInsertionCaretPositionTest.java
+++ b/test/jdk/java/awt/TextComponent/InitialInsertionCaretPositionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4185654
+  @summary tests that the text insertion caret is positioned before the first character
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.TextArea;
+
+public class InitialInsertionCaretPositionTest {
+    static TextField textField;
+    static TextArea textArea;
+    static String failureMessage = "";
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            textArea = new TextArea("abcdefghij\nabcdefghij");
+            textField = new TextField("abcdefghij");
+
+            boolean textFieldPassed = (textField.getCaretPosition() == 0);
+            boolean textAreaPassed = (textArea.getCaretPosition() == 0);
+
+            if (!textFieldPassed) {
+                failureMessage += "   The text insertion caret for the text field is not\n";
+                failureMessage += "   initially set before the first character.\n";
+            }
+            if (!textAreaPassed) {
+                failureMessage += "   The text insertion caret for the text area is not\n";
+                failureMessage += "   initially set before the first character.\n";
+            }
+            if (textAreaPassed && textFieldPassed) {
+                System.out.println("The test passed.");
+            } else {
+                System.out.println("The test failed:");
+                System.out.println(failureMessage);
+            }
+            if (!textAreaPassed || !textFieldPassed) {
+                throw new RuntimeException(failureMessage);
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/TextComponent/MiddleMouseClickPasteTest.java
+++ b/test/jdk/java/awt/TextComponent/MiddleMouseClickPasteTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4426750
+  @requires (os.family == "linux")
+  @key headful
+  @summary tests that middle mouse button click pastes primary selection
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.TextComponent;
+import java.awt.TextField;
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.InputEvent;
+import java.awt.Toolkit;
+
+public class MiddleMouseClickPasteTest {
+    static final int FRAME_ACTIVATION_TIMEOUT  = 1000;
+    static final int SELECTION_PASTE_TIMEOUT   = 1000;
+    static final int CLICK_INTERVAL            = 50;
+    static final String TEST_TEXT              = "TEST TEXT";
+    static Frame frame;
+    static TextField tf;
+    static TextArea ta;
+    static final Clipboard systemSelection = Toolkit.getDefaultToolkit().getSystemSelection();
+
+
+    public static void main(String[] args) throws Exception {
+        if (systemSelection != null) {
+            try {
+                EventQueue.invokeAndWait(MiddleMouseClickPasteTest::createAndShowGui);
+                Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+                checkPaste(tf);
+                checkPaste(ta);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                EventQueue.invokeAndWait(()-> {
+                    if (frame != null) {
+                        frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    public static void createAndShowGui() {
+        frame = new Frame();
+        tf = new TextField();
+        ta = new TextArea();
+
+        frame.setLayout(new BorderLayout());
+        frame.add(tf, BorderLayout.NORTH);
+        frame.add(ta, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void checkPaste(TextComponent textComponent) throws Exception {
+
+        final Point sourcePoint = textComponent.getLocationOnScreen();
+        final Dimension d = textComponent.getSize();
+        sourcePoint.translate(d.width / 2, d.height / 2);
+        final Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(CLICK_INTERVAL);
+
+        textComponent.setText("");
+        systemSelection.setContents(new StringSelection(TEST_TEXT), null);
+
+        robot.mouseMove(sourcePoint.x, sourcePoint.y);
+        robot.mousePress(InputEvent.BUTTON2_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON2_DOWN_MASK);
+        robot.delay(SELECTION_PASTE_TIMEOUT);
+
+        if (!TEST_TEXT.equals(textComponent.getText())) {
+            throw new RuntimeException("Primary selection not pasted" +
+                    " into: " + textComponent);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8306432](https://bugs.openjdk.org/browse/JDK-8306432)

Tested on Linux/Gnome and Windows 11. All pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306432](https://bugs.openjdk.org/browse/JDK-8306432) needs maintainer approval

### Issue
 * [JDK-8306432](https://bugs.openjdk.org/browse/JDK-8306432): Open source several AWT Text Component related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2782/head:pull/2782` \
`$ git checkout pull/2782`

Update a local copy of the PR: \
`$ git checkout pull/2782` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2782`

View PR using the GUI difftool: \
`$ git pr show -t 2782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2782.diff">https://git.openjdk.org/jdk11u-dev/pull/2782.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2782#issuecomment-2172709490)