### PR TITLE
8331063: Some HttpClient tests don't report leaks

### DIFF
--- a/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
+++ b/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,18 +210,18 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
     @DataProvider(name = "all")
     public Object[][] allcases() {
         List<Object[]> result = new ArrayList<>();
-        for (var client : List.of(authClient, noAuthClient)) {
+        for (boolean useAuth : List.of(true, false)) {
             for (boolean async : List.of(true, false)) {
                 for (int code : List.of(UNAUTHORIZED, PROXY_UNAUTHORIZED)) {
                     var srv = code == PROXY_UNAUTHORIZED ? "/proxy" : "/server";
                     for (var auth : List.of("/auth", "/noauth")) {
                         var pcode = code;
                         if (auth.equals("/noauth")) {
-                            if (client == authClient) continue;
+                            if (useAuth) continue;
                             pcode = FORBIDDEN;
                         }
                         for (var uri : List.of(httpURI, httpsURI, http2URI, https2URI)) {
-                            result.add(new Object[]{uri + srv + auth, pcode, async, client});
+                            result.add(new Object[]{uri + srv + auth, pcode, async, useAuth});
                         }
                     }
                 }
@@ -242,12 +242,13 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
     static final AtomicLong sleepCount = new AtomicLong();
 
     @Test(dataProvider = "all")
-    void test(String uriString, int code, boolean async, HttpClient client) throws Throwable {
+    void test(String uriString, int code, boolean async, boolean useAuth) throws Throwable {
         checkSkip();
+        HttpClient client = useAuth ? authClient : noAuthClient;
         var name = String.format("test(%s, %d, %s, %s)", uriString, code, async ? "async" : "sync",
                 client.authenticator().isPresent() ? "authClient" : "noAuthClient");
         out.printf("%n---- starting %s ----%n", name);
-        assert client.authenticator().isPresent() ? client == authClient : client == noAuthClient;
+        assert client.authenticator().isPresent() == useAuth;
         uriString = uriString + "/ForbiddenTest";
         for (int i=0; i<ITERATIONS; i++) {
             if (ITERATIONS > 1) out.printf("---- ITERATION %d%n",i);
@@ -390,13 +391,16 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
         authClient = noAuthClient = null;
         Thread.sleep(100);
         AssertionError fail = TRACKER.check(500);
-
-        proxy.stop();
-        authproxy.stop();
-        httpTestServer.stop();
-        httpsTestServer.stop();
-        http2TestServer.stop();
-        https2TestServer.stop();
+        try {
+            proxy.stop();
+            authproxy.stop();
+            httpTestServer.stop();
+            httpsTestServer.stop();
+            http2TestServer.stop();
+            https2TestServer.stop();
+        } finally {
+            if (fail != null) throw fail;
+        }
     }
 
     static class TestProxySelector extends ProxySelector {

--- a/test/jdk/java/net/httpclient/ProxySelectorTest.java
+++ b/test/jdk/java/net/httpclient/ProxySelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -386,15 +386,18 @@ public class ProxySelectorTest implements HttpServerAdapters {
         client = null;
         Thread.sleep(100);
         AssertionError fail = TRACKER.check(500);
-
-        proxy.stop();
-        authproxy.stop();
-        httpTestServer.stop();
-        proxyHttpTestServer.stop();
-        authProxyHttpTestServer.stop();
-        httpsTestServer.stop();
-        http2TestServer.stop();
-        https2TestServer.stop();
+        try {
+            proxy.stop();
+            authproxy.stop();
+            httpTestServer.stop();
+            proxyHttpTestServer.stop();
+            authProxyHttpTestServer.stop();
+            httpsTestServer.stop();
+            http2TestServer.stop();
+            https2TestServer.stop();
+        } finally {
+            if (fail != null) throw fail;
+        }
     }
 
     class TestProxySelector extends ProxySelector {


### PR DESCRIPTION
Backport of [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063)

Testing
- Local: Test passed on `MacOS 14.5`
  - `ForbiddenHeadTest.java`: Test results: passed: 1
  - `ProxySelectorTest.java`: Test results: passed: 1
- Pipeline: 
- Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_jdk_tier2`
    - java/net/httpclient/ForbiddenHeadTest.java: `SUCCESSFUL` GitHub 📊⏲ - [11,547 msec]
    - java/net/httpclient/ProxySelectorTest.java: `SUCCESSFUL` GitHub 📊⏲ - [11,666 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063) needs maintainer approval

### Issue
 * [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063): Some HttpClient tests don't report leaks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2797/head:pull/2797` \
`$ git checkout pull/2797`

Update a local copy of the PR: \
`$ git checkout pull/2797` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2797`

View PR using the GUI difftool: \
`$ git pr show -t 2797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2797.diff">https://git.openjdk.org/jdk11u-dev/pull/2797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2797#issuecomment-2177857836)