### PR TITLE
8316306: Open source and convert manual Swing test

### DIFF
--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4203039
+ * @summary JToolBar needs a way to limit docking to a particular orientation
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4203039
+ */
+
+public class bug4203039 {
+    private static final String instructionsText = "This test is used to verify that application-installed\n" +
+            "components prevent the toolbar from docking in\n" +
+            "those locations.\n\n" +
+
+            "This test has installed components on the SOUTH\n" +
+            "and EAST, so verify the toolbar cannot dock in those\n" +
+            "locations but can dock on the NORTH and WEST";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("bug4203039 Instructions")
+                .instructions(instructionsText)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("bug4203039");
+            frame.setSize(300, 200);
+
+            JToolBar toolbar = new JToolBar();
+            JLabel label = new JLabel("This is the toolbar");
+            toolbar.add(label);
+
+            frame.add(toolbar, BorderLayout.NORTH);
+
+            frame.add(new JComponent(){}, BorderLayout.SOUTH);
+            frame.add(new JComponent(){}, BorderLayout.EAST);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
Test blocks modified as not supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316306](https://bugs.openjdk.org/browse/JDK-8316306) needs maintainer approval

### Issue
 * [JDK-8316306](https://bugs.openjdk.org/browse/JDK-8316306): Open source and convert manual Swing test (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2840/head:pull/2840` \
`$ git checkout pull/2840`

Update a local copy of the PR: \
`$ git checkout pull/2840` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2840`

View PR using the GUI difftool: \
`$ git pr show -t 2840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2840.diff">https://git.openjdk.org/jdk11u-dev/pull/2840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2840#issuecomment-2216707136)