### PR TITLE
8320570: NegativeArraySizeException decoding >1G UTF8 bytes with non-ascii characters

### DIFF
--- a/src/java.base/share/classes/java/lang/StringCoding.java
+++ b/src/java.base/share/classes/java/lang/StringCoding.java
@@ -772,9 +772,9 @@ class StringCoding {
             }
         }
         if (dp == 0) {
-            dst = new byte[len << 1];
+            dst = StringUTF16.newBytesFor(len);
         } else {
-            byte[] buf = new byte[len << 1];
+            byte[] buf = StringUTF16.newBytesFor(len);
             StringLatin1.inflate(dst, 0, buf, 0, dp);
             dst = buf;
         }
@@ -910,7 +910,7 @@ class StringCoding {
             return Arrays.copyOf(val, val.length);
 
         int dp = 0;
-        byte[] dst = new byte[val.length << 1];
+        byte[] dst = StringUTF16.newBytesFor(val.length);
         for (int sp = 0; sp < val.length; sp++) {
             byte c = val[sp];
             if (c < 0) {

--- a/test/jdk/java/lang/String/CompactString/NegativeSize.java
+++ b/test/jdk/java/lang/String/CompactString/NegativeSize.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/*
+ * @test
+ * @bug 8077559
+ * @summary Tests Compact String for negative size.
+ * @requires vm.bits == 64 & os.maxMemory >= 4G
+ * @compile -encoding utf-8 NegativeSize.java
+ * @run main/othervm -XX:+CompactStrings -Xmx4g NegativeSize
+ * @run main/othervm -XX:-CompactStrings -Xmx4g NegativeSize
+ */
+
+// In Java8: java.lang.OutOfMemoryError: Java heap space
+// In Java9+: was java.lang.NegativeArraySizeException: -1894967266
+public class NegativeSize {
+
+    static byte[] generateData() {
+        int asciisize = 1_200_000_000;
+        byte[] nonAscii = "非アスキー".getBytes();
+        int nonAsciiSize = nonAscii.length;
+        // 1 GB
+        byte[] arr = new byte[asciisize + nonAsciiSize];
+        for (int i=0; i<asciisize; ++i) {
+            arr[i] = (byte)('0' + (i % 40));
+        }
+        for(int i=0; i<nonAsciiSize; ++i) {
+            arr[i + asciisize] = nonAscii[i];
+        }
+        return arr;
+    }
+
+
+    public static void main(String[] args) throws IOException {
+
+        try {
+            byte[] largeBytes = generateData();
+            String inStr = new String(largeBytes, StandardCharsets.UTF_8);
+            System.out.println(inStr.length());
+            System.out.println(inStr.substring(1_200_000_000));
+        } catch (OutOfMemoryError ex) {
+            if (ex.getMessage().startsWith("UTF16 String size is")) {
+                System.out.println("Succeeded with OutOfMemoryError");
+            } else {
+                throw new RuntimeException("Failed: Not the OutOfMemoryError expected", ex);
+            }
+        } catch (NegativeArraySizeException ex) {
+            throw new RuntimeException("Failed: Expected OutOfMemoryError", ex);
+        }
+    }
+}
+
+


### PR DESCRIPTION
Backport of [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570) from JDK 17. This version differs because https://github.com/openjdk/jdk17u-dev/commit/58ceb254437a51f9d7efa272b12ff01d921bfba9 is not in JDK 11. The included test has passed. Please review!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570) needs maintainer approval

### Issue
 * [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570): NegativeArraySizeException decoding &gt;1G UTF8 bytes with non-ascii characters (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2783/head:pull/2783` \
`$ git checkout pull/2783`

Update a local copy of the PR: \
`$ git checkout pull/2783` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2783`

View PR using the GUI difftool: \
`$ git pr show -t 2783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2783.diff">https://git.openjdk.org/jdk11u-dev/pull/2783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2783#issuecomment-2173611106)