### PR TITLE
8306850: Open source AWT Modal related tests

### DIFF
--- a/test/jdk/java/awt/Modal/BlockedMouseInputTest.java
+++ b/test/jdk/java/awt/Modal/BlockedMouseInputTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4957639
+  @summary REGRESSION: blocked mouse input in a special case on win32
+  @key headful
+  @run main BlockedMouseInputTest
+*/
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+/*
+ * Threads:
+ * 0) Main - running others, checking
+ * 1) First - opening first dialog
+ * 2) Second - opening second dialog, generating item state changed events
+ * We need 1 and 2 thread in order to don't block main thread
+ */
+
+public class BlockedMouseInputTest implements ItemListener {
+    Frame frame = null;
+
+    ThreadDialog thread1 = null;
+    ThreadDialog thread2 = null;
+
+    // If we recreate dialogs in the Threads classes then the test works fine
+    JComboBox<String> cb = null;
+    JDialog dialog1 = null;
+    JDialog dialog2 = null;
+
+    Robot r = null;
+    volatile Point loc = null;
+    volatile int cbWidth;
+    volatile int cbHeight;
+
+    volatile int selected;
+
+    volatile boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        BlockedMouseInputTest test = new BlockedMouseInputTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Parent frame");
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+                if (dialog1 != null) {
+                    dialog1.dispose();
+                }
+                if (dialog2 != null) {
+                    dialog2.dispose();
+                }
+            });
+        }
+    }
+
+    private void test() throws Exception {
+
+        // The state of the combobox should stay the same to new iteration of the cycle
+        // We couldn't run the thread twice
+        EventQueue.invokeAndWait(() -> {
+            cb = new JComboBox<String>(new String[]{"entry a", "entry b",
+                    "entry c", "entry d", "entry e"});
+            dialog1 = new JDialog(frame, "dialog1", true);
+            dialog2 = new JDialog(frame, "dialog2", true);
+            dialog2.getContentPane().add(cb);
+            cb.addItemListener(this);
+
+            dialog1.setLocation(20, 20);
+            dialog1.setSize(new Dimension(150, 50));
+            dialog2.setLocation(120, 120);
+            dialog2.setSize(new Dimension(150, 50));
+        });
+
+        for (int i = 0; i < 2; i++) {
+            passed = false;
+            tryGenerateEvent();
+            if (!passed && i != 0) {
+                throw new RuntimeException("Test failed: triggering not occurred, iteration - " + i);
+            }
+        }
+    }
+
+    private void tryGenerateEvent() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            thread1 = new ThreadDialog(dialog1);
+            thread2 = new ThreadDialog(dialog2);
+        });
+
+        thread1.start();
+        r.delay(500);
+        r.waitForIdle();
+        thread2.start();
+        r.delay(500);
+        r.waitForIdle();
+
+        doRobotAction();
+
+        EventQueue.invokeAndWait(() -> {
+            dialog2.setVisible(false);
+            dialog1.setVisible(false);
+        });
+    }
+
+    public void itemStateChanged(ItemEvent ie) {
+        passed = true;
+        System.out.println("event: "+ie);
+    }
+
+    public void doRobotAction() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            loc = cb.getLocationOnScreen();
+            cbWidth = cb.getWidth();
+            cbHeight = cb.getHeight();
+        });
+
+        r.mouseMove(loc.x + cbWidth / 2, loc.y + cbHeight / 2);
+        r.delay(500);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+
+        EventQueue.invokeAndWait(() -> {
+            selected = cb.getSelectedIndex();
+        });
+
+        r.mouseMove(loc.x + cbWidth / 2, loc.y + cbHeight * ((selected == 0) ? 2 : 1) + 10);
+        r.delay(500);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+
+        r.waitForIdle();
+    }
+}
+
+class ThreadDialog extends Thread {
+
+    JDialog dialog = null;
+
+    public ThreadDialog(JDialog dialog){
+        this.dialog = dialog;
+    }
+
+    public void run() {
+        dialog.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Modal/BlockedMouseInputTest2.java
+++ b/test/jdk/java/awt/Modal/BlockedMouseInputTest2.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6271546
+  @summary REG. Mouse input blocked on a window which is a child of a modal dialog
+  @key headful
+  @run main BlockedMouseInputTest2
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+public class BlockedMouseInputTest2 {
+    Frame frame;
+    Dialog dlg1;
+    Dialog dlg2;
+    Button b;
+    Robot r = null;
+    volatile boolean passed = false;
+    volatile Point p;
+    volatile int btnWidth;
+    volatile int btnHeight;
+
+    public static void main(String args[]) throws Exception {
+        BlockedMouseInputTest2 test = new BlockedMouseInputTest2();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Parent frame");
+                frame.setBounds(100, 100, 200, 100);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+
+                dlg1 = new Dialog(frame, "Dialog 1", true);
+                dlg1.setBounds(200, 200, 200, 100);
+
+            new Thread(new Runnable() {
+                public void run() {
+                    dlg1.setVisible(true);
+                }
+            }).start();
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                dlg2 = new Dialog(frame, "Dialog 2", true);
+                dlg2.setBounds(300, 300, 200, 100);
+            });
+            new Thread(new Runnable() {
+                public void run() {
+                    dlg2.setVisible(true);
+                }
+            }).start();
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                Dialog d = new Dialog(dlg2, "D", false);
+                d.setBounds(400, 400, 200, 100);
+                d.setLayout(new BorderLayout());
+                b = new Button("Test me");
+                b.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        passed = true;
+                    }
+                });
+                d.add(b, BorderLayout.CENTER);
+                d.setVisible(true);
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                p = b.getLocationOnScreen();
+                btnWidth = b.getSize().width;
+                btnHeight = b.getSize().height;
+            });
+            r.mouseMove(p.x + btnWidth / 2, p.y + btnHeight / 2);
+            r.delay(500);
+            r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            r.delay(500);
+            r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            r.delay(500);
+
+            if (!passed) {
+                throw new RuntimeException("Test is FAILED: button is not pressed");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+                if (dlg1 != null) {
+                    dlg1.dispose();
+                }
+                if (dlg2 != null) {
+                    dlg2.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/Modal/BlockedMouseInputTest3.java
+++ b/test/jdk/java/awt/Modal/BlockedMouseInputTest3.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6274378
+  @summary Test for 6274378: Blocked mouse and keyboard input after hiding modal dialog
+  @key headful
+  @run main BlockedMouseInputTest3
+*/
+
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+
+public class BlockedMouseInputTest3 {
+    Frame frame;
+
+    Dialog dlg1; // application-modal
+    Dialog dlg2; // application-modal
+    Dialog d; // toolkit-modal
+
+    Button b1; // in dlg1
+    Button b2; // in dlg2
+
+    Robot r = null;
+
+    volatile boolean b1pressed, b2pressed;
+    volatile boolean dlg1activated, dlg2activated;
+    volatile int b1Width, b1Height;
+    volatile int b2Width, b2Height;
+    volatile Point p1, p2;
+
+    public static void main(String args[]) throws Exception {
+        BlockedMouseInputTest3 test = new BlockedMouseInputTest3();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Parent frame");
+                frame.setBounds(0, 0, 200, 100);
+                frame.setVisible(true);
+
+                // create d and set it visible
+                d = new Dialog(frame, "Toolkit-modal", Dialog.ModalityType.TOOLKIT_MODAL);
+                d.setBounds(250, 0, 200, 100);
+            });
+            EventQueue.invokeLater(new Runnable() {
+                public void run() {
+                    d.setVisible(true);
+                }
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            // create dlg1 and set it visible
+            // dlg1 is blocked by d
+
+            EventQueue.invokeAndWait(() -> {
+                dlg1 = new Dialog(frame, "Application-modal 1", Dialog.ModalityType.APPLICATION_MODAL);
+                dlg1.setBounds(0, 150, 200, 100);
+                dlg1.addWindowListener(new WindowAdapter() {
+                    public void windowActivated(WindowEvent e) {
+                        dlg1activated = true;
+                    }
+                });
+                b1 = new Button("B1");
+                b1.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        b1pressed = true;
+                    }
+                });
+                dlg1.add(b1);
+            });
+            EventQueue.invokeLater(new Runnable() {
+                public void run() {
+                    dlg1.setVisible(true);
+                }
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            // create dlg2 and set it visible
+            // dlg2 is blocked by d
+            EventQueue.invokeAndWait(() -> {
+                dlg2 = new Dialog(frame, "Application-modal 2", Dialog.ModalityType.APPLICATION_MODAL);
+                dlg2.setBounds(0, 300, 200, 100);
+                dlg2.addWindowListener(new WindowAdapter() {
+                    public void windowActivated(WindowEvent e) {
+                        dlg2activated = true;
+                    }
+                });
+                b2 = new Button("B2");
+                b2.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        b2pressed = true;
+                    }
+                });
+                dlg2.add(b2);
+            });
+            EventQueue.invokeLater(new Runnable() {
+                public void run() {
+                    dlg2.setVisible(true);
+                }
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+
+            // hide d
+            // dlg2 is unblocked and dlg1 is blocked by dlg2
+            EventQueue.invokeAndWait(() -> {
+                d.setVisible(false);
+            });
+
+            r.delay(1000);
+            r.waitForIdle();
+
+            // values to check
+            b1pressed = false;
+            b2pressed = false;
+            dlg1activated = false;
+            dlg2activated = false;
+            System.err.println(KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow());
+
+            // check mouse events and activation
+            EventQueue.invokeAndWait(() -> {
+                p1 = b1.getLocationOnScreen();
+                b1Width = b1.getWidth();
+                b1Height = b1.getHeight();
+            });
+            clickPoint(r, p1.x + b1Width / 2, p1.y + b1Height / 2);
+
+            EventQueue.invokeAndWait(() -> {
+                dlg1activated = (KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow() == dlg1);
+            });
+
+            EventQueue.invokeAndWait(() -> {
+                p2 = b2.getLocationOnScreen();
+                b2Width = b2.getWidth();
+                b2Height = b2.getHeight();
+            });
+
+            clickPoint(r, p2.x + b2Width / 2, p2.y + b2Height / 2);
+
+            EventQueue.invokeAndWait(() -> {
+                dlg2activated = (KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow() == dlg2);
+            });
+
+            if (dlg1activated || b1pressed || !dlg2activated || !b2pressed) {
+                throw new RuntimeException("Test is FAILED");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+                if (dlg1 != null) {
+                    dlg1.dispose();
+                }
+                if (dlg2 != null) {
+                    dlg2.dispose();
+                }
+                if (d != null) {
+                    d.dispose();
+                }
+            });
+        }
+    }
+
+    private static void clickPoint(Robot r, int x, int y) {
+        r.mouseMove(x, y);
+        r.delay(500);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+    }
+}

--- a/test/jdk/java/awt/Modal/ModalDialogCannotBeMadeNonModalTest.java
+++ b/test/jdk/java/awt/Modal/ModalDialogCannotBeMadeNonModalTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4272629
+  @summary Modal dialog cannot be made non-modal
+  @key headful
+  @run main ModalDialogCannotBeMadeNonModalTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+public class ModalDialogCannotBeMadeNonModalTest {
+    Frame frame = null;
+    Button button = null;
+    Dialog dialog = null;
+    Robot r = null;
+    volatile Point loc = null;
+
+    volatile private boolean buttonPressed = false;
+
+    public static void main(String args[]) throws Exception {
+        ModalDialogCannotBeMadeNonModalTest test = new ModalDialogCannotBeMadeNonModalTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Parent frame");
+                frame.setLayout(new BorderLayout());
+                frame.setBounds(200, 200, 200, 200);
+                frame.setVisible(true);
+
+                button = new Button("Trigger");
+                button.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        buttonPressed = true;
+                    }
+                });
+                frame.add(button);
+                frame.setVisible(true);
+
+                dialog = new Dialog(frame, "Dialog");
+                dialog.setBounds(0, 0, 100, 100);
+                dialog.addWindowListener(new WindowAdapter() {
+                    public void windowClosing(WindowEvent we) {
+                        we.getWindow().setVisible(false);
+                    }
+                });
+            });
+
+            r.delay(500);
+            r.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                loc = button.getLocationOnScreen();
+            });
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+                if (dialog != null) {
+                    dialog.dispose();
+                }
+            });
+        }
+
+    }
+    public void test() throws Exception {
+
+        // 1-visibility, 2-modality
+        System.out.println("1 create visible, modal ... ");
+        EventQueue.invokeAndWait(() -> {
+            dialog.setModal(true);
+            setDialogVisible(true);
+        });
+        r.delay(1000);
+        r.waitForIdle();
+
+        System.out.println("2 set non visible, modal ... ");
+        EventQueue.invokeAndWait(() -> {
+            dialog.setVisible(false);
+            dialog.setModal(false);
+        });
+        r.delay(1000);
+        r.waitForIdle();
+
+        System.out.println("3 set visible, non modal ... ");
+        EventQueue.invokeAndWait(() -> {
+            setDialogVisible(true);
+        });
+        r.delay(1000);
+        r.waitForIdle();
+
+        System.out.println("4 checking ... ");
+        check();
+        r.delay(1000);
+        r.waitForIdle();
+        System.out.println("5 exit ");
+    }
+
+    public void check() throws Exception {
+        r.delay(500);
+        r.mouseMove(loc.x + button.getWidth()/2, loc.y + button.getHeight()/2);
+        r.delay(500);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+
+        if (!buttonPressed) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+
+    public void setDialogVisible(boolean visibility) {
+        if (visibility) {
+            new Thread(new Runnable() {
+                public void run() {
+                    dialog.setVisible(true);
+                }
+            }).start();
+        } else {
+            dialog.setVisible(false);
+        }
+    }
+}

--- a/test/jdk/java/awt/Modal/NonModalDialogReceiveEventsAfterModalTest.java
+++ b/test/jdk/java/awt/Modal/NonModalDialogReceiveEventsAfterModalTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4256692
+  @summary Showing a non modal dialog after a modal dialog allows both to receive events
+  @key headful
+  @run main NonModalDialogReceiveEventsAfterModalTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+
+public class NonModalDialogReceiveEventsAfterModalTest implements Runnable
+{
+    Frame modalParentFrame, nonModalParentFrame;
+    Dialog modalDialog, nonModalDialog;
+
+    volatile public static boolean passed = true;
+    volatile public static String errorMessage = null;
+
+    Robot r = null;
+    volatile Point loc = null;
+
+    public static void main(String args[]) throws Exception {
+        NonModalDialogReceiveEventsAfterModalTest test = new NonModalDialogReceiveEventsAfterModalTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+
+        // create an independent top level frame to be the
+        // parent of the modal dialog and show it
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                modalParentFrame = new Frame("Parent of modal dialog");
+                modalParentFrame.setBounds(100, 100, 200, 200);
+                modalParentFrame.setLayout(new BorderLayout());
+                modalParentFrame.setVisible(true);
+
+                // create an independent top level frame to be the
+                // parent of the non-modal dialog and show it
+                nonModalParentFrame = new Frame("Parent of non-modal dialog");
+                nonModalParentFrame.setBounds(400, 100, 200, 200);
+                nonModalParentFrame.setLayout(new BorderLayout());
+                nonModalParentFrame.setVisible(true);
+
+                // create the non-modal dialog and kick off a
+                // thread to show it in 1 second
+                nonModalDialog = new Dialog(nonModalParentFrame, "Non modal", false);
+                nonModalDialog.setBounds(400, 150, 100, 100);
+                nonModalDialog.addMouseMotionListener(new TestMouseMotionAdapter());
+                nonModalDialog.addFocusListener(new TestFocusAdapter());
+                new Thread(this).start();
+
+                // create the modal dialog and show it from this thread
+                modalDialog = new Dialog(modalParentFrame, "Modal", true);
+                modalDialog.setBounds(100, 400, 100, 100);
+                modalDialog.setVisible(true);
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (modalParentFrame != null) {
+                    modalParentFrame.dispose();
+                }
+                if (nonModalParentFrame != null) {
+                    nonModalParentFrame.dispose();
+                }
+                if (modalDialog != null) {
+                    modalDialog.dispose();
+                }
+                if (nonModalDialog != null) {
+                    nonModalDialog.dispose();
+                }
+            });
+        }
+
+    }
+
+    // This is the implementation of Runnable and is
+    // used to show the non-modal dialog in 1 second
+    public void run() {
+        r.delay(1000);
+        r.waitForIdle();
+        //show the non modal dialog
+        nonModalDialog.setVisible(true);
+
+        r.delay(1000);
+        r.waitForIdle();
+        test();
+    }
+
+    private void test() {
+
+        // mouse, focus, activate events triggering
+        r.delay(500);
+        loc = nonModalDialog.getLocationOnScreen();
+        r.delay(500);
+
+        r.mouseMove(loc.x + (int) (nonModalDialog.getWidth() / 2), loc.y + (int) (nonModalDialog.getHeight() / 2));
+        r.delay(100);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(100);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(100);
+        r.mouseMove(loc.x - 100, loc.y - 100);
+
+        r.waitForIdle();
+
+        // dispose modal window in order to finish test
+        modalDialog.dispose();
+
+        // check test result
+        if (!passed) {
+            throw new RuntimeException("test failed: " + errorMessage);
+        }
+    }
+
+    public static void testFailed(String message) {
+        passed = false;
+        errorMessage = message;
+    }
+}
+
+class TestMouseMotionAdapter extends MouseMotionAdapter {
+
+    public void mouseClicked(MouseEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("mouseClicked");
+    }
+
+    public void mouseEntered(MouseEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("mouseEntered");
+    }
+
+    public void mouseExited(MouseEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("mouseExited");
+    }
+
+    public void mousePressed(MouseEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("mousePressed");
+    }
+
+    public void mouseReleased(MouseEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("mouseReleased");
+    }
+}
+
+class TestFocusAdapter extends FocusAdapter {
+    public void focusGained(FocusEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("focusGained");
+    }
+
+    public void focusLost(FocusEvent e){
+        NonModalDialogReceiveEventsAfterModalTest.testFailed("focusLost");
+    }
+}

--- a/test/jdk/java/awt/Modal/ParentCatchupDraggingChildDialogTest.java
+++ b/test/jdk/java/awt/Modal/ParentCatchupDraggingChildDialogTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5083555
+  @summary Parent Windows of mouse events catchup while dragging child dialog window
+  @key headful
+  @run main ParentCatchupDraggingChildDialogTest
+*/
+
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+
+public class ParentCatchupDraggingChildDialogTest {
+    JFrame frame = null;
+    JDialog dialog = null;
+    DialogThread thread = null;
+    JButton trigger = new JButton("trigger");
+    JButton show = new JButton("show");
+    Robot r = null;
+    volatile Point locTrigger, locDialog;
+
+    volatile boolean passed = true;
+
+    public static void main(String args[]) throws Exception {
+        ParentCatchupDraggingChildDialogTest test = new ParentCatchupDraggingChildDialogTest();
+        test.start();
+    }
+
+    public void start () throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new JFrame("Parent frame");
+                frame.setBounds(20, 20, 300, 300);
+                frame.setLayout(new FlowLayout());
+                frame.add(trigger);
+                frame.add(show);
+                frame.setVisible(true);
+
+                dialog = new JDialog(frame, "Dialog", true);
+                dialog.setBounds(100, 100, 300, 300);
+
+                trigger.addMouseListener(new MouseAdapter() {
+                    public void mouseEntered(MouseEvent e) {
+                        System.out.println("Trigger button event: " + e);
+                        passed = false;
+                    }
+                });
+            });
+
+            thread = new DialogThread(dialog);
+            thread.start();
+
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+                if (dialog != null) {
+                    dialog.dispose();
+                }
+            });
+        }
+    }
+
+    /* Test scenario:
+     * 1) dragging mouse over the 'Trigger' button in order to be sure that the events don't occured for non modal window
+     * 2) checking
+     * 3) close dialog in order to finish test
+     */
+    private void test() throws Exception {
+        try {
+            r = new Robot();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        r.delay(500);
+        EventQueue.invokeAndWait(() -> {
+            locTrigger = trigger.getLocationOnScreen();
+        });
+
+        r.delay(500);
+        EventQueue.invokeAndWait(() -> {
+            locDialog = dialog.getLocationOnScreen();
+        });
+        r.delay(500);
+
+        r.mouseMove(locDialog.x + dialog.getWidth() / 2, locDialog.y + dialog.getHeight() / 2);
+        r.delay(500);
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+        r.mouseMove(locTrigger.x + trigger.getWidth() / 2, locTrigger.y + trigger.getHeight() / 2);
+        r.delay(500);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.delay(500);
+
+        if (!passed) {
+            throw new RuntimeException("Test failed. Triggering occured.");
+        }
+
+        EventQueue.invokeAndWait(() -> {
+            dialog.dispose();
+        });
+    }
+}
+
+class DialogThread extends Thread {
+    JDialog dialog = null;
+
+    public DialogThread(JDialog dialog){
+        this.dialog = dialog;
+    }
+
+    public void run(){
+        dialog.setVisible(true);
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8306850](https://bugs.openjdk.org/browse/JDK-8306850) for parity with Oracle 11.0.24.

Tested on Linux/Gnome and Windows 11. All tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306850](https://bugs.openjdk.org/browse/JDK-8306850) needs maintainer approval

### Issue
 * [JDK-8306850](https://bugs.openjdk.org/browse/JDK-8306850): Open source AWT Modal related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2791/head:pull/2791` \
`$ git checkout pull/2791`

Update a local copy of the PR: \
`$ git checkout pull/2791` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2791`

View PR using the GUI difftool: \
`$ git pr show -t 2791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2791.diff">https://git.openjdk.org/jdk11u-dev/pull/2791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2791#issuecomment-2175749293)