### PR TITLE
8334335: [TESTBUG] Backport of 8279164 to 11u & 17u includes elements of JDK-8163327

### DIFF
--- a/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
@@ -60,7 +60,7 @@ public class DisabledAlgorithms {
             System.getProperty("test.src", "./") + "/" + pathToStores +
                 "/" + trustStoreFile;
 
-    // disabled 3DES, DES, RC4, NULL, anon, and ECDH cipher suites
+    // disabled RC4, NULL, anon, and ECDH cipher suites
     private static final String[] disabled_ciphersuites
         = new String[] {
         "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
@@ -95,7 +95,6 @@ public class DisabledAlgorithms {
         "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
         "TLS_ECDH_anon_WITH_NULL_SHA",
         "TLS_ECDH_anon_WITH_RC4_128_SHA",
-        "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
         "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",


### PR DESCRIPTION
Clean backport of [JDK-8334335](https://bugs.openjdk.org/browse/JDK-8334335) from JDK 17u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334335](https://bugs.openjdk.org/browse/JDK-8334335) needs maintainer approval

### Issue
 * [JDK-8334335](https://bugs.openjdk.org/browse/JDK-8334335): [TESTBUG] Backport of 8279164 to 11u &amp; 17u includes elements of JDK-8163327 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2798/head:pull/2798` \
`$ git checkout pull/2798`

Update a local copy of the PR: \
`$ git checkout pull/2798` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2798`

View PR using the GUI difftool: \
`$ git pr show -t 2798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2798.diff">https://git.openjdk.org/jdk11u-dev/pull/2798.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2798#issuecomment-2179441120)