### PR TITLE
8334711: [TEST_BUG] Compilation failed of MimeFormatsTest/MimeFormatsTest.java

### DIFF
--- a/test/jdk/java/awt/datatransfer/MimeFormatsTest.java
+++ b/test/jdk/java/awt/datatransfer/MimeFormatsTest.java
@@ -103,7 +103,7 @@ public class MimeFormatsTest implements ClipboardOwner {
         ClipboardOwner owner = new ClipboardOwner() {
                 public void lostOwnership(Clipboard clipboard,
                                           Transferable contents) {
-                    System.err.println("%d exit".formatted(
+                    System.err.println(String.format("%d exit",
                             System.currentTimeMillis()));
                     System.err.println("Exiting");
                     System.exit(0);
@@ -115,7 +115,7 @@ public class MimeFormatsTest implements ClipboardOwner {
         synchronized (lock) {
             // Wait to let the parent retrieve the contents.
             try {
-                System.err.println("%d wait".formatted(
+                System.err.println(String.format("%d wait",
                         System.currentTimeMillis()));
                 lock.wait();
             } catch (InterruptedException e) {


### PR DESCRIPTION
Fix the compilation issue in MimeFormatsTest.java on jdk11 for obvious reason: formatted() is in java.lang.String since jdk15

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8334711](https://bugs.openjdk.org/browse/JDK-8334711) needs maintainer approval

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8334711](https://bugs.openjdk.org/browse/JDK-8334711): [TEST_BUG] Compilation failed of MimeFormatsTest/MimeFormatsTest.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2804/head:pull/2804` \
`$ git checkout pull/2804`

Update a local copy of the PR: \
`$ git checkout pull/2804` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2804`

View PR using the GUI difftool: \
`$ git pr show -t 2804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2804.diff">https://git.openjdk.org/jdk11u-dev/pull/2804.diff</a>

</details>
