### PR TITLE
8276036: The value of full_count in the message of insufficient codecache is wrong

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1364,7 +1364,9 @@ void CodeCache::report_codemem_full(int code_blob_type, bool print) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   assert(heap != NULL, "heap is null");
 
-  if ((heap->full_count() == 0) || print) {
+  heap->report_full();
+
+  if ((heap->full_count() == 1) || print) {
     // Not yet reported for this heap, report
     if (SegmentedCodeCache) {
       ResourceMark rm;
@@ -1401,15 +1403,13 @@ void CodeCache::report_codemem_full(int code_blob_type, bool print) {
       tty->print("%s", s.as_string());
     }
 
-    if (heap->full_count() == 0) {
+    if (heap->full_count() == 1) {
       LogTarget(Debug, codecache) lt;
       if (lt.is_enabled()) {
         CompileBroker::print_heapinfo(tty, "all", 4096); // details, may be a lot!
       }
     }
   }
-
-  heap->report_full();
 
   EventCodeCacheFull event;
   if (event.should_commit()) {


### PR DESCRIPTION
Backport of [JDK-8276036](https://bugs.openjdk.java.net/browse/JDK-8276036). Recognized as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276036](https://bugs.openjdk.org/browse/JDK-8276036) needs maintainer approval

### Issue
 * [JDK-8276036](https://bugs.openjdk.org/browse/JDK-8276036): The value of full_count in the message of insufficient codecache is wrong (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2818/head:pull/2818` \
`$ git checkout pull/2818`

Update a local copy of the PR: \
`$ git checkout pull/2818` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2818`

View PR using the GUI difftool: \
`$ git pr show -t 2818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2818.diff">https://git.openjdk.org/jdk11u-dev/pull/2818.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2818#issuecomment-2192034408)