### PR TITLE
8334332: TestIOException.java fails if run by root

### DIFF
--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -22,3 +22,7 @@ useNewOptions=true
 
 # Use --patch-module instead of -Xmodule:
 useNewPatchModule=true
+
+# Path to libraries in the topmost test directory. This is needed so @library
+# does not need ../../ notation to reach them
+external.lib.roots = ../../

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -37,7 +37,6 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.util.Map;
 
-// import JavadocTester;
 import jtreg.SkippedException;
 
 /**

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8164130
+ * @bug 8164130 8334332
  * @summary test IOException handling
- * @library ../lib
+ * @library ../lib /test/lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build JavadocTester
  * @run main TestIOException
@@ -33,7 +33,19 @@
 
 import java.io.File;
 import java.io.FileWriter;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.Map;
 
+// import JavadocTester;
+import jtreg.SkippedException;
+
+/**
+ * Tests IO Exception handling.
+ *
+ * Update: Windows does not permit setting folder to be readonly.
+ * https://support.microsoft.com/en-us/help/326549/you-cannot-view-or-change-the-read-only-or-the-system-attributes-of-fo
+ */
 public class TestIOException extends JavadocTester {
 
     public static void main(String... args) throws Exception {
@@ -45,13 +57,13 @@ public class TestIOException extends JavadocTester {
     void testReadOnlyDirectory() {
         File outDir = new File("out1");
         if (!outDir.mkdir()) {
-            throw new Error("Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         if (!outDir.setReadOnly()) {
-            throw new Error("could not set directory read-only");
+            throw skip(outDir, "could not set directory read-only");
         }
         if (outDir.canWrite()) {
-            throw new Error("directory is writable");
+            throw skip(outDir, "directory is writable");
         }
 
         try {
@@ -69,15 +81,15 @@ public class TestIOException extends JavadocTester {
     void testReadOnlyFile() throws Exception {
         File outDir = new File("out2");
         if (!outDir.mkdir()) {
-            throw new Error("Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         File index = new File(outDir, "index.html");
         try (FileWriter fw = new FileWriter(index)) { }
         if (!index.setReadOnly()) {
-            throw new Error("could not set index read-only");
+            throw skip(index, "could not set index read-only");
         }
         if (index.canWrite()) {
-            throw new Error("index is writable");
+            throw skip(index, "index is writable");
         }
 
         try {
@@ -109,13 +121,13 @@ public class TestIOException extends JavadocTester {
         File outDir = new File("out3");
         File pkgOutDir = new File(outDir, "p");
         if (!pkgOutDir.mkdirs()) {
-            throw new Error("Cannot create directory");
+            throw skip(pkgOutDir, "Cannot create directory");
         }
         if (!pkgOutDir.setReadOnly()) {
-            throw new Error("could not set directory read-only");
+            throw skip(pkgOutDir, "could not set directory read-only");
         }
         if (pkgOutDir.canWrite()) {
-            throw new Error("directory is writable");
+            throw skip(pkgOutDir, "directory is writable");
         }
 
         // run javadoc and check results
@@ -153,13 +165,13 @@ public class TestIOException extends JavadocTester {
         File pkgOutDir = new File(outDir, "p");
         File docFilesOutDir = new File(pkgOutDir, "doc-files");
         if (!docFilesOutDir.mkdirs()) {
-            throw new Error("Cannot create directory");
+            throw skip(docFilesOutDir, "Cannot create directory");
         }
         if (!docFilesOutDir.setReadOnly()) {
-            throw new Error("could not set directory read-only");
+            throw skip(docFilesOutDir, "could not set directory read-only");
         }
         if (docFilesOutDir.canWrite()) {
-            throw new Error("directory is writable");
+            throw skip(docFilesOutDir, "directory is writable");
         }
 
         try {
@@ -173,6 +185,31 @@ public class TestIOException extends JavadocTester {
         } finally {
             setOutputDirectoryCheck(DirectoryCheck.EMPTY);
             docFilesOutDir.setWritable(true);
+        }
+    }
+
+    private Error skip(File f, String message) {
+        out.print(System.getProperty("user.name"));
+        out.println(f + ": " + message);
+        showAllAttributes(f.toPath());
+        throw new SkippedException(f + ": " + message);
+    }
+
+    private void showAllAttributes(Path p) {
+        showAttributes(p, "*");
+        showAttributes(p, "posix:*");
+        showAttributes(p, "dos:*");
+    }
+
+    private void showAttributes(Path p, String attributes) {
+        out.println("Attributes: " + attributes);
+        try {
+            Map<String, Object> map = Files.readAttributes(p, attributes);
+            map.forEach((n, v) -> out.format("  %-10s: %s%n", n, v));
+        } catch (UnsupportedOperationException e) {
+            out.println("Attributes not available " + attributes);
+        } catch (Throwable t) {
+            out.println("Error accessing attributes " + attributes + ": " + t);
         }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [472b935b](https://github.com/openjdk/jdk/commit/472b935b442f7f925b665c7de91eda77f3dcbe8b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 18 Jun 2024 and was reviewed by Pavel Rappo.

The reason of backport is not clean is that, multiple PRs have been merged into the `jdk17u-dev` of this file, including `JDK-8215516`, `JDK-8164597`, etc., and these PRs cannot be directly backported to `jdk11u-dev`.

This PR also change `test/langtools/TEST.ROOT`, it's partial backport of [JDK-8242652](https://bugs.openjdk.org/browse/JDK-8242652). [JDK-8242652](https://bugs.openjdk.org/browse/JDK-8242652) can't backport to jdk11u-dev, the jdk11u-dev repo dosen't have file `test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java`.

Only change test testcase, the risk is quite very low.

The change verified on below env:

- [x] linux non-root user
- [x] linix root user
- [x] windows

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334332](https://bugs.openjdk.org/browse/JDK-8334332) needs maintainer approval

### Issue
 * [JDK-8334332](https://bugs.openjdk.org/browse/JDK-8334332): TestIOException.java fails if run by root (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2795/head:pull/2795` \
`$ git checkout pull/2795`

Update a local copy of the PR: \
`$ git checkout pull/2795` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2795`

View PR using the GUI difftool: \
`$ git pr show -t 2795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2795.diff">https://git.openjdk.org/jdk11u-dev/pull/2795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2795#issuecomment-2176410977)
</details>
