### PR TITLE
8328896: Fontmetrics for large Fonts has zero width

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CStrike.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrike.java
@@ -201,7 +201,7 @@ public final class CStrike extends PhysicalStrike {
         getGlyphImageBounds(glyphCode, pt.x, pt.y, floatRect);
 
         if (floatRect.width == 0 && floatRect.height == 0) {
-            result.setRect(0, 0, -1, -1);
+            result.setRect(0, 0, 0, 0);
             return;
         }
 

--- a/src/java.desktop/share/classes/sun/font/FileFontStrike.java
+++ b/src/java.desktop/share/classes/sun/font/FileFontStrike.java
@@ -37,6 +37,7 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.concurrent.ConcurrentHashMap;
 import static sun.awt.SunHints.*;
+import sun.java2d.pipe.OutlineTextRenderer;
 
 
 public class FileFontStrike extends PhysicalStrike {
@@ -107,6 +108,7 @@ public class FileFontStrike extends PhysicalStrike {
     boolean useNatives;
     NativeStrike[] nativeStrikes;
 
+    static final int MAX_IMAGE_SIZE = OutlineTextRenderer.THRESHHOLD;
     /* Used only for communication to native layer */
     private int intPtSize;
 
@@ -734,6 +736,20 @@ public class FileFontStrike extends PhysicalStrike {
      */
     void getGlyphImageBounds(int glyphCode, Point2D.Float pt,
                              Rectangle result) {
+
+        if (intPtSize > MAX_IMAGE_SIZE) {
+            Rectangle.Float obds = getGlyphOutlineBounds(glyphCode);
+            if (obds.isEmpty()) {
+                Rectangle bds = getGlyphOutline(glyphCode, pt.x, pt.y).getBounds();
+                result.setBounds(bds);
+            } else {
+                result.x = (int)Math.floor(pt.x + obds.getX() + 0.5f);
+                result.y = (int)Math.floor(pt.y + obds.getY() + 0.5f);
+                result.width = (int)Math.floor(obds.getWidth() + 0.5f);
+                result.height = (int)Math.floor(obds.getHeight() + 0.5f);
+            }
+            return;
+        }
 
         long ptr = getGlyphImagePtr(glyphCode);
         float topLeftX, topLeftY;

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -422,6 +422,8 @@ static double euclidianDistance(double a, double b) {
     return sqrt(a*a+b*b);
 }
 
+#define TOO_LARGE(a, b) (abs((int)(a / b)) > 32766)
+
 JNIEXPORT jlong JNICALL
 Java_sun_font_FreetypeFontScaler_createScalerContextNative(
         JNIEnv *env, jobject scaler, jlong pScaler, jdoubleArray matrix,
@@ -433,6 +435,7 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
              (FTScalerInfo*) jlong_to_ptr(pScaler);
 
     if (context == NULL) {
+        free(context);
         invalidateJavaScaler(env, scaler, NULL);
         return (jlong) 0;
     }
@@ -442,7 +445,18 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
         //text can not be smaller than 1 point
         ptsz = 1.0;
     }
+    if (ptsz > 16384) {
+        ptsz = 16384;    // far enough from 32767
+        fm = TEXT_FM_ON; // avoids calculations which might overflow
+    }
     context->ptsz = (int)(ptsz * 64);
+    if (TOO_LARGE(dmat[0], ptsz) || TOO_LARGE(dmat[1], ptsz) ||
+        TOO_LARGE(dmat[2], ptsz) || TOO_LARGE(dmat[3], ptsz))
+    {
+        free(context);
+        return (jlong)0;
+    }
+
     context->transform.xx =  FloatToFTFixed((float)(dmat[0]/ptsz));
     context->transform.yx = -FloatToFTFixed((float)(dmat[1]/ptsz));
     context->transform.xy = -FloatToFTFixed((float)(dmat[2]/ptsz));

--- a/test/jdk/java/awt/FontMetrics/ExtremeFontSizeTest.java
+++ b/test/jdk/java/awt/FontMetrics/ExtremeFontSizeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+/*
+ * @test
+ * @bug 8328896
+ * @summary test that using very large font sizes used don't break later uses
+ */
+
+public class ExtremeFontSizeTest {
+
+    static BufferedImage bi = new BufferedImage(1,1,1);
+    static Graphics2D g2d = bi.createGraphics();
+    static String testString = "M";
+    static Font font = new Font("SansSerif", Font.PLAIN, 12);
+    static int fontSize = 0;
+    static boolean failed = false;
+    static int[] fontSizes = { 10, 12, 1000, 2000, 20000, 100000, 8 };
+    static double[] scales = { 1.0, 900.0};
+    static boolean[] fms = { false, true };
+
+    public static void main(String[] args) {
+
+        /* run tests validating bounds etc are non-zero
+         * then run with extreme scales for which zero is allowed - but not required
+         * then run the first tests again to be sure they are still reasonable.
+        */
+        runTests();
+        test(5_000_000, 10_000, false, testString, false);
+        test(5_000_000, 10_000, true, testString, false);
+        test(0, 0.00000001, false, testString, false);
+        runTests();
+
+        if (failed) {
+            throw new RuntimeException("Test failed. Check stdout log.");
+        }
+    }
+
+    static void runTests() {
+        for (int fontSize : fontSizes) {
+            for (double scale : scales) {
+                for (boolean fm : fms) {
+                    test(fontSize, scale, fm, testString, true);
+                }
+            }
+        }
+    }
+
+    static void test(int size, double scale, boolean fm, String str, boolean checkAll) {
+
+        AffineTransform at = AffineTransform.getScaleInstance(scale, scale);
+        FontRenderContext frc = new FontRenderContext(at, false, fm);
+        font = font.deriveFont((float)size);
+        g2d.setTransform(at);
+        g2d.setFont(font);
+        FontMetrics metrics = g2d.getFontMetrics();
+        int height = metrics.getHeight();
+        double width = font.getStringBounds(str, frc).getWidth();
+
+        GlyphVector gv = font.createGlyphVector(frc, str.toCharArray());
+        Rectangle pixelBounds = gv.getPixelBounds(frc, 0, 0);
+        Rectangle2D visualBounds = gv.getVisualBounds();
+
+        System.out.println("Test parameters: size="+size+" scale="+scale+" fm="+fm+" str="+str);
+        System.out.println("font height="+metrics.getHeight());
+        System.out.println("string bounds width="+width);
+        System.out.println("GlyphVector Pixel Bounds="+ pixelBounds);
+        System.out.println("GlyphVector Visual Bounds="+ visualBounds);
+
+
+        if (height < 0 || width < 0 || pixelBounds.getWidth() < 0 || visualBounds.getWidth() < 0) {
+            failed = true;
+            System.out.println(" *** Unexpected negative size reported  *** ");
+         }
+         if (!checkAll) {
+            System.out.println();
+            return;
+        }
+
+        if (height == 0 || width == 0 || (pixelBounds.isEmpty()) || visualBounds.isEmpty() ) {
+            failed = true;
+            System.out.println("Pixel bounds empty="+pixelBounds.isEmpty());
+            System.out.println("Visual bounds empty="+visualBounds.isEmpty());
+            System.out.println(" *** RESULTS NOT AS EXPECTED  *** ");
+        }
+        System.out.println();
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8328896](https://bugs.openjdk.org/browse/JDK-8328896). Applies cleanly except one hunk which is omitted:
```diff
--- src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
+++ src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
@@ -1020,4 +1020,20 @@ @implementation CGGI_GlyphCanvas
             CTFontGetAdvancesForGlyphs(font, kCTFontDefaultOrientation, glyphs, advances, count);
         }
     }
-}+    int MAX_SIZE = 1 << 30;
+    if (bboxes) {
+        for (int i = 0; i < count; i++) {
+           if (bboxes[i].origin.x > (double)MAX_SIZE) bboxes[i].origin.x = 0;
+           if (bboxes[i].origin.y > (double)MAX_SIZE) bboxes[i].origin.y = 0;
+           if (bboxes[i].size.width > (double)MAX_SIZE) bboxes[i].size.width = 0;
+           if (bboxes[i].size.height > (double)MAX_SIZE) bboxes[i].size.height = 0;
+        }
+    }
+    if (advances) {
+        for (int i = 0; i < count; i++) {
+           if (advances[i].width > (double)MAX_SIZE) advances[i].width = 0;
+           if (advances[i].height > (double)MAX_SIZE) advances[i].height = 0;
+        }
+    }
+}
+
```
[JDK-8263583](https://bugs.openjdk.org/browse/JDK-8263583) is not in 11u.

The included test has passed on linux, but failed on my MacBook Pro M1. Test has passed in 17u-dev, so there must be something wrong in 11u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8328896](https://bugs.openjdk.org/browse/JDK-8328896) needs maintainer approval

### Issue
 * [JDK-8328896](https://bugs.openjdk.org/browse/JDK-8328896): Fontmetrics for large Fonts has zero width (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2826/head:pull/2826` \
`$ git checkout pull/2826`

Update a local copy of the PR: \
`$ git checkout pull/2826` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2826`

View PR using the GUI difftool: \
`$ git pr show -t 2826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2826.diff">https://git.openjdk.org/jdk11u-dev/pull/2826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2826#issuecomment-2196671433)