### PR TITLE
8333804: java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures

### DIFF
--- a/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
+++ b/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
@@ -390,7 +390,7 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
     public void teardown() throws Exception {
         authClient = noAuthClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(1500);
         try {
             proxy.stop();
             authproxy.stop();


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333804](https://bugs.openjdk.org/browse/JDK-8333804) needs maintainer approval

### Issue
 * [JDK-8333804](https://bugs.openjdk.org/browse/JDK-8333804): java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2833/head:pull/2833` \
`$ git checkout pull/2833`

Update a local copy of the PR: \
`$ git checkout pull/2833` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2833`

View PR using the GUI difftool: \
`$ git pr show -t 2833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2833.diff">https://git.openjdk.org/jdk11u-dev/pull/2833.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2833#issuecomment-2208198197)