### PR TITLE
8330416: Update system property for Java SE specification maintenance version

### DIFF
--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,7 +198,7 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
     PUTPROP(props, "java.specification.version",
             VERSION_SPECIFICATION);
     PUTPROP(props, "java.specification.maintenance.version",
-            "2");
+            "3");
     PUTPROP(props, "java.specification.name",
             "Java Platform API Specification");
     PUTPROP(props, "java.specification.vendor",


### PR DESCRIPTION
Please review this PR which is a backport of https://github.com/openjdk/jdk11u-ri/commit/22fe35f286c71e01945cacc95ef090cadf1c3d99.
This is a trivial increment of the `"java.specification.maintenance.version"` system property value from 2 to 3.
Associated GHA run: https://github.com/justin-curtis-lu/jdk11u-dev/actions/runs/9553142262.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330416](https://bugs.openjdk.org/browse/JDK-8330416) needs maintainer approval

### Issue
 * [JDK-8330416](https://bugs.openjdk.org/browse/JDK-8330416): Update system property for Java SE specification maintenance version (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2784/head:pull/2784` \
`$ git checkout pull/2784`

Update a local copy of the PR: \
`$ git checkout pull/2784` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2784`

View PR using the GUI difftool: \
`$ git pr show -t 2784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2784.diff">https://git.openjdk.org/jdk11u-dev/pull/2784.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2784#issuecomment-2174385743)