### PR TITLE
Backport d6679031e0316f9ce0613b7db6bdf8ad46d31501

### DIFF
--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,10 +323,9 @@ public final class MonitorVmStartTerminate {
 
         private void executeJava() throws Throwable {
             String className = JavaProcess.class.getName();
-            String classPath = System.getProperty("test.classes");
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Dtest.timeout.factor=" + System.getProperty("test.timeout.factor", "1.0"),
-                "-cp", classPath, className, mainArgsIdentifier);
+                className, mainArgsIdentifier);
             OutputAnalyzer ob = ProcessTools.executeProcess(pb);
             System.out.println("Java Process " + getMainArgsIdentifier() + " stderr:"
                     + ob.getStderr());


### PR DESCRIPTION
Clean backport of [JDK-8314823](https://bugs.openjdk.org/browse/JDK-8314823) for parity with Oracle 11.0.24


