### PR TITLE
8231427: Warning cleanup in tests of java.io.Serializable

### DIFF
--- a/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
+++ b/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  * @run main ResolveProxyClass
  */
 
-import java.lang.reflect.*;
 import java.io.*;
 
 public class ResolveProxyClass {
@@ -52,7 +51,7 @@ public class ResolveProxyClass {
             super();
         }
 
-        protected Class resolveProxyClass(String[] interfaces)
+        protected Class<?> resolveProxyClass(String[] interfaces)
             throws IOException, ClassNotFoundException
         {
             return super.resolveProxyClass(interfaces);
@@ -82,7 +81,7 @@ public class ResolveProxyClass {
             ClassLoader expectedLoader = ResolveProxyClass.class.getClassLoader();
 
             TestObjectInputStream in = new TestObjectInputStream();
-            Class proxyClass = in.resolveProxyClass(
+            Class<?> proxyClass = in.resolveProxyClass(
                 new String[] { Runnable.class.getName() });
             ClassLoader proxyLoader = proxyClass.getClassLoader();
             System.err.println("proxy class \"" + proxyClass +

--- a/test/jdk/java/io/ObjectInputStream/TestObjectStreamClass.java
+++ b/test/jdk/java/io/ObjectInputStream/TestObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ public class TestObjectStreamClass {
     }
 
     static class TestClass implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         String str = "hello world";
     }
 

--- a/test/jdk/java/io/Serializable/ClassCastExceptionDetail/Read.java
+++ b/test/jdk/java/io/Serializable/ClassCastExceptionDetail/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,9 @@ class Foo implements Serializable {
     private Float bar;
 }
 
-class Gub extends Foo {}
+class Gub extends Foo {
+    private static final long serialVersionUID = 1L;
+}
 
 public class Read {
     public static void main(String[] args) throws Exception {

--- a/test/jdk/java/io/Serializable/ClassCastExceptionDetail/Write.java
+++ b/test/jdk/java/io/Serializable/ClassCastExceptionDetail/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,12 @@ import java.io.*;
 
 class Foo implements Serializable {
     private static final long serialVersionUID = 0L;
-    private Integer bar = new Integer(0);
+    private Integer bar = 0;
 }
 
-class Gub extends Foo {}
+class Gub extends Foo {
+    private static final long serialVersionUID = 1L;
+}
 
 public class Write {
     public static void main(String[] args) throws Exception {

--- a/test/jdk/java/io/Serializable/GetField/Read2.java
+++ b/test/jdk/java/io/Serializable/GetField/Read2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ class Foo implements Serializable {
     float f;
     double d;
     String str;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object extra;
 
     private void readObject(ObjectInputStream in)

--- a/test/jdk/java/io/Serializable/InvalidClassException/noargctor/DefaultPackage.java
+++ b/test/jdk/java/io/Serializable/InvalidClassException/noargctor/DefaultPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,24 +56,33 @@ class DefaultPackagePrivateConstructor {
 class DefaultPublicSerializable
 extends DefaultPackagePublicConstructor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 };
 
 class DefaultProtectedSerializable
 extends DefaultPackageProtectedConstructor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 };
 
 class DefaultAccessSerializable
 extends DefaultPackageDefaultAccessConstructor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class DefaultPrivateSerializable
 extends DefaultPackagePrivateConstructor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 
     DefaultPrivateSerializable() {
@@ -82,6 +91,8 @@ extends DefaultPackagePrivateConstructor implements Serializable
 };
 
 class ExternalizablePublicConstructor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     public ExternalizablePublicConstructor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -92,7 +103,10 @@ class ExternalizablePublicConstructor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizableProtectedConstructor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     protected ExternalizableProtectedConstructor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -103,7 +117,10 @@ class ExternalizableProtectedConstructor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizableAccessConstructor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     ExternalizableAccessConstructor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -114,7 +131,10 @@ class ExternalizableAccessConstructor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizablePrivateConstructor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     private ExternalizablePrivateConstructor() {
     }
     public ExternalizablePrivateConstructor(int i) {

--- a/test/jdk/java/io/Serializable/InvalidClassException/noargctor/Serialize/SubclassAcrossPackage.java
+++ b/test/jdk/java/io/Serializable/InvalidClassException/noargctor/Serialize/SubclassAcrossPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,18 +34,24 @@ import java.io.*;
 class PublicSerializable
 extends NonSerializable.PublicCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 };
 
 class ProtectedSerializable
 extends NonSerializable.ProtectedCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 };
 
 class DifferentPackageSerializable
 extends NonSerializable.PackageCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
     DifferentPackageSerializable() {
         super(1);
@@ -55,11 +61,15 @@ extends NonSerializable.PackageCtor implements Serializable
 class SamePackageSerializable
 extends Serialize.SamePackageCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     SamePackageSerializable() {
     }
 };
 
 class SamePackageProtectedCtor {
+    private static final long serialVersionUID = 1L;
+
     protected SamePackageProtectedCtor() {
     }
 };
@@ -67,12 +77,16 @@ class SamePackageProtectedCtor {
 class SamePackageProtectedSerializable
 extends Serialize.SamePackageProtectedCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     SamePackageProtectedSerializable() {
     }
 };
 
 
 class SamePackagePrivateCtor {
+    private static final long serialVersionUID = 1L;
+
     private SamePackagePrivateCtor() {
     }
     public SamePackagePrivateCtor(int l) {
@@ -82,6 +96,8 @@ class SamePackagePrivateCtor {
 class SamePackagePrivateSerializable
 extends Serialize.SamePackagePrivateCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     SamePackagePrivateSerializable() {
         super(1);
     }
@@ -90,6 +106,8 @@ extends Serialize.SamePackagePrivateCtor implements Serializable
 class PrivateSerializable
 extends NonSerializable.PrivateCtor implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     int field1 = 5;
 
     PrivateSerializable() {
@@ -98,6 +116,8 @@ extends NonSerializable.PrivateCtor implements Serializable
 };
 
 class ExternalizablePublicCtor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     public ExternalizablePublicCtor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -108,7 +128,10 @@ class ExternalizablePublicCtor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizableProtectedCtor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     protected ExternalizableProtectedCtor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -119,7 +142,10 @@ class ExternalizableProtectedCtor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizablePackageCtor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     ExternalizablePackageCtor() {
     }
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -130,7 +156,10 @@ class ExternalizablePackageCtor implements Externalizable {
         }
 };
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class ExternalizablePrivateCtor implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     private ExternalizablePrivateCtor() {
     }
     public ExternalizablePrivateCtor(int i) {

--- a/test/jdk/java/io/Serializable/NPEProvoker/NPEProvoker.java
+++ b/test/jdk/java/io/Serializable/NPEProvoker/NPEProvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 
 public class NPEProvoker implements java.io.Externalizable {
+    private static final long serialVersionUID = 1L;
+
     private String test = "test";
 
     public void readExternal(ObjectInput in) throws IOException,

--- a/test/jdk/java/io/Serializable/NoClassDefFoundErrorTrap/NoClassDefFoundErrorTrap.java
+++ b/test/jdk/java/io/Serializable/NoClassDefFoundErrorTrap/NoClassDefFoundErrorTrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,9 @@ public class NoClassDefFoundErrorTrap {
     private static NoClassDefFoundError ncdfe;
 
     public interface Bar {}
-    public static class Foo implements Bar, java.io.Serializable {}
+    public static class Foo implements Bar, java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+    }
 
     /**
      * Test subclass of ObjectInputStream that overrides resolveClass
@@ -55,7 +57,7 @@ public class NoClassDefFoundErrorTrap {
             super(in);
         }
 
-        protected Class resolveClass(ObjectStreamClass desc)
+        protected Class<?> resolveClass(ObjectStreamClass desc)
             throws IOException, ClassNotFoundException
         {
             String name = desc.getName();

--- a/test/jdk/java/io/Serializable/PutField/Write2.java
+++ b/test/jdk/java/io/Serializable/PutField/Write2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ class Foo implements Serializable {
         new ObjectStreamField("s2", String.class)
     };
 
+    @SuppressWarnings("deprecation")
     private void writeObject(ObjectOutputStream out) throws IOException {
         ObjectOutputStream.PutField fields = out.putFields();
         fields.put("s1", "qwerty");

--- a/test/jdk/java/io/Serializable/badSerialPersistentField/BadSerialPersistentField.java
+++ b/test/jdk/java/io/Serializable/badSerialPersistentField/BadSerialPersistentField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,16 @@
 import java.io.*;
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("nonexistent", int.class)
     };
 }
 
 class B implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("mismatched", int.class)
     };
@@ -44,6 +48,8 @@ class B implements Serializable {
 }
 
 class C implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("existent", int.class)
     };

--- a/test/jdk/java/io/Serializable/badSerialVersionUID/BadSerialVersionUID.java
+++ b/test/jdk/java/io/Serializable/badSerialVersionUID/BadSerialVersionUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,42 +32,50 @@
 import java.io.*;
 
 class Z implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final boolean serialVersionUID = false;
 }
 
 class B implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final byte serialVersionUID = 5;
 }
 
 class C implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final char serialVersionUID = 5;
 }
 
 class S implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final short serialVersionUID = 5;
 }
 
 class I implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final int serialVersionUID = 5;
 }
 
 class F implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final float serialVersionUID = 5.0F;
 }
 
 class D implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final double serialVersionUID = 5.0;
 }
 
 class L implements Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final Object serialVersionUID = "5";
 }
 
 
 public class BadSerialVersionUID {
     public static void main(String[] args) throws Exception {
-        Class[] ignore = { Z.class, F.class, D.class, L.class };
-        Class[] convert = { B.class, C.class, S.class, I.class };
+        Class<?>[] ignore = { Z.class, F.class, D.class, L.class };
+        Class<?>[] convert = { B.class, C.class, S.class, I.class };
 
         for (int i = 0; i < ignore.length; i++) {
             ObjectStreamClass.lookup(ignore[i]).getSerialVersionUID();

--- a/test/jdk/java/io/Serializable/badSubstByReplace/BadSubstByReplace.java
+++ b/test/jdk/java/io/Serializable/badSubstByReplace/BadSubstByReplace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,16 @@
  */
 import java.io.*;
 
-class A implements Serializable {}
+class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+}
 
-class B implements Serializable {}
+class B implements Serializable {
+    private static final long serialVersionUID = 1L;
+}
 
 class Container implements Serializable {
+    private static final long serialVersionUID = 1L;
     A a = new A();
 }
 

--- a/test/jdk/java/io/Serializable/checkModifiers/CheckModifiers.java
+++ b/test/jdk/java/io/Serializable/checkModifiers/CheckModifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,10 @@
 
 import java.io.*;
 class TestClass1 implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // Missing the "final" modifier
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("field1", Integer.class),
         new ObjectStreamField("field2", Double.TYPE),
@@ -58,7 +61,7 @@ class TestClass1 implements Serializable {
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField pfields = ois.readFields();
 
-        field1 = (Integer) pfields.get("field1", new Integer(100));
+        field1 = (Integer) pfields.get("field1", Integer.valueOf(100));
         field2 = pfields.get("field2", 99.99);
 
         /* These fields must be present in the stream */
@@ -79,7 +82,10 @@ class TestClass1 implements Serializable {
 
 
 class TestClass2 implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // public instead of private
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     public static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("field1", Integer.class),
         new ObjectStreamField("field2", Double.TYPE),
@@ -101,7 +107,7 @@ class TestClass2 implements Serializable {
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField pfields = ois.readFields();
 
-        field1 = (Integer) pfields.get("field1", new Integer(100));
+        field1 = (Integer) pfields.get("field1", Integer.valueOf(100));
         field2 = pfields.get("field2", 99.99);
 
         /* These fields must be present in the stream */
@@ -121,7 +127,10 @@ class TestClass2 implements Serializable {
 };
 
 class TestClass3 implements Serializable{
+    private static final long serialVersionUID = 1L;
+
     // Not of type ObjectStreamField
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private final String[] serialPersistentFields =  {"Foo","Foobar"};;
     Integer field1;
     double field2;
@@ -139,7 +148,7 @@ class TestClass3 implements Serializable{
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField pfields = ois.readFields();
 
-        field1 = (Integer) pfields.get("field1", new Integer(100));
+        field1 = (Integer) pfields.get("field1", Integer.valueOf(100));
         field2 = pfields.get("field2", 99.99);
         field3 = pfields.get("field3", 99);
         field4 = (String) pfields.get("field4", "Default string");
@@ -156,6 +165,8 @@ class TestClass3 implements Serializable{
 };
 
 class TestClass4 implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // Correct format
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("field1", Integer.class),
@@ -178,7 +189,7 @@ class TestClass4 implements Serializable {
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField pfields = ois.readFields();
 
-        field1 = (Integer) pfields.get("field1", new Integer(100));
+        field1 = (Integer) pfields.get("field1", Integer.valueOf(100));
         field2 = pfields.get("field2", 99.99);
 
         try {
@@ -199,16 +210,16 @@ class TestClass4 implements Serializable {
 public class CheckModifiers {
     public static void main(String[] args)
         throws ClassNotFoundException, IOException{
-        TestClass1 tc1 = new TestClass1(new Integer(100), 25.56, 2000,
+        TestClass1 tc1 = new TestClass1(100, 25.56, 2000,
             new String("Test modifiers of serialPersistentFields"));
 
-        TestClass2 tc2 = new TestClass2(new Integer(100), 25.56, 2000,
+        TestClass2 tc2 = new TestClass2(100, 25.56, 2000,
             new String("Test modifiers of serialPersistentFields"));
 
-        TestClass3 tc3 = new TestClass3(new Integer(100), 25.56, 2000,
+        TestClass3 tc3 = new TestClass3(100, 25.56, 2000,
             new String("Test Type of serialPersistentFields"));
 
-        TestClass4 tc4 = new TestClass4(new Integer(100), 25.56, 2000,
+        TestClass4 tc4 = new TestClass4(100, 25.56, 2000,
             new String("Test modifiers of serialPersistentFields"));
 
 

--- a/test/jdk/java/io/Serializable/class/SerialA_2/A.java
+++ b/test/jdk/java/io/Serializable/class/SerialA_2/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 import java.io.Serializable;
 
 public class A implements Serializable {
-    static final long serialVersionUID = 746945609796141988L;
+    private static final long serialVersionUID = 746945609796141988L;
 
     int field1;
     int field2;

--- a/test/jdk/java/io/Serializable/classDescFlagConflict/Foo.java
+++ b/test/jdk/java/io/Serializable/classDescFlagConflict/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
 import java.io.*;
 
 public class Foo implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     public void writeExternal(ObjectOutput out) throws IOException {}
     public void readExternal(ObjectInput in)
         throws IOException, ClassNotFoundException {}

--- a/test/jdk/java/io/Serializable/classDescGetField/GetField.java
+++ b/test/jdk/java/io/Serializable/classDescGetField/GetField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
 import java.io.*;
 
 public class GetField implements Serializable{
+    private static final long serialVersionUID = 1L;
+
     String str;
     int i;
 

--- a/test/jdk/java/io/Serializable/classDescHooks/CNFException.java
+++ b/test/jdk/java/io/Serializable/classDescHooks/CNFException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class CNFException {
     public static void main(String[] args) throws Exception {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(bout);
-        oout.writeObject(new Integer(5));
+        oout.writeObject(5);
         oout.close();
         ObjectInputStream oin =
             new CNFInputStream(new ByteArrayInputStream(bout.toByteArray()));

--- a/test/jdk/java/io/Serializable/classDescHooks/ClassDescHooks.java
+++ b/test/jdk/java/io/Serializable/classDescHooks/ClassDescHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,9 @@ import java.util.*;
 
 class Foo implements Serializable {
     private static final long serialVersionUID = 1L;
-    Short s = new Short((short) 1);
-    Integer i = new Integer(2);
-    Long l = new Long(3);
+    Short s = (short) 1;
+    Integer i = 2;
+    Long l = 3L;
 
     public boolean equals(Object obj) {
         if (obj instanceof Foo) {
@@ -42,6 +42,10 @@ class Foo implements Serializable {
             return s.equals(ofoo.s) && i.equals(ofoo.i) && l.equals(ofoo.l);
         }
         return false;
+    }
+
+    public int hashCode() {
+        return i;
     }
 }
 

--- a/test/jdk/java/io/Serializable/classDescHooks/ExternLoopback.java
+++ b/test/jdk/java/io/Serializable/classDescHooks/ExternLoopback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,9 @@ import java.io.*;
 import java.util.*;
 
 class LoopbackOutputStream extends ObjectOutputStream {
-    LinkedList descs;
+    LinkedList<ObjectStreamClass> descs;
 
-    LoopbackOutputStream(OutputStream out, LinkedList descs)
+    LoopbackOutputStream(OutputStream out, LinkedList<ObjectStreamClass> descs)
         throws IOException
     {
         super(out);
@@ -49,9 +49,9 @@ class LoopbackOutputStream extends ObjectOutputStream {
 }
 
 class LoopbackInputStream extends ObjectInputStream {
-    LinkedList descs;
+    LinkedList<ObjectStreamClass> descs;
 
-    LoopbackInputStream(InputStream in, LinkedList descs) throws IOException {
+    LoopbackInputStream(InputStream in, LinkedList<ObjectStreamClass> descs) throws IOException {
         super(in);
         this.descs = descs;
     }
@@ -59,11 +59,12 @@ class LoopbackInputStream extends ObjectInputStream {
     protected ObjectStreamClass readClassDescriptor()
         throws IOException, ClassNotFoundException
     {
-        return (ObjectStreamClass) descs.removeFirst();
+        return descs.removeFirst();
     }
 }
 
 public class ExternLoopback implements Externalizable {
+    private static final long serialVersionUID = 1L;
 
     String a, b, c;
 
@@ -100,13 +101,17 @@ public class ExternLoopback implements Externalizable {
         return streq(a, other.a) && streq(b, other.b) && streq(c, other.c);
     }
 
+    public int hashCode() {
+        return a.hashCode();
+    }
+
     static boolean streq(String s1, String s2) {
         return (s1 != null) ? s1.equals(s2) : (s2 == null);
     }
 
     public static void main(String[] args) throws Exception {
         ExternLoopback lb = new ExternLoopback("foo", "bar", "baz");
-        LinkedList descs = new LinkedList();
+        LinkedList<ObjectStreamClass> descs = new LinkedList<>();
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         LoopbackOutputStream lout = new LoopbackOutputStream(bout, descs);
         lout.writeObject(lb);

--- a/test/jdk/java/io/Serializable/classDescHooks/Loopback.java
+++ b/test/jdk/java/io/Serializable/classDescHooks/Loopback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,9 @@ import java.io.*;
 import java.util.*;
 
 class LoopbackOutputStream extends ObjectOutputStream {
-    LinkedList descs;
+    LinkedList<ObjectStreamClass> descs;
 
-    LoopbackOutputStream(OutputStream out, LinkedList descs)
+    LoopbackOutputStream(OutputStream out, LinkedList<ObjectStreamClass> descs)
         throws IOException
     {
         super(out);
@@ -50,21 +50,22 @@ class LoopbackOutputStream extends ObjectOutputStream {
 }
 
 class LoopbackInputStream extends ObjectInputStream {
-    LinkedList descs;
+    LinkedList<ObjectStreamClass> descs;
 
-    LoopbackInputStream(InputStream in, LinkedList descs) throws IOException {
+    LoopbackInputStream(InputStream in, LinkedList<ObjectStreamClass> descs) throws IOException {
         super(in);
         this.descs = descs;
     }
 
     protected ObjectStreamClass readClassDescriptor()
-        throws IOException, ClassNotFoundException
     {
-        return (ObjectStreamClass) descs.removeFirst();
+        return descs.removeFirst();
     }
 }
 
 public class Loopback implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     String str;
 
     Loopback(String str) {
@@ -73,7 +74,7 @@ public class Loopback implements Serializable {
 
     public static void main(String[] args) throws Exception {
         Loopback lb = new Loopback("foo");
-        LinkedList descs = new LinkedList();
+        LinkedList<ObjectStreamClass> descs = new LinkedList<>();
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         LoopbackOutputStream lout = new LoopbackOutputStream(bout, descs);
         lout.writeObject(lb);

--- a/test/jdk/java/io/Serializable/cloneArray/CloneArray.java
+++ b/test/jdk/java/io/Serializable/cloneArray/CloneArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ public class CloneArray {
     static Object replacement;
 
     static class Resolver implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         private Object readResolve() throws ObjectStreamException {
             return replacement;
         }

--- a/test/jdk/java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java
+++ b/test/jdk/java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
 import java.io.*;
 
 class Good implements Serializable {
+    private static final long serialVersionUID = 6319710844400051132L;
+
     static {
         try { Thread.sleep(1000); } catch (InterruptedException ex) {}
     }
@@ -47,12 +49,12 @@ class Bad implements Serializable {
 }
 
 class SuccessfulLookup extends Thread {
-    Class cl;
+    Class<?> cl;
     long suid;
     Object barrier;
     boolean ok;
 
-    SuccessfulLookup(Class cl, long suid, Object barrier) {
+    SuccessfulLookup(Class<?> cl, long suid, Object barrier) {
         this.cl = cl;
         this.suid = suid;
         this.barrier = barrier;
@@ -72,11 +74,11 @@ class SuccessfulLookup extends Thread {
 }
 
 class FailingLookup extends Thread {
-    Class cl;
-    Object barrier;
+    Class<?> cl;
+    final Object barrier;
     boolean ok;
 
-    FailingLookup(Class cl, Object barrier) {
+    FailingLookup(Class<?> cl, Object barrier) {
         this.cl = cl;
         this.barrier = barrier;
     }
@@ -99,7 +101,7 @@ class FailingLookup extends Thread {
 public class ConcurrentClassDescLookup {
     public static void main(String[] args) throws Exception {
         ClassLoader loader = ConcurrentClassDescLookup.class.getClassLoader();
-        Class cl = Class.forName("Good", false, loader);
+        Class<?> cl = Class.forName("Good", false, loader);
         Object barrier = new Object();
         SuccessfulLookup[] slookups = new SuccessfulLookup[50];
         for (int i = 0; i < slookups.length; i++) {

--- a/test/jdk/java/io/Serializable/defaultDataEnd/DefaultDataEnd.java
+++ b/test/jdk/java/io/Serializable/defaultDataEnd/DefaultDataEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int i1 = 1, i2 = 2;
     String s1 = "foo", s2 = "bar";
 
@@ -66,6 +68,8 @@ class A implements Serializable {
 }
 
 class B implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int i1 = 1, i2 = 2;
     String s1 = "foo", s2 = "bar";
 
@@ -101,6 +105,8 @@ class B implements Serializable {
 }
 
 class C implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException
     {

--- a/test/jdk/java/io/Serializable/defaultReadObjectCNFException/DefaultReadObjectCNFException.java
+++ b/test/jdk/java/io/Serializable/defaultReadObjectCNFException/DefaultReadObjectCNFException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@
 import java.io.*;
 
 class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     Object obj = new Bar();
 
     private void readObject(ObjectInputStream in)
@@ -44,12 +47,14 @@ class Foo implements Serializable {
     }
 }
 
-class Bar implements Serializable {}
+class Bar implements Serializable {
+    private static final long serialVersionUID = 1L;
+}
 
 class TestObjectInputStream extends ObjectInputStream {
     TestObjectInputStream(InputStream in) throws IOException { super(in); }
 
-    protected Class resolveClass(ObjectStreamClass desc)
+    protected Class<?> resolveClass(ObjectStreamClass desc)
         throws IOException, ClassNotFoundException
     {
         if (desc.getName().equals(Bar.class.getName())) {

--- a/test/jdk/java/io/Serializable/defaulted/GetFieldRead.java
+++ b/test/jdk/java/io/Serializable/defaulted/GetFieldRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,9 @@
 
 import java.io.*;
 class TestClass implements Serializable {
-    public static final Integer DEFAULT_OBJECT_I = new Integer(99);
+    public static final Integer DEFAULT_OBJECT_I = 99;
     public static final Foo DEFAULT_OBJECT_F = new Foo();
-    private static final long serialVersionUID=5748652654655279289L;
+    private static final long serialVersionUID = 5748652654655279289L;
 
     // Fields to be serialized.
     private static final ObjectStreamField[] serialPersistentFields = {

--- a/test/jdk/java/io/Serializable/defaulted/GetFieldWrite.java
+++ b/test/jdk/java/io/Serializable/defaulted/GetFieldWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,7 @@ public class GetFieldWrite {
     {
         FileOutputStream fos = new FileOutputStream("data.ser");
         ObjectOutput out = new ObjectOutputStream(fos);
-        out.writeObject(new TestClass(new Foo(100, 200), new Integer(100),
-            200));
+        out.writeObject(new TestClass(new Foo(100, 200), 100, 200));
         out.close();
     }
 };
@@ -72,6 +71,8 @@ public class GetFieldWrite {
  * Test class to be used as data field
  */
 class Foo implements Serializable{
+    private static final long serialVersionUID = 1L;
+
     int a;
     int b;
     public Foo() {

--- a/test/jdk/java/io/Serializable/enum/classObject/Test.java
+++ b/test/jdk/java/io/Serializable/enum/classObject/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Test {
     public static void main(String[] args) throws Exception {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(bout);
-        Class[] classes = { Enum.class, Foo.foo.getClass(),
+        Class<?>[] classes = { Enum.class, Foo.foo.getClass(),
                             Foo.bar.getClass(), Foo.baz.getClass() };
         for (int i = 0; i < classes.length; i++) {
             oout.writeObject(classes[i]);

--- a/test/jdk/java/io/Serializable/enum/ignoreSerializationFields/Test.java
+++ b/test/jdk/java/io/Serializable/enum/ignoreSerializationFields/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ enum Foo {
 
     foo,
     bar {
+        @SuppressWarnings("serial") /* Incorrect declarations are being tested */
         private static final long serialVersionUID = 2L;
         // bar is implemented as an inner class instance, so the following
         // declaration would cause a compile-time error
@@ -42,7 +43,10 @@ enum Foo {
         // };
     };
 
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("blargh", Integer.TYPE)
     };
@@ -50,7 +54,7 @@ enum Foo {
 
 public class Test {
     public static void main(String[] args) throws Exception {
-        Class[] classes =
+        Class<?>[] classes =
             { Foo.class, Foo.foo.getClass(), Foo.bar.getClass() };
         for (int i = 0; i < classes.length; i++) {
             ObjectStreamClass desc = ObjectStreamClass.lookup(classes[i]);

--- a/test/jdk/java/io/Serializable/enum/ignoreSerializationMethods/Test.java
+++ b/test/jdk/java/io/Serializable/enum/ignoreSerializationMethods/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,14 +33,17 @@ enum Foo {
 
     foo,
     bar {
+        @SuppressWarnings("serial") /* Incorrect declarations are being tested */
         private void writeObject(ObjectOutputStream out) throws IOException {
             throw new Error("bar.writeObject invoked");
         }
+        @SuppressWarnings("serial") /* Incorrect declarations are being tested */
         private void readObject(ObjectInputStream in)
             throws IOException, ClassNotFoundException
         {
             throw new Error("bar.readObject invoked");
         }
+        @SuppressWarnings("serial") /* Incorrect declarations are being tested */
         Object writeReplace() throws ObjectStreamException {
             throw new Error("bar.writeReplace invoked");
         }
@@ -50,14 +53,17 @@ enum Foo {
         // }
     };
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private void writeObject(ObjectOutputStream out) throws IOException {
         throw new Error("Foo.writeObject invoked");
     }
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException
     {
         throw new Error("Foo.readObject invoked");
     }
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     Object writeReplace() throws ObjectStreamException {
         throw new Error("Foo.writeReplace invoked");
     }

--- a/test/jdk/java/io/Serializable/enum/mismatchedTypecode/Test.java
+++ b/test/jdk/java/io/Serializable/enum/mismatchedTypecode/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class Test {
         }
 
         oout = new TestObjectOutputStream(bout = new ByteArrayOutputStream());
-        oout.writeObject(new Integer(5));
+        oout.writeObject(5);
         oout.close();
         oin = new ObjectInputStream(
             new ByteArrayInputStream(bout.toByteArray()));

--- a/test/jdk/java/io/Serializable/evolution/AddedExternField/ReadAddedField.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedExternField/ReadAddedField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ class A implements Serializable {
 }
 
 class D implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int x;
     D(int y) {
         x = y;

--- a/test/jdk/java/io/Serializable/evolution/AddedExternField/WriteAddedField.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedExternField/WriteAddedField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@
 import java.io.*;
 
 class NewExternFieldClass implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     byte l;
 
     public NewExternFieldClass() {
@@ -60,6 +62,8 @@ class NewExternFieldClass implements Externalizable {
 }
 
 class D implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int x;
     D(int y) {
         x = y;

--- a/test/jdk/java/io/Serializable/evolution/AddedField/ReadAddedField.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedField/ReadAddedField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
 import java.io.*;
 
 class IncompatibleFieldClass implements Serializable {
-    private static long serialVersionUID = 4L;
+    private static final long serialVersionUID = 3L;
     int x = 5;
 };
 

--- a/test/jdk/java/io/Serializable/evolution/AddedField/WriteAddedField.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedField/WriteAddedField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@
 import java.io.*;
 
 class NewFieldClass implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int k;
 
     NewFieldClass(int value) {
@@ -45,11 +47,14 @@ class NewFieldClass implements Serializable {
 };
 
 class IncompatibleFieldClass implements Serializable {
-    private static long serialVersionUID = 3L;
+    private static final long serialVersionUID = 3L;
     int x = 5;
 };
 
+@SuppressWarnings("serial") /* Incorrect use is being tested */
 class NewExternFieldClass implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     byte l;
 
     public NewExternFieldClass(int value) {

--- a/test/jdk/java/io/Serializable/evolution/AddedSuperClass/ReadAddedSuperClass2.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedSuperClass/ReadAddedSuperClass2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@
 import java.io.*;
 
 class AddedSuperClass implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // Needed at least one field to recreate failure.
     int field;
 }

--- a/test/jdk/java/io/Serializable/evolution/AddedSuperClass/WriteAddedSuperClass.java
+++ b/test/jdk/java/io/Serializable/evolution/AddedSuperClass/WriteAddedSuperClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,8 @@
 import java.io.*;
 
 class AddedSuperClass implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // Needed at least one field to recreate failure.
     int field;
 }

--- a/test/jdk/java/io/Serializable/expectedStackTrace/ExpectedStackTrace.java
+++ b/test/jdk/java/io/Serializable/expectedStackTrace/ExpectedStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,9 +42,11 @@ class NotSerializableObject {
     }
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested */
 class SerializableObject extends NotSerializableObject
     implements Serializable
 {
+    private static final long serialVersionUID = 1L;
 
     public SerializableObject(String m_str, Integer m_int) {
         super(m_str, m_int);
@@ -67,7 +69,7 @@ public class ExpectedStackTrace {
         ObjectStreamClass osc =
             ObjectStreamClass.lookup(SerializableObject.class);
         SerializableObject initObj =
-            (SerializableObject) osc.forClass().newInstance();
+            (SerializableObject) osc.forClass().getConstructor().newInstance();
         return initObj;
     }
 

--- a/test/jdk/java/io/Serializable/explicitCNFException/ExplicitCNFException.java
+++ b/test/jdk/java/io/Serializable/explicitCNFException/ExplicitCNFException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private void readObject(ObjectInputStream in)
         throws ClassNotFoundException, IOException
     {
@@ -39,6 +41,8 @@ class A implements Serializable {
 }
 
 class B implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     public B() {}
 
     public void writeExternal(ObjectOutput out) throws IOException {}

--- a/test/jdk/java/io/Serializable/failureAtomicity/Bar.template
+++ b/test/jdk/java/io/Serializable/failureAtomicity/Bar.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.io.Serializable;
 import failureAtomicity.SerialRef;
 
 public class Bar extends Foo implements Serializable {
-    static final long serialVersionUID = -0L;
+    private static final long serialVersionUID = -0L;
 
     public final long barPrim;
     public final String barRef;

--- a/test/jdk/java/io/Serializable/failureAtomicity/Foo.template
+++ b/test/jdk/java/io/Serializable/failureAtomicity/Foo.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.io.Serializable;
 import failureAtomicity.SerialRef;
 
 public class Foo implements Serializable {
-    static final long serialVersionUID = -0L;
+    private static final long serialVersionUID = -0L;
 
     public final int fooPrim;
     public final String fooRef;

--- a/test/jdk/java/io/Serializable/failureAtomicity/SerialRef.java
+++ b/test/jdk/java/io/Serializable/failureAtomicity/SerialRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,10 @@ import java.io.Serializable;
 // For verification purposes only.
 
 public class SerialRef implements Serializable {
-    static final long serialVersionUID = -0L;
+    private static final long serialVersionUID = -0L;
     public static Object obj;
 
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private final Object ref;
 
     public SerialRef(Object ref) {

--- a/test/jdk/java/io/Serializable/fieldTypeString/Write.java
+++ b/test/jdk/java/io/Serializable/fieldTypeString/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import java.io.*;
 
 class Foo implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object obj;
 
     Foo(Object obj) {
@@ -59,7 +60,7 @@ public class Write {
         ObjectOutputStream oout =
             new ObjectOutputStream(new FileOutputStream("foo.ser"));
         oout.writeObject(new Foo("foo"));
-        oout.writeObject(new Foo(new Integer(0)));
+        oout.writeObject(new Foo(0));
         oout.close();
 
         oout = new ObjectOutputStream(new FileOutputStream("bar.ser"));

--- a/test/jdk/java/io/Serializable/finalFields/FinalFields.java
+++ b/test/jdk/java/io/Serializable/finalFields/FinalFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
 import java.io.*;
 
 class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     final int i;
 
     Foo(int i) {
@@ -40,6 +42,10 @@ class Foo implements Serializable {
             return false;
         Foo f = (Foo) obj;
         return (i == f.i);
+    }
+
+    public int hashCode() {
+        return i;
     }
 }
 
@@ -68,4 +74,5 @@ public class FinalFields {
         if (! (f1.equals(f1copy) && f2.equals(f2copy)))
             throw new Error("copies don't match originals");
     }
+
 }

--- a/test/jdk/java/io/Serializable/getSuidClinitError/GetSuidClinitError.java
+++ b/test/jdk/java/io/Serializable/getSuidClinitError/GetSuidClinitError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 
 import java.io.*;
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class A implements Serializable {
     static {
         // compiler prohibits direct throw
@@ -41,30 +42,36 @@ class A implements Serializable {
     }
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class B implements Serializable {
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class C implements Serializable {
     static { System.out.println("C.<clinit>"); }
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class B1 extends B {
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class B2 extends B {
     static { System.out.println("B2.<clinit>"); }
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class C1 extends C {
 }
 
+@SuppressWarnings("serial") /* Incorrect declarations are being tested. */
 class C2 extends C {
     static { System.out.println("C2.<clinit>"); }
 }
 
 public class GetSuidClinitError {
     public static void main(String[] args) throws Exception {
-        Class cl = Class.forName(
+        Class<?> cl = Class.forName(
             "A", false, GetSuidClinitError.class.getClassLoader());
         for (int i = 0; i < 2; i++) {
             try {
@@ -83,7 +90,7 @@ public class GetSuidClinitError {
             }
         }
 
-        Class[] cls = new Class[] {
+        Class<?>[] cls = {
             B.class, B1.class, B2.class,
             C.class, C1.class, C2.class
         };

--- a/test/jdk/java/io/Serializable/lookupInterfaceDesc/LookupInterfaceDesc.java
+++ b/test/jdk/java/io/Serializable/lookupInterfaceDesc/LookupInterfaceDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,12 @@
 import java.io.*;
 
 interface Foo extends Serializable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     static final long serialVersionUID = 0xCAFE;
 }
 
 interface Bar extends Externalizable {
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     static final long serialVersionUID = 0xBABE;
 }
 

--- a/test/jdk/java/io/Serializable/misplacedArrayClassDesc/MisplacedArrayClassDesc.java
+++ b/test/jdk/java/io/Serializable/misplacedArrayClassDesc/MisplacedArrayClassDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 
 class TestArray implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     // size of array
     private static final int ARR_SIZE = 5;
     // serializable field

--- a/test/jdk/java/io/Serializable/modifyStaticFields/ModifyStaticFields.java
+++ b/test/jdk/java/io/Serializable/modifyStaticFields/ModifyStaticFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
 import java.io.*;
 
 public class ModifyStaticFields implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private static final ObjectStreamField[] serialPersistentFields =
         new ObjectStreamField[] { new ObjectStreamField("str", String.class) };
 

--- a/test/jdk/java/io/Serializable/nestedReplace/NestedReplace.java
+++ b/test/jdk/java/io/Serializable/nestedReplace/NestedReplace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,18 +35,23 @@
 import java.io.*;
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     Object writeReplace() throws ObjectStreamException {
         return new B();
     }
 }
 
 class B implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     Object writeReplace() throws ObjectStreamException {
         return new C();
     }
 }
 
 class C implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     static int writeReplaceCalled = 0;
 
@@ -61,6 +66,8 @@ class C implements Serializable {
 }
 
 class D implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     Object readResolve() throws ObjectStreamException {
         throw new Error("readResolve() called more than once");
     }

--- a/test/jdk/java/io/Serializable/noSuchFieldClarification/NoSuchFieldClarification.java
+++ b/test/jdk/java/io/Serializable/noSuchFieldClarification/NoSuchFieldClarification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,9 @@
  import java.io.*;
 
  class TwoDPoint implements Serializable {
+     private static final long serialVersionUID = 1L;
 
-         private double radius;
+     private double radius;
          private double angle;
 
          private static final ObjectStreamField[] serialPersistentFields  = {

--- a/test/jdk/java/io/Serializable/notAvailable/NotAvailable.java
+++ b/test/jdk/java/io/Serializable/notAvailable/NotAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,8 @@ public class NotAvailable {
 }
 
 class Class1 implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int a, b;
 
     public Class1(int aa, int bb) {

--- a/test/jdk/java/io/Serializable/oldTests/AnnotateClass.java
+++ b/test/jdk/java/io/Serializable/oldTests/AnnotateClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ class TestOutputStream extends ObjectOutputStream {
     /* When any class is written, add a "magic" string
      * that must be verified by the TestInputStream.
      */
-    protected void annotateClass(Class cl) throws IOException {
+    protected void annotateClass(Class<?> cl) throws IOException {
         this.writeUTF("magic");
     }
 
@@ -112,7 +112,6 @@ class TestOutputStream extends ObjectOutputStream {
      * Other objects are written as themselves.
      */
     protected Object replaceObject(Object obj)
-        throws IOException
     {
         /* For PrintStreams, like stdout and stderr, encode */
         if (obj instanceof PrintStream) {
@@ -169,6 +168,7 @@ class TestInputStream extends ObjectInputStream {
  * and a small integer.
  */
 class StdStream implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     private int stream = 0;
 
     public StdStream(PrintStream s) {

--- a/test/jdk/java/io/Serializable/oldTests/ArrayTest.java
+++ b/test/jdk/java/io/Serializable/oldTests/ArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 public class ArrayTest implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     byte b[] = { 0, 1};
     short s[] = { 0, 1, 2};
     char c[] = { 'Z', 'Y', 'X'};

--- a/test/jdk/java/io/Serializable/oldTests/ArraysOfArrays.java
+++ b/test/jdk/java/io/Serializable/oldTests/ArraysOfArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,40 +42,40 @@ public class ArraysOfArrays {
             ostream = new FileOutputStream("piotest5.tmp");
             ObjectOutputStream p = new ObjectOutputStream(ostream);
 
-            byte b[][] = {{ 0, 1}, {2,3}};
-            p.writeObject((Object)b);
+            byte[][] b = {{ 0, 1}, {2,3}};
+            p.writeObject(b);
 
-            short s[][] = {{ 0, 1, 2}, {3,4,5}};
-            p.writeObject((Object)s);
+            short[][] s = {{ 0, 1, 2}, {3,4,5}};
+            p.writeObject(s);
 
-            char c[][] = {{ 0, 1, 2, 3}, {4, 5, 6, 7}};
-            p.writeObject((Object)c);
+            char[][] c = {{ 0, 1, 2, 3}, {4, 5, 6, 7}};
+            p.writeObject(c);
 
-            int i[][] = {{ 0, 1, 2, 3, 4}, {5, 6, 7, 8, 9}};
-            p.writeObject((Object)i);
+            int[][] i = {{ 0, 1, 2, 3, 4}, {5, 6, 7, 8, 9}};
+            p.writeObject(i);
 
-            long l[][] = {{ 0, 1, 2, 3, 4, 5}, {6,7,8,9,10,11}};
+            long[][] l = {{ 0, 1, 2, 3, 4, 5}, {6,7,8,9,10,11}};
             p.writeObject((Object)l);
 
-            boolean z[][] = new boolean[2][2];
+            boolean[][] z = new boolean[2][2];
 
             z[0][0] = true;
             z[0][1] = false;
             z[1] = z[0];        // Use first row same as second
 
-            p.writeObject((Object)z);
+            p.writeObject(z);
 
-            float f[][] = {{ 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f},
+            float[][] f = {{ 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f},
                 { 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f}};
-            p.writeObject((Object)f);
+            p.writeObject(f);
 
-            double d[][] = {{ 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0d},
+            double[][] d = {{ 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0d},
                 { 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 7.1d}};
-            p.writeObject((Object)d);
+            p.writeObject(d);
 
-            Integer Int[][] = {{ new Integer(3), new Integer(2)},
-                { new Integer(1), new Integer(0)}};
-            p.writeObject((Object)Int);
+            Integer Int[][] = {{ 3, 2},
+                               { 1, 0}};
+            p.writeObject(Int);
 
             p.flush();
 
@@ -84,12 +84,12 @@ public class ArraysOfArrays {
             istream = new FileInputStream("piotest5.tmp");
             ObjectInputStream q = new ObjectInputStream(istream);
 
-            byte b_u[][] = (byte [][]) (q.readObject());
+            byte[][] b_u = (byte [][]) (q.readObject());
             for (int ix = 0; ix < b_u.length; ix++) {
                 for(int iy = 0; iy < b_u[ix].length; iy++) {
                     if (b[ix][iy] != b_u[ix][iy]) {
                         System.err.println("\nByte array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
+                            ix + "][" + iy + "] expected " + b[ix][iy] +
                             " actual = " + b_u[ix][iy]);
                         throw new Error();
                     }
@@ -97,97 +97,97 @@ public class ArraysOfArrays {
             }
 
 
-            short s_u[][] = (short [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            short[][] s_u = (short [][])(q.readObject());
+            for (int ix = 0; ix < s_u.length; ix++) {
+                for(int iy = 0; iy < s_u[ix].length; iy++) {
+                    if (s[ix][iy] != s_u[ix][iy]) {
                         System.err.println("\nshort array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + s[ix][iy] +
+                            " actual = " + s_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            char c_u[][] = (char [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            char[][] c_u = (char [][])(q.readObject());
+            for (int ix = 0; ix < c_u.length; ix++) {
+                for(int iy = 0; iy < c_u[ix].length; iy++) {
+                    if (c[ix][iy] != c_u[ix][iy]) {
                         System.err.println("\nchar array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + c[ix][iy] +
+                            " actual = " + c_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            int i_u[][] = (int [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            int[][] i_u = (int [][])(q.readObject());
+            for (int ix = 0; ix < i_u.length; ix++) {
+                for(int iy = 0; iy < i_u[ix].length; iy++) {
+                    if (i[ix][iy] != i_u[ix][iy]) {
                         System.err.println("\nint array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + i[ix][iy] +
+                            " actual = " + i_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            long l_u[][] = (long [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            long[][] l_u = (long [][])(q.readObject());
+            for (int ix = 0; ix < l_u.length; ix++) {
+                for(int iy = 0; iy < l_u[ix].length; iy++) {
+                    if (l[ix][iy] != l_u[ix][iy]) {
                         System.err.println("\nlong array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + l[ix][iy] +
+                            " actual = " + l_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            boolean z_u[][] = (boolean [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            boolean[][] z_u = (boolean [][])(q.readObject());
+            for (int ix = 0; ix < z_u.length; ix++) {
+                for(int iy = 0; iy < z_u[ix].length; iy++) {
+                    if (z[ix][iy] != z_u[ix][iy]) {
                         System.err.println("\nboolean array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + z[ix][iy] +
+                            " actual = " + z_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            float f_u[][] = (float [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            float[][] f_u = (float [][])(q.readObject());
+            for (int ix = 0; ix < f_u.length; ix++) {
+                for(int iy = 0; iy < f_u[ix].length; iy++) {
+                    if (f[ix][iy] != f_u[ix][iy]) {
                         System.err.println("\nfloat array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + f[ix][iy] +
+                            " actual = " + f_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            double d_u[][] = (double [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            double[][] d_u = (double [][])(q.readObject());
+            for (int ix = 0; ix < d_u.length; ix++) {
+                for(int iy = 0; iy < d_u[ix].length; iy++) {
+                    if (d[ix][iy] != d_u[ix][iy]) {
                         System.err.println("\ndouble array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + d[ix][iy] +
+                            " actual = " + d_u[ix][iy]);
                         throw new Error();
                     }
                 }
             }
 
-            Integer Int_u[][] = (Integer [][])(q.readObject());
-            for (int ix = 0; ix < b_u.length; ix++) {
-                for(int iy = 0; iy < b_u[ix].length; iy++) {
-                    if (b[ix][iy] != b_u[ix][iy]) {
+            Integer[][] Int_u = (Integer [][])(q.readObject());
+            for (int ix = 0; ix < Int_u.length; ix++) {
+                for(int iy = 0; iy < Int_u[ix].length; iy++) {
+                    if (!Int[ix][iy].equals(Int_u[ix][iy])) {
                         System.err.println("\nInteger array mismatch [" +
-                            ix + "][" + iy + " expected " + b[ix][iy] +
-                            " actual = " + b_u[ix][iy]);
+                            ix + "][" + iy + "] expected " + Int[ix][iy] +
+                            " actual = " + Int_u[ix][iy]);
                         throw new Error();
                     }
                 }

--- a/test/jdk/java/io/Serializable/oldTests/BinaryTree.java
+++ b/test/jdk/java/io/Serializable/oldTests/BinaryTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,8 @@ public class BinaryTree {
 }
 
 class BinaryTreeTest implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     public BinaryTreeTest left;
     public BinaryTreeTest right;
     public int id;

--- a/test/jdk/java/io/Serializable/oldTests/CheckForException.java
+++ b/test/jdk/java/io/Serializable/oldTests/CheckForException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,8 @@ public class CheckForException {
 }
 
 class PickleClass implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     int ii = 17;
     transient int tmp[];
 
@@ -129,6 +131,8 @@ class PickleClass implements java.io.Serializable {
 }
 
 class NoPickleClass extends PickleClass {
+    private static final long serialVersionUID = 1L;
+
     private void writeObject(ObjectOutputStream pw)
         throws NotSerializableException
     {
@@ -143,6 +147,8 @@ class NoPickleClass extends PickleClass {
 }
 
 class TryPickleClass  extends NoPickleClass {
+    private static final long serialVersionUID = 1L;
+
     int i = 7;
     transient int tmp[];
 

--- a/test/jdk/java/io/Serializable/oldTests/CheckingEquality.java
+++ b/test/jdk/java/io/Serializable/oldTests/CheckingEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,8 @@ public class CheckingEquality {
 }
 
 class Firstpsio implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     String one;
     int two;
     float three[];
@@ -125,6 +127,8 @@ class Firstpsio implements java.io.Serializable {
 }
 
 class Secondpsio extends Firstpsio  {
+    private static final long serialVersionUID = 1L;
+
     String quatre;
     int cinq;
 
@@ -173,6 +177,7 @@ class Secondpsio extends Firstpsio  {
 }
 
 class Thirdpsio extends Secondpsio {
+    private static final long serialVersionUID = 1L;
 
     static String ign = "ignored";
     transient Object oh;
@@ -184,7 +189,8 @@ class Thirdpsio extends Secondpsio {
     static final byte dcare = (byte) 128;
     private short nine = 8888;
     long ten;
-    java.util.Enumeration zero;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
+    java.util.Enumeration<?> zero;
 
 
     boolean equals(Thirdpsio other) {
@@ -227,7 +233,7 @@ class Thirdpsio extends Secondpsio {
         eight = (byte)8;
         nine = (short)9;
         ten = (long)100000;
-        java.util.Enumeration em = null; /* default */
+        java.util.Enumeration<?> em = null; /* default */
 
         super.init();
     }

--- a/test/jdk/java/io/Serializable/oldTests/CircularList.java
+++ b/test/jdk/java/io/Serializable/oldTests/CircularList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,8 @@ public class CircularList {
 }
 
 class CircularListTest implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     public CircularListTest next = null;
     public static CircularListTest list = null;
 

--- a/test/jdk/java/io/Serializable/oldTests/PrimitivesTest.java
+++ b/test/jdk/java/io/Serializable/oldTests/PrimitivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 public class PrimitivesTest implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     byte b = 1;
     char c = 'c';
     float f = 3.14159f;

--- a/test/jdk/java/io/Serializable/oldTests/ValidateClass.java
+++ b/test/jdk/java/io/Serializable/oldTests/ValidateClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class ValidateClass {
             Validator vc_u;
 
             vc_u = (Validator)q.readObject();
-            if (vc_u.validated != Integer.MIN_VALUE) {
+            if (Validator.validated != Integer.MIN_VALUE) {
                 System.err.println("\nTEST FAILED: Validation callbacks did " +
                     "not complete.");
                 throw new Error();
@@ -80,6 +80,7 @@ public class ValidateClass {
 }
 
 class MissingWriterClass implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     int i = 77;
 
     private void writeObject(ObjectOutputStream pw) throws IOException {
@@ -88,6 +89,7 @@ class MissingWriterClass implements java.io.Serializable {
 }
 
 class MissingReaderClass implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     int i = 77;
 
     private void readObject(ObjectInputStream pr) throws IOException {
@@ -97,6 +99,8 @@ class MissingReaderClass implements java.io.Serializable {
 
 
 class Validator implements ObjectInputValidation, java.io.Serializable  {
+    private static final long serialVersionUID = 1L;
+
     static int validated = Integer.MAX_VALUE; // Last value validated
     int priority;
     Validator next = null;

--- a/test/jdk/java/io/Serializable/optionalDataEnd/OptionalDataEnd.java
+++ b/test/jdk/java/io/Serializable/optionalDataEnd/OptionalDataEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 
 class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int reps;
 
     Foo(int reps) {
@@ -40,7 +42,7 @@ class Foo implements Serializable {
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         for (int i = 0; i < reps; i++) {
-            out.writeObject(new Integer(i));
+            out.writeObject(i);
         }
     }
 

--- a/test/jdk/java/io/Serializable/packageAccess/B.java
+++ b/test/jdk/java/io/Serializable/packageAccess/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  */
 
 public class B extends A implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     public B() {
         super(0);
     }

--- a/test/jdk/java/io/Serializable/packageAccess/C.java
+++ b/test/jdk/java/io/Serializable/packageAccess/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 
 public class C implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     Object writeReplace() throws ObjectStreamException {
         throw new Error("package-private writeReplace called");
     }

--- a/test/jdk/java/io/Serializable/packageAccess/D.java
+++ b/test/jdk/java/io/Serializable/packageAccess/D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,4 +29,5 @@
  */
 
 public class D extends C implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
 }

--- a/test/jdk/java/io/Serializable/packageAccess/PackageAccessTest.java
+++ b/test/jdk/java/io/Serializable/packageAccess/PackageAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ import jdk.test.lib.util.JarUtils;
 
 public class PackageAccessTest {
 
-    static Class bcl;
-    static Class dcl;
+    static Class<?> bcl;
+    static Class<?> dcl;
 
     public static void main(String[] args) throws Exception {
         setup();
@@ -62,7 +62,7 @@ public class PackageAccessTest {
             bcl = Class.forName("B", true, ldr);
             dcl = Class.forName("D", true, ldr);
 
-            Object b = bcl.newInstance();
+            Object b = bcl.getConstructor().newInstance();
             try {
                 swizzle(b);
                 throw new Error("expected InvalidClassException for class B");
@@ -74,7 +74,7 @@ public class PackageAccessTest {
                 throw new Error("package private constructor of A invoked");
             }
 
-            Object d = dcl.newInstance();
+            Object d = dcl.getConstructor().newInstance();
             swizzle(d);
         }
     }
@@ -103,7 +103,7 @@ class TestObjectInputStream extends ObjectInputStream {
         super(in);
     }
 
-    protected Class resolveClass(ObjectStreamClass desc)
+    protected Class<?> resolveClass(ObjectStreamClass desc)
         throws IOException, ClassNotFoundException
     {
         String n = desc.getName();

--- a/test/jdk/java/io/Serializable/parents/EvolvedClass.java
+++ b/test/jdk/java/io/Serializable/parents/EvolvedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,8 @@ public class EvolvedClass {
  * must not be invoked.
  */
 class ASuperClass implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     String name;
 
     ASuperClass() {

--- a/test/jdk/java/io/Serializable/parents/OriginalClass.java
+++ b/test/jdk/java/io/Serializable/parents/OriginalClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,8 @@ public class OriginalClass {
 
 
 class ASubClass implements Serializable {
+    private static final long serialVersionUID = 6341246181948372513L;
+
     int num;
 
     ASubClass(int num) {

--- a/test/jdk/java/io/Serializable/partialClassDesc/PartialClassDesc.java
+++ b/test/jdk/java/io/Serializable/partialClassDesc/PartialClassDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ class A implements Serializable {
 
 public class PartialClassDesc {
     public static void main(String[] args) throws Exception {
-        Class cl = Class.forName(
+        Class<?> cl = Class.forName(
             "A", false, PartialClassDesc.class.getClassLoader());
         ObjectStreamClass desc = null;
         try {

--- a/test/jdk/java/io/Serializable/primitiveClasses/PrimitiveClasses.java
+++ b/test/jdk/java/io/Serializable/primitiveClasses/PrimitiveClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.io.*;
 
 public class PrimitiveClasses {
     public static void main(String[] args) throws Exception {
-        Class[] primClasses = new Class[] {
+        Class<?>[] primClasses = {
             boolean.class, byte.class, char.class, short.class,
             int.class, long.class, float.class, double.class, void.class
         };

--- a/test/jdk/java/io/Serializable/proxy/Basic.java
+++ b/test/jdk/java/io/Serializable/proxy/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,12 +36,13 @@ interface Bar { float bar(); }
 
 // dummy invocation handler
 class Handler implements InvocationHandler, Serializable {
+    private static final long serialVersionUID = 1L;
 
     static Method fooMethod, barMethod;
     static {
         try {
-            fooMethod = Foo.class.getDeclaredMethod("foo", new Class[0]);
-            barMethod = Bar.class.getDeclaredMethod("bar", new Class[0]);
+            fooMethod = Foo.class.getDeclaredMethod("foo", new Class<?>[0]);
+            barMethod = Bar.class.getDeclaredMethod("bar", new Class<?>[0]);
         } catch (NoSuchMethodException ex) {
             throw new Error();
         }
@@ -59,9 +60,9 @@ class Handler implements InvocationHandler, Serializable {
         throws Throwable
     {
         if (method.equals(fooMethod)) {
-            return new Integer(foo);
+            return foo;
         } else if (method.equals(barMethod)) {
-            return new Float(bar);
+            return bar;
         } else {
             throw new UnsupportedOperationException();
         }
@@ -73,7 +74,7 @@ class ProxyBlindInputStream extends ObjectInputStream {
 
     ProxyBlindInputStream(InputStream in) throws IOException { super(in); }
 
-    protected Class resolveProxyClass(String[] interfaces)
+    protected Class<?> resolveProxyClass(String[] interfaces)
         throws IOException, ClassNotFoundException
     {
         throw new ClassNotFoundException();
@@ -83,7 +84,7 @@ class ProxyBlindInputStream extends ObjectInputStream {
 public class Basic {
     public static void main(String[] args) throws Exception {
         ClassLoader loader = Basic.class.getClassLoader();
-        Class[] interfaces = new Class[] { Foo.class, Bar.class };
+        Class<?>[] interfaces = { Foo.class, Bar.class };
         Random rand = new Random();
         int foo = rand.nextInt();
         float bar = rand.nextFloat();

--- a/test/jdk/java/io/Serializable/proxy/replace/Test.java
+++ b/test/jdk/java/io/Serializable/proxy/replace/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.io.*;
 import java.lang.reflect.*;
 
 public class Test implements InvocationHandler, Serializable {
+    private static final long serialVersionUID = 1L;
 
     static ClassLoader loader = Test.class.getClassLoader();
 
@@ -39,10 +40,10 @@ public class Test implements InvocationHandler, Serializable {
         String methName = method.getName();
         if (methName.equals("writeReplace")) {
             return Proxy.newProxyInstance(
-                loader, new Class[] { ReadResolve.class }, this);
+                loader, new Class<?>[] { ReadResolve.class }, this);
         } else if (methName.equals("readResolve")) {
             return Proxy.newProxyInstance(
-                loader, new Class[] { Resolved.class }, this);
+                loader, new Class<?>[] { Resolved.class }, this);
         } else if (method.getDeclaringClass() == Object.class) {
             return method.invoke(this, args);
         } else {
@@ -54,7 +55,7 @@ public class Test implements InvocationHandler, Serializable {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(bout);
         oout.writeObject(Proxy.newProxyInstance(
-            loader, new Class[] { WriteReplace.class }, new Test()));
+            loader, new Class<?>[] { WriteReplace.class }, new Test()));
         oout.close();
         ObjectInputStream oin = new ObjectInputStream(
             new ByteArrayInputStream(bout.toByteArray()));

--- a/test/jdk/java/io/Serializable/proxy/skipMissing/Handler.java
+++ b/test/jdk/java/io/Serializable/proxy/skipMissing/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import java.io.*;
 import java.lang.reflect.*;
 
 class Handler implements InvocationHandler, Serializable {
+    private static final long serialVersionUID = 1L;
+
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable
     {

--- a/test/jdk/java/io/Serializable/proxy/skipMissing/Write.java
+++ b/test/jdk/java/io/Serializable/proxy/skipMissing/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ interface I {}          // interface present only on writing side
 class A implements Serializable {
     private static final long serialVersionUID = 0L;
     String a = "a";
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object proxy;
     String z = "z";
 
@@ -65,7 +66,7 @@ public class Write {
     public static void main(String[] args) throws Exception {
         Object proxy = Proxy.newProxyInstance(
             Write.class.getClassLoader(),
-            new Class[] { I.class }, new Handler());
+            new Class<?>[] { I.class }, new Handler());
         ObjectOutputStream oout = new ObjectOutputStream(
             new FileOutputStream("tmp.ser"));
         oout.writeObject(new A(proxy));

--- a/test/jdk/java/io/Serializable/readObjectNoData/Read.java
+++ b/test/jdk/java/io/Serializable/readObjectNoData/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ class A {
 class B extends A implements Serializable {
     private static final long serialVersionUID = 0L;
     boolean bCalled = false;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     private void readObjectNoData(int wrong) throws ObjectStreamException {
         bCalled = true;
     }
@@ -82,6 +83,7 @@ class D extends C {
 class E extends D {
     private static final long serialVersionUID = 0L;
     boolean eCalled = false;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     void readObjectNoData() throws ObjectStreamException {
         eCalled = true;
     }

--- a/test/jdk/java/io/Serializable/recursiveClassDescLookup/Test.java
+++ b/test/jdk/java/io/Serializable/recursiveClassDescLookup/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ class Foo implements Serializable {
 
 public class Test {
     public static void main(String[] args) throws Exception {
-        Class fooCl = Class.forName("Foo", false, Test.class.getClassLoader());
+        Class<?> fooCl = Class.forName("Foo", false, Test.class.getClassLoader());
         ObjectStreamClass.lookup(fooCl);
         System.out.println("done.");
     }

--- a/test/jdk/java/io/Serializable/replaceStringArray/ReplaceStringArray.java
+++ b/test/jdk/java/io/Serializable/replaceStringArray/ReplaceStringArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import java.io.*;
 import java.lang.reflect.Array;
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     String stringA;
     String stringB;
     String stringC;
@@ -74,7 +76,7 @@ class SubstituteObjectOutputStream extends ObjectOutputStream {
             Object[] array = (Object[]) obj;
             /* Double the array.
              * Initialize new array elements with original array. */
-            Class arrayComponentType = array.getClass().getComponentType();
+            Class<?> arrayComponentType = array.getClass().getComponentType();
             Object[] newarray =
                 (Object[])Array.newInstance(arrayComponentType,
                                             array.length * 2);
@@ -108,7 +110,7 @@ class SubstituteObjectInputStream extends ObjectInputStream {
 
             /* Double the array.
              * Initialize new array elements with original array. */
-            Class arrayComponentType = array.getClass().getComponentType();
+            Class<?> arrayComponentType = array.getClass().getComponentType();
             Object[] newarray =
                 (Object[])Array.newInstance(arrayComponentType,
                                             array.length * 2);

--- a/test/jdk/java/io/Serializable/resolveClass/MethodTest.java
+++ b/test/jdk/java/io/Serializable/resolveClass/MethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,11 @@ import java.io.*;
 import java.lang.reflect.*;
 
 public class MethodTest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static void main(String[] args) throws Exception {
         Method readObject = ObjectInputStream.class.getDeclaredMethod(
-            "readObject", new Class[0]);
+            "readObject", new Class<?>[0]);
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(bout);
         oout.writeObject(new MethodTest());

--- a/test/jdk/java/io/Serializable/resolveClass/consTest/ConsTest.java
+++ b/test/jdk/java/io/Serializable/resolveClass/consTest/ConsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,9 +42,10 @@ import java.lang.reflect.Constructor;
 import jdk.test.lib.util.JarUtils;
 
 public class ConsTest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static void main(String[] args) throws Exception {
-        Constructor cons = Boot.class.getConstructor(
-            new Class[] { ObjectInputStream.class });
+        Constructor<?> cons = Boot.class.getConstructor(ObjectInputStream.class);
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oout = new ObjectOutputStream(bout);
         oout.writeObject(new ConsTest());
@@ -53,7 +54,7 @@ public class ConsTest implements Serializable {
         for (int i = 0; i < 100; i++) {
             ObjectInputStream oin = new ObjectInputStream(
                 new ByteArrayInputStream(bout.toByteArray()));
-            cons.newInstance(new Object[]{ oin });
+            cons.newInstance(oin);
         }
     }
 }

--- a/test/jdk/java/io/Serializable/resolveClass/deserializeButton/DeserializeButtonTest.java
+++ b/test/jdk/java/io/Serializable/resolveClass/deserializeButton/DeserializeButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class DeserializeButtonTest {
 
         try (URLClassLoader ldr =
             new URLClassLoader(new URL[]{ new URL("file:cb.jar") })) {
-            Runnable r = (Runnable) Class.forName("Foo", true, ldr).newInstance();
+            Runnable r = (Runnable) Class.forName("Foo", true, ldr)
+                    .getConstructor().newInstance();
             r.run();
         }
     }

--- a/test/jdk/java/io/Serializable/resolveClass/deserializeButton/Foo.java
+++ b/test/jdk/java/io/Serializable/resolveClass/deserializeButton/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,9 @@ import java.util.Vector;
 
 public class Foo implements Runnable {
 
-    static class TestElement extends Object implements Serializable {}
+    static class TestElement extends Object implements Serializable {
+        private static final long serialVersionUID = 1L;
+    }
 
     public void run() {
         try {

--- a/test/jdk/java/io/Serializable/resolveClassException/ResolveClassException.java
+++ b/test/jdk/java/io/Serializable/resolveClassException/ResolveClassException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,8 @@ class BrokenObjectInputStream extends ObjectInputStream {
         super(in);
     }
 
-    protected Class resolveClass(ObjectStreamClass desc)
-        throws IOException, ClassNotFoundException
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+        throws ClassNotFoundException
     {
         throw new ClassNotFoundException(message);
     }
@@ -53,7 +53,7 @@ public class ResolveClassException {
         Object obj;
 
         // write and read an object
-        obj = new Integer(5);
+        obj = 5;
         bout = new ByteArrayOutputStream();
         oout = new ObjectOutputStream(bout);
         oout.writeObject(obj);
@@ -67,7 +67,7 @@ public class ResolveClassException {
         }
 
         // write and read an array of objects
-        obj = new Integer[] { new Integer(5) };
+        obj = new Integer[] { 5 };
         bout = new ByteArrayOutputStream();
         oout = new ObjectOutputStream(bout);
         oout.writeObject(obj);

--- a/test/jdk/java/io/Serializable/resolveProxyClass/NonPublicInterface.java
+++ b/test/jdk/java/io/Serializable/resolveProxyClass/NonPublicInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import java.lang.reflect.Proxy;
 public class NonPublicInterface {
 
     static class Handler implements InvocationHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
         public Object invoke(Object obj, Method meth, Object[] args) {
             return null;
         }

--- a/test/jdk/java/io/Serializable/sanityCheck/SanityCheck.java
+++ b/test/jdk/java/io/Serializable/sanityCheck/SanityCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.*;
 import java.util.*;
 
 class Item implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     static final int ARRAYLEN = 1000;
     static final int STRLEN = 1000;
@@ -55,6 +56,7 @@ class Item implements Serializable {
     double[] dary;
 
     String str;
+    @SuppressWarnings("serial")  /* Incorrect declarations are being tested */
     Object[] oary;
 
     Item() {
@@ -86,7 +88,7 @@ class Item implements Serializable {
             fary[i] = rand.nextFloat();
             jary[i] = rand.nextLong();
             dary[i] = rand.nextDouble();
-            oary[i] = new Integer(rand.nextInt());
+            oary[i] = rand.nextInt();
         }
 
         char[] strChars = new char[STRLEN];
@@ -125,6 +127,11 @@ class Item implements Serializable {
         }
 
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(i, j);
     }
 }
 

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -775,6 +775,7 @@ public class SerialFilterTest implements Serializable {
     static class ReadResolveToArray implements Serializable, ObjectInputFilter {
         private static final long serialVersionUID = 123456789L;
 
+        @SuppressWarnings("serial") /* Incorrect declarations are being tested */
         private final Object array;
         private final int length;
 

--- a/test/jdk/java/io/Serializable/serialver/classpath/ClasspathTest.java
+++ b/test/jdk/java/io/Serializable/serialver/classpath/ClasspathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.ProcessTools;
 
 public class ClasspathTest implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     int a;
     int b;
 

--- a/test/jdk/java/io/Serializable/serialver/nested/NestedTest.java
+++ b/test/jdk/java/io/Serializable/serialver/nested/NestedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,11 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.ProcessTools;
 
 public class NestedTest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static class Test1 implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         public static class Test2 implements Serializable{
             private static final long serialVersionUID = 100L;
         }

--- a/test/jdk/java/io/Serializable/skipToEndOfBlockData/SkipToEndOfBlockData.java
+++ b/test/jdk/java/io/Serializable/skipToEndOfBlockData/SkipToEndOfBlockData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
 import java.io.*;
 
 class MismatchedRead implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int i;
     float f;
 
@@ -59,9 +61,15 @@ class MismatchedRead implements Serializable {
         MismatchedRead other = (MismatchedRead) obj;
         return (i == other.i && f == other.f);
     }
+
+    public int hashCode() {
+        return i;
+    }
 }
 
 class MismatchedReadExternal implements Externalizable {
+    private static final long serialVersionUID = 1L;
+
     int i;
     float f;
 
@@ -91,9 +99,15 @@ class MismatchedReadExternal implements Externalizable {
         MismatchedReadExternal other = (MismatchedReadExternal) obj;
         return (i == other.i && f == other.f);
     }
+
+    public int hashCode() {
+        return i;
+    }
 }
 
 class InnocentBystander implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     String s;
 
     InnocentBystander(String s) {
@@ -107,6 +121,10 @@ class InnocentBystander implements Serializable {
         if (s != null)
             return s.equals(other.s);
         return (s == other.s);
+    }
+
+    public int hashCode() {
+        return s.hashCode();
     }
 }
 

--- a/test/jdk/java/io/Serializable/skipWriteObject/Write.java
+++ b/test/jdk/java/io/Serializable/skipWriteObject/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,8 @@ class Foo implements Serializable {
 }
 
 class Bar implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     int a, b;
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();

--- a/test/jdk/java/io/Serializable/skippedObjCNFException/Read.java
+++ b/test/jdk/java/io/Serializable/skippedObjCNFException/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ class A implements Serializable {
 
 class B implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object c;
 }
 

--- a/test/jdk/java/io/Serializable/skippedObjCNFException/Write.java
+++ b/test/jdk/java/io/Serializable/skippedObjCNFException/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,13 @@ class A implements Serializable {
     // all three following fields not present on reading side
     B b = new B();
     C c = new C();
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object ca = new Object[] { new C() };
 }
 
 class B implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object c = new C();
 }
 

--- a/test/jdk/java/io/Serializable/stopCustomDeserialization/Read.java
+++ b/test/jdk/java/io/Serializable/stopCustomDeserialization/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.*;
 
 class A implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object x;
 }
 

--- a/test/jdk/java/io/Serializable/stopCustomDeserialization/Write.java
+++ b/test/jdk/java/io/Serializable/stopCustomDeserialization/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.io.*;
 
 class A implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect declarations are being tested */
     Object x = new X();
 }
 

--- a/test/jdk/java/io/Serializable/subclass/AbstractObjectInputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/AbstractObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -253,7 +253,7 @@ public abstract class AbstractObjectInputStream extends ObjectInputStream
      * @exception InstantiationException  TBD.
      */
     protected final native Object
-        allocateNewObject(Class ofClass, Class ctorClass)
+        allocateNewObject(Class<?> ofClass, Class<?> ctorClass)
         throws InstantiationException, IllegalAccessException;
 
     /**
@@ -271,7 +271,7 @@ public abstract class AbstractObjectInputStream extends ObjectInputStream
      * @exception InstantiationException  TBD.
      */
     protected final native Object
-        allocateNewArray(Class componentClass, int length)
+        allocateNewArray(Class<?> componentClass, int length)
         throws InstantiationException, IllegalAccessException;
 
     /**
@@ -317,5 +317,6 @@ public abstract class AbstractObjectInputStream extends ObjectInputStream
     public abstract int skipBytes(int len) throws IOException;
 
     /* @deprecated */
+    @SuppressWarnings("deprecation")
     public abstract String readLine() throws IOException;
 };

--- a/test/jdk/java/io/Serializable/subclass/SubclassTest.java
+++ b/test/jdk/java/io/Serializable/subclass/SubclassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,8 @@ import java.io.Serializable;
  * Test if customized readObject and writeObject are called.
  */
 class B implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int publicIntField;
     public static int numWriteObjectCalled = 0;
     B(int v) {
@@ -80,9 +82,11 @@ class B implements Serializable {
  */
 
 class C implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int xx1;
     public int xx2;
-    static final ObjectStreamField[] serialPersistentFields = {
+    private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("x1", Integer.TYPE),
         new ObjectStreamField("x2", Integer.TYPE),
         new ObjectStreamField("x3", Integer.TYPE),
@@ -106,6 +110,8 @@ class C implements Serializable {
 
 
 class A implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int  publicIntField;
     public long publicLongField;
     public B    publicBField;

--- a/test/jdk/java/io/Serializable/subclass/XObjectInputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/XObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ class XObjectInputStream extends AbstractObjectInputStream {
 
         Object readResult = null;
         Object prevObject = currentObject;
-        Class  prevDesc   = currentClassDescriptor;
+        Class<?>  prevDesc   = currentClassDescriptor;
 
         boolean NotImplemented = true;
         if (NotImplemented)
@@ -243,7 +243,7 @@ class XObjectInputStream extends AbstractObjectInputStream {
      }
 
     private Object currentObject;
-    private Class currentClassDescriptor;
+    private Class<?> currentClassDescriptor;
 
 
 
@@ -256,15 +256,15 @@ class XObjectInputStream extends AbstractObjectInputStream {
      * Set the accessible flag on it here. ObjectOutputStream
      * will call it as necessary.
      */
-    public static Method getReadObjectMethod(final Class cl) {
+    public static Method getReadObjectMethod(final Class<?> cl) {
 
-        Method readObjectMethod = (Method)
+        Method readObjectMethod =
             java.security.AccessController.doPrivileged
-            (new java.security.PrivilegedAction() {
-                public Object run() {
+            (new java.security.PrivilegedAction<Method>() {
+                public Method run() {
                     Method m = null;
                     try {
-                        Class[] args = {ObjectInputStream.class};
+                        Class<?>[] args = {ObjectInputStream.class};
                         m = cl.getDeclaredMethod("readObject", args);
                         int mods = m.getModifiers();
                         // Method must be private and non-static
@@ -292,8 +292,8 @@ class XObjectInputStream extends AbstractObjectInputStream {
     {
         try {
             java.security.AccessController.doPrivileged
-                (new java.security.PrivilegedExceptionAction() {
-                    public Object run() throws InvocationTargetException,
+                (new java.security.PrivilegedExceptionAction<Void>() {
+                    public Void run() throws InvocationTargetException,
                                         java.lang.IllegalAccessException {
                         m.invoke(obj, argList);
                         return null;

--- a/test/jdk/java/io/Serializable/subclass/XObjectOutputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/XObjectOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,7 +116,7 @@ public class XObjectOutputStream extends AbstractObjectOutputStream {
             int mods = fields[i].getModifiers();
             if (Modifier.isStatic(mods) || Modifier.isTransient(mods))
                 continue;
-            Class FieldType = fields[i].getType();
+            Class<?> FieldType = fields[i].getType();
             if (FieldType.isPrimitive()) {
                 System.out.println("Field " + fields[i].getName() +
                                     " has primitive type " + FieldType.toString());
@@ -127,7 +127,7 @@ public class XObjectOutputStream extends AbstractObjectOutputStream {
                     writeObject(fields[i].get(obj));
                     if (FieldType.isArray()) {
                         Object[] array = ((Object[]) fields[i].get(obj));
-                        Class componentType = FieldType.getComponentType();
+                        Class<?> componentType = FieldType.getComponentType();
                         if (componentType.isPrimitive())
                             System.out.println("Output " + array.length + " primitive elements of" +
                                                componentType.toString());
@@ -227,6 +227,7 @@ public class XObjectOutputStream extends AbstractObjectOutputStream {
         /**
          * Write the data and fields to the specified ObjectOutput stream.
          */
+        @SuppressWarnings("deprecation")
         public void write(ObjectOutput out) throws IOException {
             for (int i = 0; i < next; i++)
                 System.out.println(fieldName[i] + "=" + intValue[i]);
@@ -300,15 +301,15 @@ public class XObjectOutputStream extends AbstractObjectOutputStream {
      * Set the accessible flag on it here.
      * Subclass of AbstractObjectOutputStream will call it as necessary.
      */
-    public static Method getWriteObjectMethod(final Class cl) {
+    public static Method getWriteObjectMethod(final Class<?> cl) {
 
-        Method writeObjectMethod = (Method)
+        Method writeObjectMethod =
             java.security.AccessController.doPrivileged
-            (new java.security.PrivilegedAction() {
-                public Object run() {
+            (new java.security.PrivilegedAction<Method>() {
+                public Method run() {
                     Method m = null;
                     try {
-                        Class[] args = {ObjectOutputStream.class};
+                        Class<?>[] args = {ObjectOutputStream.class};
                         m = cl.getDeclaredMethod("writeObject", args);
                         int mods = m.getModifiers();
                         // Method must be private and non-static
@@ -336,8 +337,8 @@ public class XObjectOutputStream extends AbstractObjectOutputStream {
     {
         try {
             java.security.AccessController.doPrivileged
-                (new java.security.PrivilegedExceptionAction() {
-                    public Object run() throws InvocationTargetException,
+                (new java.security.PrivilegedExceptionAction<Void>() {
+                    public Void run() throws InvocationTargetException,
                                         java.lang.IllegalAccessException {
                         m.invoke(obj, argList);
                         return null;

--- a/test/jdk/java/io/Serializable/superclassDataLoss/A.java
+++ b/test/jdk/java/io/Serializable/superclassDataLoss/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  */
 
 public class A implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
     protected final int i;
     protected A(int i) { this.i = i; }
 }

--- a/test/jdk/java/io/Serializable/superclassDataLoss/B.java
+++ b/test/jdk/java/io/Serializable/superclassDataLoss/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  */
 
 public class B extends A implements Runnable {
+    private static final long serialVersionUID = 1L;
+
     public B() { super(0xDEADBEEF); }
 
     // verify superclass data still present

--- a/test/jdk/java/io/Serializable/superclassDataLoss/SuperclassDataLossTest.java
+++ b/test/jdk/java/io/Serializable/superclassDataLoss/SuperclassDataLossTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class MixedSuperclassStream extends ObjectInputStream {
         this.ldr12A = ldr12A;
     }
 
-    protected Class resolveClass(ObjectStreamClass desc)
+    protected Class<?> resolveClass(ObjectStreamClass desc)
         throws IOException, ClassNotFoundException
     {
         // resolve A's classdesc to class != B's superclass
@@ -91,7 +91,8 @@ public class SuperclassDataLossTest {
              URLClassLoader ldr2 = new URLClassLoader(new URL[] { new URL("file:cb2.jar") })) {
             setup();
 
-            Runnable a = (Runnable) Class.forName("B", true, ldr1).newInstance();
+            Runnable a = (Runnable) Class.forName("B", true, ldr1)
+                    .getConstructor().newInstance();
             a.run();
 
             ByteArrayOutputStream bout = new ByteArrayOutputStream();

--- a/test/jdk/java/io/Serializable/survivePrematureClose/SurvivePrematureClose.java
+++ b/test/jdk/java/io/Serializable/survivePrematureClose/SurvivePrematureClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
 import java.io.*;
 
 class A implements Externalizable {
+    private static final long serialVersionUID = 1L;
 
     public A() {}
 
@@ -49,6 +50,7 @@ class A implements Externalizable {
 }
 
 class B implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();

--- a/test/jdk/java/io/Serializable/typeSafeEnum/TypeSafeEnum.java
+++ b/test/jdk/java/io/Serializable/typeSafeEnum/TypeSafeEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
 import java.io.*;
 
 public class TypeSafeEnum implements Serializable, ObjectInputValidation {
+    private static final long serialVersionUID = 1L;
+
     private static int numWriteObject = 0;
     private static int numReadObject = 0;
 
@@ -47,7 +49,7 @@ public class TypeSafeEnum implements Serializable, ObjectInputValidation {
     static boolean verbose = false;
 
 
-    private Object writeReplace() throws IOException {
+    private Object writeReplace() {
         numWriteReplace++;
         if (verbose) {
             System.out.println("TypeSafeEnum.writeReplace() " +
@@ -56,7 +58,7 @@ public class TypeSafeEnum implements Serializable, ObjectInputValidation {
         return this;
     }
 
-    private Object readResolve() throws IOException {
+    private Object readResolve() {
         numReadResolve++;
         if (verbose) {
             System.out.println("readResolve called on " + this.toString());

--- a/test/jdk/java/io/Serializable/typeStringBackRef/TypeStringBackRef.java
+++ b/test/jdk/java/io/Serializable/typeStringBackRef/TypeStringBackRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 import java.io.*;
 
 public class TypeStringBackRef implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     String a, b, c, d, e, f, g;
 

--- a/test/jdk/java/io/Serializable/underlyingOutputStreamException/UnderlyingOutputStreamException.java
+++ b/test/jdk/java/io/Serializable/underlyingOutputStreamException/UnderlyingOutputStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 import java.io.*;
 
 class OriginalIOException extends IOException {
+    private static final long serialVersionUID = 1L;
 }
 
 class BrokenOutputStream extends OutputStream {

--- a/test/jdk/java/io/Serializable/unnamedPackageSwitch/UnnamedPackageSwitchTest.java
+++ b/test/jdk/java/io/Serializable/unnamedPackageSwitch/UnnamedPackageSwitchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ class A implements Serializable {
 
 class TestObjectInputStream extends ObjectInputStream {
     TestObjectInputStream(InputStream in) throws IOException { super(in); }
-    protected Class resolveClass(ObjectStreamClass desc)
+    protected Class<?> resolveClass(ObjectStreamClass desc)
         throws IOException, ClassNotFoundException
     {
         String name = desc.getName();

--- a/test/jdk/java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass.java
+++ b/test/jdk/java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,4 +65,5 @@ public class UnresolvableObjectStreamClass {
 }
 
 class MySerializable implements Serializable {
+    private static final long serialVersionUID = 1L;
 }

--- a/test/jdk/java/io/Serializable/unresolvedClassDesc/Foo.java
+++ b/test/jdk/java/io/Serializable/unresolvedClassDesc/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,4 +29,5 @@
  */
 
 public class Foo implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
 }

--- a/test/jdk/java/io/Serializable/unshared/Write.java
+++ b/test/jdk/java/io/Serializable/unshared/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@
 import java.io.*;
 
 class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private static final ObjectStreamField[] serialPersistentFields =
         new ObjectStreamField[] {
             new ObjectStreamField("shared1", String.class),
@@ -54,6 +56,7 @@ class Foo implements Serializable {
 
 class Bar implements Serializable {
     private static final long serialVersionUID = 0L;
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     Object obj;
 
     Bar(Object obj) {

--- a/test/jdk/java/io/Serializable/userRWObjError/UserRWObjError.java
+++ b/test/jdk/java/io/Serializable/userRWObjError/UserRWObjError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.io.*;
  */
 
 public class UserRWObjError implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
 
     public static void main(String[] args) throws Exception {
         try {

--- a/test/jdk/java/io/Serializable/validate/Validate.java
+++ b/test/jdk/java/io/Serializable/validate/Validate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,8 @@ public class Validate {
 }
 
 class Class1 implements Serializable, ObjectInputValidation {
+    private static final long serialVersionUID = 1L;
+
     int a, b;
     transient int validates;
 

--- a/test/jdk/java/io/Serializable/verifyDynamicObjHandleTable/VerifyDynamicObjHandleTable.java
+++ b/test/jdk/java/io/Serializable/verifyDynamicObjHandleTable/VerifyDynamicObjHandleTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 class A implements Serializable {
-    static HashSet writeObjectExtent = new HashSet();
+    private static final long serialVersionUID = 1L;
+
+    static HashSet<A> writeObjectExtent = new HashSet<>();
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         if (writeObjectExtent.contains(this)) {
@@ -63,7 +65,7 @@ public class VerifyDynamicObjHandleTable {
         // allow writeObject to be called on any objects that
         // have already been serialized. These objects should be
         // written out by reference.
-        Iterator iter = A.writeObjectExtent.iterator();
+        Iterator<A> iter = A.writeObjectExtent.iterator();
         while (iter.hasNext()) {
             out.writeObject(iter.next());
         }

--- a/test/jdk/java/io/Serializable/writeObjectMemory/WriteObjectMemory.java
+++ b/test/jdk/java/io/Serializable/writeObjectMemory/WriteObjectMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 class A implements Serializable {
-    static HashSet writeObjectExtent = new HashSet();
+    private static final long serialVersionUID = 1L;
+
+    static HashSet<A>writeObjectExtent = new HashSet<>();
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         if (writeObjectExtent.contains(this)) {
@@ -53,7 +55,7 @@ class A implements Serializable {
 
 public class WriteObjectMemory {
     public static void main(String args[])
-        throws IOException, ClassNotFoundException
+        throws IOException
     {
         ObjectOutputStream out =
             new ObjectOutputStream(new ByteArrayOutputStream(3000));
@@ -65,7 +67,7 @@ public class WriteObjectMemory {
         // allow writeObject to be called on any objects that
         // have already been serialized. These objects should be
         // written out by reference.
-        Iterator iter = A.writeObjectExtent.iterator();
+        Iterator<A> iter = A.writeObjectExtent.iterator();
         while (iter.hasNext()) {
             out.writeObject(iter.next());
         }

--- a/test/jdk/java/io/Serializable/writeReplace/WriteReplace.java
+++ b/test/jdk/java/io/Serializable/writeReplace/WriteReplace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ import java.io.*;
 public class WriteReplace {
 
     static class ReplaceMe implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @SuppressWarnings("serial") /* Incorrect use is being tested */
         private Object obj;
         private boolean writeReplaceCalled = false;
 

--- a/test/jdk/java/io/Serializable/wrongReturnTypes/Read.java
+++ b/test/jdk/java/io/Serializable/wrongReturnTypes/Read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ class A implements Serializable {
 
     static boolean readObjectNoDataCalled;
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private Object readObjectNoData() throws ObjectStreamException {
         readObjectNoDataCalled = true;
         return null;
@@ -46,6 +47,7 @@ class B extends A {
     static boolean readObjectCalled;
     static boolean readResolveCalled;
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private Integer readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException
     {
@@ -54,6 +56,7 @@ class B extends A {
         return null;
     }
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private B readResolve() throws ObjectStreamException {
         readResolveCalled = true;
         return this;

--- a/test/jdk/java/io/Serializable/wrongReturnTypes/Write.java
+++ b/test/jdk/java/io/Serializable/wrongReturnTypes/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,12 +43,14 @@ class B implements Serializable {
     static boolean writeObjectCalled;
     static boolean writeReplaceCalled;
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private Object writeObject(ObjectOutputStream out) throws IOException {
         writeObjectCalled = true;
         out.defaultWriteObject();
         return null;
     }
 
+    @SuppressWarnings("serial") /* Incorrect use is being tested */
     private B writeReplace() throws ObjectStreamException {
         writeReplaceCalled = true;
         return this;


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8231427](https://bugs.openjdk.org/browse/JDK-8231427) needs maintainer approval

### Issue
 * [JDK-8231427](https://bugs.openjdk.org/browse/JDK-8231427): Warning cleanup in tests of java.io.Serializable (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2825/head:pull/2825` \
`$ git checkout pull/2825`

Update a local copy of the PR: \
`$ git checkout pull/2825` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2825`

View PR using the GUI difftool: \
`$ git pr show -t 2825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2825.diff">https://git.openjdk.org/jdk11u-dev/pull/2825.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2825#issuecomment-2196242734)