### PR TITLE
8212597: Optimize String concatenation setup when using primitive operands

### DIFF
--- a/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
+++ b/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
@@ -69,6 +69,15 @@ public class HelloClasslist {
         Stream.of(helloWorld.split(","))
               .forEach(System.out::println);
 
+        // Common concatenation patterns
+        String const_I = "string" + args.length;
+        String const_S = "string" + String.valueOf(args.length);
+        String S_const = String.valueOf(args.length) + "string";
+        String S_S     = String.valueOf(args.length) + String.valueOf(args.length);
+        String const_J = "string" + System.currentTimeMillis();
+        String I_const = args.length + "string";
+        String J_const = System.currentTimeMillis() + "string";
+
         String newDate = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(
                 LocalDateTime.now(ZoneId.of("GMT")));
 

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -139,61 +139,6 @@ final class StringConcatHelper {
     }
 
     /**
-     * Mix coder into current coder
-     * @param current current coder
-     * @param value   value to mix in
-     * @return new coder
-     */
-    static byte mixCoder(byte current, boolean value) {
-        // Booleans are represented with Latin1
-        return current;
-    }
-
-    /**
-     * Mix coder into current coder
-     * @param current current coder
-     * @param value   value to mix in
-     * @return new coder
-     */
-    static byte mixCoder(byte current, byte value) {
-        // Bytes are represented with Latin1
-        return current;
-    }
-
-    /**
-     * Mix coder into current coder
-     * @param current current coder
-     * @param value   value to mix in
-     * @return new coder
-     */
-    static byte mixCoder(byte current, short value) {
-        // Shorts are represented with Latin1
-        return current;
-    }
-
-    /**
-     * Mix coder into current coder
-     * @param current current coder
-     * @param value   value to mix in
-     * @return new coder
-     */
-    static byte mixCoder(byte current, int value) {
-        // Ints are represented with Latin1
-        return current;
-    }
-
-    /**
-     * Mix coder into current coder
-     * @param current current coder
-     * @param value   value to mix in
-     * @return new coder
-     */
-    static byte mixCoder(byte current, long value) {
-        // Longs are represented with Latin1
-        return current;
-    }
-
-    /**
      * Prepends the stringly representation of boolean value into buffer,
      * given the coder and final index. Index is measured in chars, not in bytes!
      *


### PR DESCRIPTION
This is a backport of b3b41df70fb5ec3187d165786b3c8ad2d4b4012b / [JDK-8212597](https://bugs.openjdk.org/browse/JDK-8212597)

This backport is needed to facilitate clean backports of various String concat improvements that are on todo list for 11 which are otherwise very complex and high risk to rework:

JDK-8212726 Replace some use of drop- and foldArguments with filtering argument combinator in StringConcatFactory
JDK-8213035 Pack MethodHandleInlineStrategy coder and length into a long
JDK-8213478 Reduce rebinds when applying repeated filters and conversions
JDK-8222852 Reduce String concat combinator tree shapes by folding constants into prependers
JDK-8223454 Reduce String concatenation shapes by folding initialLengthCoder into last mixer

This is a clean backport.

Testing: x86_64 build, tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8212597](https://bugs.openjdk.org/browse/JDK-8212597) needs maintainer approval

### Issue
 * [JDK-8212597](https://bugs.openjdk.org/browse/JDK-8212597): Optimize String concatenation setup when using primitive operands (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2813/head:pull/2813` \
`$ git checkout pull/2813`

Update a local copy of the PR: \
`$ git checkout pull/2813` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2813`

View PR using the GUI difftool: \
`$ git pr show -t 2813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2813.diff">https://git.openjdk.org/jdk11u-dev/pull/2813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2813#issuecomment-2189045430)