### PR TITLE
8276306: jdk/jshell/CustomInputToolBuilder.java fails intermittently on storage acquisition

### DIFF
--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import jdk.jshell.tool.JavaShellToolBuilder;
 import org.testng.annotations.Test;
@@ -88,6 +89,7 @@ public class CustomInputToolBuilder extends KullaTesting {
                     .out(printOut, printOut, printOut)
                     .interactiveTerminal(interactiveTerminal)
                     .promptCapture(true)
+                    .persistence(new HashMap<>())
                     .start("--no-startup");
 
             String actual = new String(out.toByteArray());


### PR DESCRIPTION
Clean backport of [JDK-8276306](https://bugs.openjdk.java.net/browse/JDK-8276306).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276306](https://bugs.openjdk.org/browse/JDK-8276306) needs maintainer approval

### Issue
 * [JDK-8276306](https://bugs.openjdk.org/browse/JDK-8276306): jdk/jshell/CustomInputToolBuilder.java fails intermittently on storage acquisition (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2794/head:pull/2794` \
`$ git checkout pull/2794`

Update a local copy of the PR: \
`$ git checkout pull/2794` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2794`

View PR using the GUI difftool: \
`$ git pr show -t 2794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2794.diff">https://git.openjdk.org/jdk11u-dev/pull/2794.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2794#issuecomment-2176399297)