### PR TITLE
8318039: GHA: Bump macOS and Xcode versions

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-11
+    runs-on: macos-13
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '11.7'
+      xcode-toolset-version: '14.3.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
@@ -234,7 +234,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '12.4'
+      xcode-toolset-version: '14.3.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -298,7 +298,7 @@ jobs:
     with:
       platform: macos-x64
       bootjdk-platform: macos-x64
-      runs-on: macos-11
+      runs-on: macos-13
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ jobs:
         run: |
           # On macOS we need to install some dependencies for testing
           brew install make
-          sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'


### PR DESCRIPTION
A backport of [JDK-8318039](https://bugs.openjdk.org/browse/JDK-8318039) to update GHA to the newest macos/XCode versions.

This in preparation of  [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) (i.e., all macos builds that are currently hanging now will fail until JDK-8296812 is in place).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318039](https://bugs.openjdk.org/browse/JDK-8318039) needs maintainer approval

### Issue
 * [JDK-8318039](https://bugs.openjdk.org/browse/JDK-8318039): GHA: Bump macOS and Xcode versions (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2835/head:pull/2835` \
`$ git checkout pull/2835`

Update a local copy of the PR: \
`$ git checkout pull/2835` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2835`

View PR using the GUI difftool: \
`$ git pr show -t 2835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2835.diff">https://git.openjdk.org/jdk11u-dev/pull/2835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2835#issuecomment-2210334589)