### PR TITLE
8272973: Incorrect compile command used by TestIllegalArrayCopyBeforeInfiniteLoop

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -27,7 +27,7 @@
  * @requires vm.compiler2.enabled
  * @summary ArrayCopy with negative index before infinite loop
  * @run main/othervm -Xbatch -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop::foo
  *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop
  */
 
@@ -38,7 +38,7 @@ import java.util.Arrays;
 public class TestIllegalArrayCopyBeforeInfiniteLoop {
     private static char src[] = new char[10];
     private static int count = 0;
-    private static final int iter = 10_000;
+    private static final int iter = 20_000;
 
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < iter; ++i) {

--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -38,7 +38,7 @@ import java.util.Arrays;
 public class TestIllegalArrayCopyBeforeInfiniteLoop {
     private static char src[] = new char[10];
     private static int count = 0;
-    private static final int iter = 20_000;
+    private static final int iter = 10_000;
 
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < iter; ++i) {


### PR DESCRIPTION
Backport of [JDK-8272973](https://bugs.openjdk.org/browse/JDK-8272973).

Parity with 11.0.25-oracle. 

Test passes in both `release`  and `fastdebug` mode with `private static final int iter = 10_000;`

But with `private static final int iter = 20_000;` the test passes in `release` mode, but **fails in `fastdebug` mode** with **`assert(n->req() == 2 && n->in(1) != __null) failed: Only one data input expected`**:

```
# To suppress the following error report, specify this argument
# after -XX: or in .hotspotrc:  SuppressErrorAt=/cfgnode.cpp:621
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/avieirov/REPOS/OPENJDK/jdk11u-dev/src/hotspot/share/opto/cfgnode.cpp:621), pid=1641259, tid=1641275
#  assert(n->req() == 2 && n->in(1) != __null) failed: Only one data input expected
#
# JRE version: OpenJDK Runtime Environment (11.0.25) (fastdebug build 11.0.25-internal+0-adhoc.avieirov.jdk11u-dev)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 11.0.25-internal+0-adhoc.avieirov.jdk11u-dev, mixed mode, compressed oops, g1 gc, linux-amd64)
...
```

We may either:

1. Keep max iteration to `10_000`, so at least this test  runs (in both `release` and `fastdebug` modes) which seems to be the goal of 8272973.
2. Or try to first backport [JDK-8312438](https://bugs.openjdk.org/browse/JDK-8312438) which in turn seems to be related to [JDK-8263577](https://bugs.openjdk.org/browse/JDK-8263577) with seems to be a significant change [20297a1b](https://github.com/openjdk/jdk/commit/20297a1b)

Please let me know preferred way to proceed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8272973](https://bugs.openjdk.org/browse/JDK-8272973) needs maintainer approval

### Issue
 * [JDK-8272973](https://bugs.openjdk.org/browse/JDK-8272973): Incorrect compile command used by TestIllegalArrayCopyBeforeInfiniteLoop (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2828/head:pull/2828` \
`$ git checkout pull/2828`

Update a local copy of the PR: \
`$ git checkout pull/2828` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2828`

View PR using the GUI difftool: \
`$ git pr show -t 2828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2828.diff">https://git.openjdk.org/jdk11u-dev/pull/2828.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2828#issuecomment-2199604255)