### PR TITLE
8327840: Automate javax/swing/border/Test4129681.java

### DIFF
--- a/test/jdk/javax/swing/border/Test4129681.java
+++ b/test/jdk/javax/swing/border/Test4129681.java
@@ -21,50 +21,62 @@
  * questions.
  */
 
-import java.awt.event.ItemEvent;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.JCheckBox;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
 
 /*
  * @test
  * @bug 4129681
  * @summary Tests disabling of titled border's caption
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @run main/manual Test4129681
+ * @run main/othervm -Dsun.java2d.uiScale=1 Test4129681
  */
 
 public class Test4129681 {
     public static void main(String[] args) throws Exception {
-        String testInstructions = "Click the checkbox to disable the label.\n" +
-                                  "The test passes if the title of the border\n" +
-                                  "is disabled as well as the label.\n";
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        int correctColoredPixels = 0;
+        int totalPixels = 0;
+        int tolerance = 20;
+        JLabel label;
+        Color labelDisableColor = Color.RED;
+        Dimension SIZE = new Dimension(100, 40);
+        Point startPoint = new Point(8, 4);
+        Point endPoint = new Point(18, 14);
 
-        PassFailJFrame.builder()
-                .title("Test Instructions")
-                .instructions(testInstructions)
-                .rows(4)
-                .columns(25)
-                .splitUI(Test4129681::init)
-                .build()
-                .awaitAndCheck();
-    }
+        label = new JLabel("Label");
+        label.setBorder(BorderFactory.createTitledBorder("\u2588".repeat(5)));
+        UIManager.getDefaults().put("Label.disabledForeground", labelDisableColor);
+        label.setSize(SIZE);
+        label.setEnabled(false);
+        BufferedImage image = new BufferedImage(label.getWidth(), label.getHeight(),
+                BufferedImage.TYPE_INT_ARGB);
 
-    public static JComponent init() {
-        JLabel label = new JLabel("message");
-        JCheckBox check = new JCheckBox("Enable/Disable");
-        check.addItemListener(event ->
-                label.setEnabled(ItemEvent.DESELECTED == event.getStateChange()));
-        label.setBorder(BorderFactory.createTitledBorder("label"));
-        label.setEnabled(!check.isSelected());
+        Graphics2D g2d = image.createGraphics();
+        label.paint(g2d);
+        g2d.dispose();
 
-        Box main = Box.createVerticalBox();
-        main.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
-        main.add(check);
-        main.add(label);
-        return main;
+        for (int x = startPoint.x; x < endPoint.x; x++) {
+            for (int y = startPoint.y; y < endPoint.y; y++) {
+                if (image.getRGB(x, y) == labelDisableColor.getRGB()) {
+                    correctColoredPixels++;
+                }
+                totalPixels++;
+            }
+        }
+
+        if (((double) correctColoredPixels / totalPixels * 100) <= tolerance) {
+            ImageIO.write(image, "png", new File("failureImage.png"));
+            throw new RuntimeException("Label with border is not disabled");
+        }
+        System.out.println("Test Passed");
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [177b8a24](https://github.com/openjdk/jdk/commit/177b8a241c11782b302607c0068b15b38112e67c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tejesh R on 22 Mar 2024 and was reviewed by Abhishek Kumar and Phil Race.

The change is not clean since in jdk11u-dev the usage of textblock was removed in the test: https://github.com/openjdk/jdk11u-dev/commit/5bd20f07c70ff7b85794281b514b494bc8506181, but the resulted code after this patch is identical to openjdk/jdk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327840](https://bugs.openjdk.org/browse/JDK-8327840) needs maintainer approval

### Issue
 * [JDK-8327840](https://bugs.openjdk.org/browse/JDK-8327840): Automate javax/swing/border/Test4129681.java (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2785/head:pull/2785` \
`$ git checkout pull/2785`

Update a local copy of the PR: \
`$ git checkout pull/2785` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2785`

View PR using the GUI difftool: \
`$ git pr show -t 2785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2785.diff">https://git.openjdk.org/jdk11u-dev/pull/2785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2785#issuecomment-2174862107)