### PR TITLE
8328238: Convert few closed manual applet tests to main

### DIFF
--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4419914
+ * @summary Tests that tab movement is correct in RTL component orientation.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4419914
+*/
+
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import java.util.Locale;
+
+public class bug4419914 {
+    private static final String INSTRUCTIONS = """
+        1. You will see a frame with five buttons.
+        2. Confirm that each button is placed as follows:
+             NORTH
+        END  CENTER  START
+             SOUTH
+        3. Press the "NORTH" button and confirm the button is focused.
+        4. Press TAB repeatedly and confirm that the TAB focus moves from right to left.
+             (NORTH - START - CENTER - END - SOUTH - NORTH - START - CENTER - ...)
+
+            If there's anything different from the above items, click Fail else click Pass.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Tab movement Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(12)
+                .columns(42)
+                .testUI(bug4419914::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4419914");
+        frame.setFocusCycleRoot(true);
+        frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+        frame.setLocale(Locale.ENGLISH);
+
+        frame.enableInputMethods(false);
+        frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+        frame.setLocale(Locale.ENGLISH);
+        frame.setLayout(new BorderLayout());
+        frame.add(new JButton("SOUTH"), BorderLayout.SOUTH);
+        frame.add(new JButton("CENTER"), BorderLayout.CENTER);
+        frame.add(new JButton("END"), BorderLayout.LINE_END);
+        frame.add(new JButton("START"), BorderLayout.LINE_START);
+        frame.add(new JButton("NORTH"), BorderLayout.NORTH);
+        frame.setSize(300, 150);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -37,17 +37,11 @@ import javax.swing.JFrame;
 import java.util.Locale;
 
 public class bug4419914 {
-    private static final String INSTRUCTIONS = """
-        1. You will see a frame with five buttons.
-        2. Confirm that each button is placed as follows:
-             NORTH
-        END  CENTER  START
-             SOUTH
-        3. Press the "NORTH" button and confirm the button is focused.
-        4. Press TAB repeatedly and confirm that the TAB focus moves from right to left.
-             (NORTH - START - CENTER - END - SOUTH - NORTH - START - CENTER - ...)
-
-            If there's anything different from the above items, click Fail else click Pass.""";
+    private static final String INSTRUCTIONS =
+        "Put the cursor at the beginning of the first text line and move the\n" +
+        "cursor to the right using arrow key.\n" +
+        "If the text is not corrupted then click Pass\n" +
+        "If the text disappear while cursor moves click Fail.";
 
     public static void main(String[] args) throws Exception {
         PassFailJFrame.builder()

--- a/test/jdk/javax/swing/text/PaintTest.java
+++ b/test/jdk/javax/swing/text/PaintTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4210250
+ * @summary Tests that PlainView repaints the necessary lines of text.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PaintTest
+ */
+
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+public class PaintTest {
+
+    private static final String INSTRUCTIONS = """
+        Click the paint button.
+        If half of the second line is erased,
+        that is you can only see the bottom half of the second line
+        with the top half painted over in white, click fail, else click pass.""";
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("PlainView Repaint Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(7)
+                .columns(35)
+                .testUI(PaintTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("PaintTest");
+
+        new PaintTest().create(frame.getContentPane());
+        frame.pack();
+        return frame;
+    }
+
+
+    void create(Container parent) {
+        parent.setLayout(new FlowLayout());
+
+        final JTextArea ta = new JTextArea
+            ("A sample textarea\nwith a couple of lines\nof text") {
+                public Dimension getPreferredSize() {
+                    Dimension size = super.getPreferredSize();
+                    if (getFont() != null) {
+                        size.height += getFontMetrics(getFont())
+                                       .getHeight() / 2;
+                    }
+                    return size;
+                }
+            };
+        JButton button = new JButton("paint");
+
+        button.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                SwingUtilities.invokeLater(new Runnable() {
+                    public void run() {
+                        Rectangle taBounds = ta.getBounds();
+                        int fontHeight =
+                            ta.getFontMetrics(ta.getFont()).getHeight();
+
+                        taBounds.height = fontHeight + fontHeight / 2;
+                        ta.repaint(taBounds);
+                    }
+                });
+            }
+        });
+
+        parent.add(new JScrollPane(ta));
+        parent.add(button);
+    }
+}

--- a/test/jdk/javax/swing/text/PaintTest.java
+++ b/test/jdk/javax/swing/text/PaintTest.java
@@ -44,11 +44,11 @@ import javax.swing.SwingUtilities;
 
 public class PaintTest {
 
-    private static final String INSTRUCTIONS = """
-        Click the paint button.
-        If half of the second line is erased,
-        that is you can only see the bottom half of the second line
-        with the top half painted over in white, click fail, else click pass.""";
+    private static final String INSTRUCTIONS =
+        "Click the paint button.\n" +
+        "If half of the second line is erased,\n" +
+        "that is you can only see the bottom half of the second line\n" +
+        "with the top half painted over in white, click fail, else click pass.";
 
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/text/bug4148489.java
+++ b/test/jdk/javax/swing/text/bug4148489.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4148489
+ * @summary Text gets deleted with negative values for setFirstLineIndent.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4148489
+ */
+
+import java.awt.BorderLayout;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+import javax.swing.UIManager;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyleContext;
+import javax.swing.text.Style;
+
+public class bug4148489 {
+
+    static StyleContext sc;
+    static DefaultStyledDocument doc;
+
+    private static final String INSTRUCTIONS = """
+        Put the cursor at the beginning of the first text line and move the
+        cursor to the right using arrow key.
+        If the text is not corrupted then click Pass
+        If the text disappear while cursor moves click Fail.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Text traversal Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(35)
+                .testUI(bug4148489::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        try {
+            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+        } catch (Exception e) {
+            System.err.println("Error loading L&F: " + e);
+        }
+        JPanel testPanel = new JPanel();
+        testPanel.setLayout(new BorderLayout());
+        sc = new StyleContext();
+        doc = new DefaultStyledDocument(sc);
+
+        setParagraph();
+        JTextComponent editor = new JTextPane(doc);
+        JScrollPane scroller = new JScrollPane();
+        scroller.getViewport().add(editor);
+        JPanel panel = new JPanel();
+        panel.setLayout(new BorderLayout());
+        panel.add("Center", scroller);
+        testPanel.add("Center", panel);
+        JFrame frame = new JFrame("Styled Document");
+        frame.add(testPanel);
+        frame.pack();
+        return frame;
+    }
+
+    static void setParagraph() {
+        Style sty = sc.addStyle("normal", sc.getStyle(StyleContext.DEFAULT_STYLE));
+        //here sets the negative value for setFirstLineIndent
+        StyleConstants.setFirstLineIndent(sty, -50);
+        StyleConstants.setLeftIndent(sty, 50);
+        String data = "Here I wrote some text for test. You can ignore this text because of it's a senseless text.";
+        try {
+            Style s = null;
+            doc.insertString(doc.getLength(), data, s);
+            Style ls = sc.getStyle("normal");
+            doc.setLogicalStyle(doc.getLength() - 1, ls);
+            doc.insertString(doc.getLength(), "\n", null);
+        } catch (BadLocationException e) {
+            throw new RuntimeException("BadLocationException occures while calls insertString()...", e);
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/bug4148489.java
+++ b/test/jdk/javax/swing/text/bug4148489.java
@@ -48,11 +48,11 @@ public class bug4148489 {
     static StyleContext sc;
     static DefaultStyledDocument doc;
 
-    private static final String INSTRUCTIONS = """
-        Put the cursor at the beginning of the first text line and move the
-        cursor to the right using arrow key.
-        If the text is not corrupted then click Pass
-        If the text disappear while cursor moves click Fail.""";
+    private static final String INSTRUCTIONS =
+        "Put the cursor at the beginning of the first text line and move the\n" +
+        "cursor to the right using arrow key.\n" +
+        "If the text is not corrupted then click Pass\n" +
+        "If the text disappear while cursor moves click Fail.";
 
     public static void main(String[] args) throws Exception {
         PassFailJFrame.builder()

--- a/test/jdk/javax/swing/text/html/StyleSheet/bug4803145.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/bug4803145.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4803145
+ * @summary  Tests if bullets for HTML <ul> are on the correct side for Arabic and Hebrew in JEditorPane
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4803145
+*/
+
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4803145 {
+
+    private static final String INSTRUCTIONS = """
+        A JEditorPane with some html list in Hebrew appears.
+        The bullets should be on the left side of the list items.
+        Press the "switch text orientation" button.
+        After the text relayouts:
+
+            - If the bullets are to the right of the list items then test PASSED.
+
+            - If the bullets remained on the left side then test FAILED.""";
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("JEditorPane Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(10)
+                .columns(30)
+                .testUI(bug4803145::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        String text =
+           "<ul>" +
+             "<li>&#1502;&#1489;&#1493;&#1488;" +
+             "<li>&#1488;&#1495;&#1505;&#1493;&#1503;" +
+             "<li>(new code) &#1492;&#1511;&#1493;&#1491; &#1492;&#1497;&#1513;&#1503; (Old Code)" +
+            "</ul>";
+
+        JFrame f = new JFrame("bug4803145");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.setSize(500, 500);
+        f.add(jep);
+
+        JButton switchButton = new JButton("switch text orientation");
+        switchButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                boolean isLeftToRight = jep.getComponentOrientation().isLeftToRight();
+                jep.setComponentOrientation(isLeftToRight ? ComponentOrientation.RIGHT_TO_LEFT :
+                                                            ComponentOrientation.LEFT_TO_RIGHT);
+            }
+        });
+        f.add(switchButton, BorderLayout.SOUTH);
+        f.pack();
+        return f;
+    }
+
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/bug4803145.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/bug4803145.java
@@ -41,15 +41,13 @@ import javax.swing.text.html.HTMLEditorKit;
 
 public class bug4803145 {
 
-    private static final String INSTRUCTIONS = """
-        A JEditorPane with some html list in Hebrew appears.
-        The bullets should be on the left side of the list items.
-        Press the "switch text orientation" button.
-        After the text relayouts:
-
-            - If the bullets are to the right of the list items then test PASSED.
-
-            - If the bullets remained on the left side then test FAILED.""";
+    private static final String INSTRUCTIONS =
+        "A JEditorPane with some html list in Hebrew appears.\n" +
+        "The bullets should be on the left side of the list items.\n" +
+        "Press the \"switch text orientation\" button.\n" +
+        "After the text relayouts:\n" +
+            "- If the bullets are to the right of the list items then test PASSED.\n" +
+            "- If the bullets remained on the left side then test FAILED.";
 
     public static void main(String[] args) throws Exception {
          PassFailJFrame.builder()


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
fix text blocks, so not clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328238](https://bugs.openjdk.org/browse/JDK-8328238) needs maintainer approval

### Issue
 * [JDK-8328238](https://bugs.openjdk.org/browse/JDK-8328238): Convert few closed manual applet tests to main (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2830/head:pull/2830` \
`$ git checkout pull/2830`

Update a local copy of the PR: \
`$ git checkout pull/2830` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2830`

View PR using the GUI difftool: \
`$ git pr show -t 2830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2830.diff">https://git.openjdk.org/jdk11u-dev/pull/2830.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2830#issuecomment-2202643650)