### PR TITLE
8255898: Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS

### DIFF
--- a/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
+++ b/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
@@ -28,7 +28,7 @@
   @summary namefilter is not called for file dialog on windows
   @library ../../regtesthelpers
   @build Util
-  @run main FilenameFilterTest
+  @run main/othervm FilenameFilterTest
 */
 
 import java.awt.*;


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
test/jdk/ProblemList.txt
java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
already added, make it clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255898](https://bugs.openjdk.org/browse/JDK-8255898) needs maintainer approval

### Issue
 * [JDK-8255898](https://bugs.openjdk.org/browse/JDK-8255898): Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2841/head:pull/2841` \
`$ git checkout pull/2841`

Update a local copy of the PR: \
`$ git checkout pull/2841` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2841`

View PR using the GUI difftool: \
`$ git pr show -t 2841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2841.diff">https://git.openjdk.org/jdk11u-dev/pull/2841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2841#issuecomment-2216709948)