### PR TITLE
8299635: Hotspot update for deprecated sprintf in Xcode 14

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -250,7 +250,7 @@ uint MachConstantBaseNode::size(PhaseRegAlloc*) const {
 #ifndef PRODUCT
 void MachConstantBaseNode::format(PhaseRegAlloc* ra_, outputStream* st) const {
   char reg[128];
-  ra_->dump_register(this, reg);
+  ra_->dump_register(this, reg, sizeof(reg));
   st->print("MOV_SLOW    &constanttable,%s\t! constant table base", reg);
 }
 #endif

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2044,7 +2044,7 @@ uint MachNopNode::size(PhaseRegAlloc *ra_) const {
 void BoxLockNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
   char reg_str[128];
-  ra_->dump_register(this, reg_str);
+  ra_->dump_register(this, reg_str, sizeof(reg_str));
   st->print("ADDI    %s, SP, %d \t// box node", reg_str, offset);
 }
 #endif

--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -267,7 +267,7 @@ int AixAttachListener::init() {
 //
 AixAttachOperation* AixAttachListener::read_request(int s) {
   char ver_str[8];
-  sprintf(ver_str, "%d", ATTACH_PROTOCOL_VER);
+  os::snprintf_checked(ver_str, sizeof(ver_str), "%d", ATTACH_PROTOCOL_VER);
 
   // The request is a sequence of strings so we first figure out the
   // expected count and the maximum possible length of the request.
@@ -312,7 +312,7 @@ AixAttachOperation* AixAttachListener::read_request(int s) {
           if ((strlen(buf) != strlen(ver_str)) ||
               (atoi(buf) != ATTACH_PROTOCOL_VER)) {
             char msg[32];
-            sprintf(msg, "%d\n", ATTACH_ERROR_BADVERSION);
+            os::snprintf_checked(msg, sizeof(msg), "%d\n", ATTACH_ERROR_BADVERSION);
             write_fully(s, msg, strlen(msg));
             return NULL;
           }
@@ -446,7 +446,7 @@ void AixAttachOperation::complete(jint result, bufferedStream* st) {
 
   // write operation result
   char msg[32];
-  sprintf(msg, "%d\n", result);
+  os::snprintf_checked(msg, sizeof(msg), "%d\n", result);
   int rc = AixAttachListener::write_fully(this->socket(), msg, strlen(msg));
 
   // write any result data
@@ -566,7 +566,7 @@ bool AttachListener::is_init_trigger() {
   char fn[PATH_MAX + 1];
   int ret;
   struct stat64 st;
-  sprintf(fn, ".attach_pid%d", os::current_process_id());
+  os::snprintf_checked(fn, sizeof(fn), ".attach_pid%d", os::current_process_id());
   RESTARTABLE(::stat64(fn, &st), ret);
   if (ret == -1) {
     log_trace(attach)("Failed to find attach file: %s, trying alternate", fn);

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -539,7 +539,7 @@ void os::init_system_properties_values() {
 #define DEFAULT_LIBPATH "/lib:/usr/lib"
 #define EXTENSIONS_DIR  "/lib/ext"
 
-  // Buffer that fits several sprintfs.
+  // Buffer that fits several snprintfs.
   // Note that the space for the trailing null is provided
   // by the nulls included by the sizeof operator.
   const size_t bufsize =
@@ -585,13 +585,14 @@ void os::init_system_properties_values() {
 
   // Concatenate user and invariant part of ld_library_path.
   // That's +1 for the colon and +1 for the trailing '\0'.
-  char *ld_library_path = (char *)NEW_C_HEAP_ARRAY(char, strlen(v) + 1 + sizeof(DEFAULT_LIBPATH) + 1, mtInternal);
-  sprintf(ld_library_path, "%s%s" DEFAULT_LIBPATH, v, v_colon);
+  size_t pathsize = strlen(v) + 1 + sizeof(DEFAULT_LIBPATH) + 1;
+  char *ld_library_path = NEW_C_HEAP_ARRAY(char, pathsize, mtInternal);
+  os::snprintf_checked(ld_library_path, pathsize, "%s%s" DEFAULT_LIBPATH, v, v_colon);
   Arguments::set_library_path(ld_library_path);
   FREE_C_HEAP_ARRAY(char, ld_library_path);
 
   // Extensions directories.
-  sprintf(buf, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
+  os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
   FREE_C_HEAP_ARRAY(char, buf);

--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -248,7 +248,7 @@ int LinuxAttachListener::init() {
 //
 LinuxAttachOperation* LinuxAttachListener::read_request(int s) {
   char ver_str[8];
-  sprintf(ver_str, "%d", ATTACH_PROTOCOL_VER);
+  os::snprintf_checked(ver_str, sizeof(ver_str), "%d", ATTACH_PROTOCOL_VER);
 
   // The request is a sequence of strings so we first figure out the
   // expected count and the maximum possible length of the request.
@@ -291,7 +291,7 @@ LinuxAttachOperation* LinuxAttachListener::read_request(int s) {
           if ((strlen(buf) != strlen(ver_str)) ||
               (atoi(buf) != ATTACH_PROTOCOL_VER)) {
             char msg[32];
-            sprintf(msg, "%d\n", ATTACH_ERROR_BADVERSION);
+            os::snprintf_checked(msg, sizeof(msg), "%d\n", ATTACH_ERROR_BADVERSION);
             write_fully(s, msg, strlen(msg));
             return NULL;
           }
@@ -415,7 +415,7 @@ void LinuxAttachOperation::complete(jint result, bufferedStream* st) {
 
   // write operation result
   char msg[32];
-  sprintf(msg, "%d\n", result);
+  os::snprintf_checked(msg, sizeof(msg), "%d\n", result);
   int rc = LinuxAttachListener::write_fully(this->socket(), msg, strlen(msg));
 
   // write any result data
@@ -534,7 +534,7 @@ bool AttachListener::is_init_trigger() {
   char fn[PATH_MAX + 1];
   int ret;
   struct stat64 st;
-  sprintf(fn, ".attach_pid%d", os::current_process_id());
+  os::snprintf_checked(fn, sizeof(fn), ".attach_pid%d", os::current_process_id());
   RESTARTABLE(::stat64(fn, &st), ret);
   if (ret == -1) {
     log_trace(attach)("Failed to find attach file: %s, trying alternate", fn);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -500,11 +500,9 @@ void os::init_system_properties_values() {
     const char *v_colon = ":";
     if (v == NULL) { v = ""; v_colon = ""; }
     // That's +1 for the colon and +1 for the trailing '\0'.
-    char *ld_library_path = (char *)NEW_C_HEAP_ARRAY(char,
-                                                     strlen(v) + 1 +
-                                                     sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
-                                                     mtInternal);
-    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
+    size_t pathsize = strlen(v) + 1 + sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1;
+    char *ld_library_path = NEW_C_HEAP_ARRAY(char, pathsize, mtInternal);
+    os::snprintf_checked(ld_library_path, pathsize, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
     Arguments::set_library_path(ld_library_path);
     FREE_C_HEAP_ARRAY(char, ld_library_path);
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -447,7 +447,7 @@ void os::init_system_properties_values() {
 #define SYS_EXT_DIR     "/usr/java/packages"
 #define EXTENSIONS_DIR  "/lib/ext"
 
-  // Buffer that fits several sprintfs.
+  // Buffer that fits several snprintfs.
   // Note that the space for the colon and the trailing null are provided
   // by the nulls included by the sizeof operator.
   const size_t bufsize =
@@ -510,7 +510,7 @@ void os::init_system_properties_values() {
   }
 
   // Extensions directories.
-  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
+  os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
   FREE_C_HEAP_ARRAY(char, buf);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -305,8 +305,9 @@ void os::init_system_properties_values() {
     char path[MAX_PATH];
     char buf[2 * MAX_PATH + 2 * sizeof(EXT_DIR) + sizeof(PACKAGE_DIR) + 1];
     GetWindowsDirectory(path, MAX_PATH);
-    sprintf(buf, "%s%s;%s%s%s", Arguments::get_java_home(), EXT_DIR,
-            path, PACKAGE_DIR, EXT_DIR);
+    os::snprintf_checked(buf, sizeof(buf), "%s%s;%s%s%s",
+                         Arguments::get_java_home(), EXT_DIR,
+                         path, PACKAGE_DIR, EXT_DIR);
     Arguments::set_ext_dirs(buf);
   }
   #undef EXT_DIR

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1304,7 +1304,7 @@ bool InstructForm::check_branch_variant(ArchDesc &AD, InstructForm *short_branch
 void InstructForm::rep_var_format(FILE *fp, const char *rep_var) {
   // Handle special constant table variables.
   if (strcmp(rep_var, "constanttablebase") == 0) {
-    fprintf(fp, "char reg[128];  ra->dump_register(in(mach_constant_base_node_input()), reg);\n");
+    fprintf(fp, "char reg[128];  ra->dump_register(in(mach_constant_base_node_input()), reg, sizeof(reg));\n");
     fprintf(fp, "    st->print(\"%%s\", reg);\n");
     return;
   }
@@ -2503,7 +2503,7 @@ void  OperandForm::int_format(FILE *fp, FormDict &globals, uint index) {
                    strcmp(ideal_type(globalAD->globalNames()), "RegFlags") == 0)) {
     // !!!!! !!!!!
     fprintf(fp,"  { char reg_str[128];\n");
-    fprintf(fp,"    ra->dump_register(node,reg_str);\n");
+    fprintf(fp,"    ra->dump_register(node,reg_str, sizeof(reg_str));\n");
     fprintf(fp,"    st->print(\"%cs\",reg_str);\n",'%');
     fprintf(fp,"  }\n");
   } else if (_matrule && (dtype = _matrule->is_base_constant(globals)) != Form::none) {
@@ -2511,7 +2511,7 @@ void  OperandForm::int_format(FILE *fp, FormDict &globals, uint index) {
   } else if (ideal_to_sReg_type(_ident) != Form::none) {
     // Special format for Stack Slot Register
     fprintf(fp,"  { char reg_str[128];\n");
-    fprintf(fp,"    ra->dump_register(node,reg_str);\n");
+    fprintf(fp,"    ra->dump_register(node,reg_str, sizeof(reg_str));\n");
     fprintf(fp,"    st->print(\"%cs\",reg_str);\n",'%');
     fprintf(fp,"  }\n");
   } else {
@@ -2532,7 +2532,7 @@ void  OperandForm::ext_format(FILE *fp, FormDict &globals, uint index) {
     fprintf(fp,"  { char reg_str[128];\n");
     fprintf(fp,"    ra->dump_register(node->in(idx");
     if ( index != 0 ) fprintf(fp,              "+%d",index);
-    fprintf(fp,                                      "),reg_str);\n");
+    fprintf(fp,                                      "),reg_str,sizeof(reg_str));\n");
     fprintf(fp,"    st->print(\"%cs\",reg_str);\n",'%');
     fprintf(fp,"  }\n");
   } else if (_matrule && (dtype = _matrule->is_base_constant(globals)) != Form::none) {
@@ -2542,7 +2542,7 @@ void  OperandForm::ext_format(FILE *fp, FormDict &globals, uint index) {
     fprintf(fp,"  { char reg_str[128];\n");
     fprintf(fp,"    ra->dump_register(node->in(idx");
     if ( index != 0 ) fprintf(fp,                  "+%d",index);
-    fprintf(fp,                                       "),reg_str);\n");
+    fprintf(fp,                                       "),reg_str,sizeof(reg_str));\n");
     fprintf(fp,"    st->print(\"%cs\",reg_str);\n",'%');
     fprintf(fp,"  }\n");
   } else {

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -358,7 +358,7 @@ static void format_helper( PhaseRegAlloc *regalloc, outputStream* st, Node *n, c
   if (regalloc->node_regs_max_index() > 0 &&
       OptoReg::is_valid(regalloc->get_reg_first(n))) { // Check for undefined
     char buf[50];
-    regalloc->dump_register(n,buf);
+    regalloc->dump_register(n,buf,sizeof(buf));
     st->print(" %s%d]=%s",msg,i,buf);
   } else {                      // No register, but might be constant
     const Type *t = n->bottom_type();

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -2144,44 +2144,42 @@ void PhaseChaitin::dump_simplified() const {
   tty->cr();
 }
 
-static char *print_reg( OptoReg::Name reg, const PhaseChaitin *pc, char *buf ) {
+static char *print_reg(OptoReg::Name reg, const PhaseChaitin* pc, char* buf, size_t buf_size) {
   if ((int)reg < 0)
-    sprintf(buf, "<OptoReg::%d>", (int)reg);
+    os::snprintf_checked(buf, buf_size, "<OptoReg::%d>", (int)reg);
   else if (OptoReg::is_reg(reg))
     strcpy(buf, Matcher::regName[reg]);
   else
-    sprintf(buf,"%s + #%d",OptoReg::regname(OptoReg::c_frame_pointer),
+    os::snprintf_checked(buf, buf_size, "%s + #%d",OptoReg::regname(OptoReg::c_frame_pointer),
             pc->reg2offset(reg));
   return buf+strlen(buf);
 }
 
 // Dump a register name into a buffer.  Be intelligent if we get called
 // before allocation is complete.
-char *PhaseChaitin::dump_register( const Node *n, char *buf  ) const {
-  if( this == NULL ) {          // Not got anything?
-    sprintf(buf,"N%d",n->_idx); // Then use Node index
-  } else if( _node_regs ) {
+char *PhaseChaitin::dump_register(const Node* n, char* buf, size_t buf_size) const {
+  if( _node_regs ) {
     // Post allocation, use direct mappings, no LRG info available
-    print_reg( get_reg_first(n), this, buf );
+    print_reg( get_reg_first(n), this, buf, buf_size);
   } else {
     uint lidx = _lrg_map.find_const(n); // Grab LRG number
     if( !_ifg ) {
-      sprintf(buf,"L%d",lidx);  // No register binding yet
+      os::snprintf_checked(buf, buf_size, "L%d",lidx);  // No register binding yet
     } else if( !lidx ) {        // Special, not allocated value
       strcpy(buf,"Special");
     } else {
       if (lrgs(lidx)._is_vector) {
         if (lrgs(lidx).mask().is_bound_set(lrgs(lidx).num_regs()))
-          print_reg( lrgs(lidx).reg(), this, buf ); // a bound machine register
+          print_reg( lrgs(lidx).reg(), this, buf, buf_size); // a bound machine register
         else
-          sprintf(buf,"L%d",lidx); // No register binding yet
+          os::snprintf_checked(buf, buf_size, "L%d",lidx); // No register binding yet
       } else if( (lrgs(lidx).num_regs() == 1)
                  ? lrgs(lidx).mask().is_bound1()
                  : lrgs(lidx).mask().is_bound_pair() ) {
         // Hah!  We have a bound machine register
-        print_reg( lrgs(lidx).reg(), this, buf );
+        print_reg( lrgs(lidx).reg(), this, buf, buf_size);
       } else {
-        sprintf(buf,"L%d",lidx); // No register binding yet
+        os::snprintf_checked(buf, buf_size, "L%d",lidx); // No register binding yet
       }
     }
   }

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -792,7 +792,7 @@ private:
 
 public:
   void dump_frame() const;
-  char *dump_register( const Node *n, char *buf  ) const;
+  char *dump_register(const Node* n, char* buf, size_t buf_size) const;
 private:
   static void print_chaitin_statistics();
 #endif

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -534,7 +534,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
       if (index >= 10) {
         print_prop(short_name, "PA");
       } else {
-        sprintf(buffer, "P%d", index);
+        os::snprintf_checked(buffer, sizeof(buffer), "P%d", index);
         print_prop(short_name, buffer);
       }
     } else if (strcmp(node->Name(), "IfTrue") == 0) {
@@ -550,7 +550,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
         // max. 2 chars allowed
         if (value >= -9 && value <= 99) {
-          sprintf(buffer, "%d", value);
+          os::snprintf_checked(buffer, sizeof(buffer), "%d", value);
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "I");
@@ -564,7 +564,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
         // max. 2 chars allowed
         if (value >= -9 && value <= 99) {
-          sprintf(buffer, JLONG_FORMAT, value);
+          os::snprintf_checked(buffer, sizeof(buffer), JLONG_FORMAT, value);
           print_prop(short_name, buffer);
         } else {
           print_prop(short_name, "L");
@@ -631,7 +631,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
     if (_chaitin && _chaitin != (PhaseChaitin *)((intptr_t)0xdeadbeef)) {
       buffer[0] = 0;
-      _chaitin->dump_register(node, buffer);
+      _chaitin->dump_register(node, buffer, sizeof(buffer));
       print_prop("reg", buffer);
       uint lrg_id = 0;
       if (node->_idx < _chaitin->_lrg_map.size()) {

--- a/src/hotspot/share/opto/regalloc.hpp
+++ b/src/hotspot/share/opto/regalloc.hpp
@@ -127,7 +127,7 @@ public:
   static int _max_framesize;
 
   virtual void dump_frame() const = 0;
-  virtual char *dump_register( const Node *n, char *buf  ) const = 0;
+  virtual char *dump_register( const Node *n, char *buf, size_t buf_size) const = 0;
   static void print_statistics();
 #endif
 };

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1617,17 +1617,17 @@ bool TypeInt::is_finite() const {
 //------------------------------dump2------------------------------------------
 // Dump TypeInt
 #ifndef PRODUCT
-static const char* intname(char* buf, jint n) {
+static const char* intname(char* buf, size_t buf_size, jint n) {
   if (n == min_jint)
     return "min";
   else if (n < min_jint + 10000)
-    sprintf(buf, "min+" INT32_FORMAT, n - min_jint);
+    os::snprintf_checked(buf, buf_size, "min+" INT32_FORMAT, n - min_jint);
   else if (n == max_jint)
     return "max";
   else if (n > max_jint - 10000)
-    sprintf(buf, "max-" INT32_FORMAT, max_jint - n);
+    os::snprintf_checked(buf, buf_size, "max-" INT32_FORMAT, max_jint - n);
   else
-    sprintf(buf, INT32_FORMAT, n);
+    os::snprintf_checked(buf, buf_size, INT32_FORMAT, n);
   return buf;
 }
 
@@ -1636,7 +1636,7 @@ void TypeInt::dump2( Dict &d, uint depth, outputStream *st ) const {
   if (_lo == min_jint && _hi == max_jint)
     st->print("int");
   else if (is_con())
-    st->print("int:%s", intname(buf, get_con()));
+    st->print("int:%s", intname(buf, sizeof(buf), get_con()));
   else if (_lo == BOOL->_lo && _hi == BOOL->_hi)
     st->print("bool");
   else if (_lo == BYTE->_lo && _hi == BYTE->_hi)
@@ -1646,11 +1646,11 @@ void TypeInt::dump2( Dict &d, uint depth, outputStream *st ) const {
   else if (_lo == SHORT->_lo && _hi == SHORT->_hi)
     st->print("short");
   else if (_hi == max_jint)
-    st->print("int:>=%s", intname(buf, _lo));
+    st->print("int:>=%s", intname(buf, sizeof(buf), _lo));
   else if (_lo == min_jint)
-    st->print("int:<=%s", intname(buf, _hi));
+    st->print("int:<=%s", intname(buf, sizeof(buf), _hi));
   else
-    st->print("int:%s..%s", intname(buf, _lo), intname(buf2, _hi));
+    st->print("int:%s..%s", intname(buf, sizeof(buf), _lo), intname(buf2, sizeof(buf2), _hi));
 
   if (_widen != 0 && this != TypeInt::INT)
     st->print(":%.*s", _widen, "wwww");
@@ -1879,37 +1879,37 @@ bool TypeLong::is_finite() const {
 //------------------------------dump2------------------------------------------
 // Dump TypeLong
 #ifndef PRODUCT
-static const char* longnamenear(jlong x, const char* xname, char* buf, jlong n) {
+static const char* longnamenear(jlong x, const char* xname, char* buf, size_t buf_size, jlong n) {
   if (n > x) {
     if (n >= x + 10000)  return NULL;
-    sprintf(buf, "%s+" JLONG_FORMAT, xname, n - x);
+    os::snprintf_checked(buf, buf_size, "%s+" JLONG_FORMAT, xname, n - x);
   } else if (n < x) {
     if (n <= x - 10000)  return NULL;
-    sprintf(buf, "%s-" JLONG_FORMAT, xname, x - n);
+    os::snprintf_checked(buf, buf_size, "%s-" JLONG_FORMAT, xname, x - n);
   } else {
     return xname;
   }
   return buf;
 }
 
-static const char* longname(char* buf, jlong n) {
+static const char* longname(char* buf, size_t buf_size, jlong n) {
   const char* str;
   if (n == min_jlong)
     return "min";
   else if (n < min_jlong + 10000)
-    sprintf(buf, "min+" JLONG_FORMAT, n - min_jlong);
+    os::snprintf_checked(buf, buf_size, "min+" JLONG_FORMAT, n - min_jlong);
   else if (n == max_jlong)
     return "max";
   else if (n > max_jlong - 10000)
-    sprintf(buf, "max-" JLONG_FORMAT, max_jlong - n);
-  else if ((str = longnamenear(max_juint, "maxuint", buf, n)) != NULL)
+    os::snprintf_checked(buf, buf_size, "max-" JLONG_FORMAT, max_jlong - n);
+  else if ((str = longnamenear(max_juint, "maxuint", buf, buf_size, n)) != NULL)
     return str;
-  else if ((str = longnamenear(max_jint, "maxint", buf, n)) != NULL)
+  else if ((str = longnamenear(max_jint, "maxint", buf, buf_size, n)) != NULL)
     return str;
-  else if ((str = longnamenear(min_jint, "minint", buf, n)) != NULL)
+  else if ((str = longnamenear(min_jint, "minint", buf, buf_size, n)) != NULL)
     return str;
   else
-    sprintf(buf, JLONG_FORMAT, n);
+    os::snprintf_checked(buf, buf_size, JLONG_FORMAT, n);
   return buf;
 }
 
@@ -1918,13 +1918,13 @@ void TypeLong::dump2( Dict &d, uint depth, outputStream *st ) const {
   if (_lo == min_jlong && _hi == max_jlong)
     st->print("long");
   else if (is_con())
-    st->print("long:%s", longname(buf, get_con()));
+    st->print("long:%s", longname(buf, sizeof(buf), get_con()));
   else if (_hi == max_jlong)
-    st->print("long:>=%s", longname(buf, _lo));
+    st->print("long:>=%s", longname(buf, sizeof(buf), _lo));
   else if (_lo == min_jlong)
-    st->print("long:<=%s", longname(buf, _hi));
+    st->print("long:<=%s", longname(buf, sizeof(buf), _hi));
   else
-    st->print("long:%s..%s", longname(buf, _lo), longname(buf2, _hi));
+    st->print("long:%s..%s", longname(buf, sizeof(buf), _lo), longname(buf2,sizeof(buf2),  _hi));
 
   if (_widen != 0 && this != TypeLong::LONG)
     st->print(":%.*s", _widen, "wwww");

--- a/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/libAddModuleExportsAndOpensTest.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/AddModuleExportsAndOpens/libAddModuleExportsAndOpensTest.c
@@ -238,7 +238,7 @@ jint check_add_module_exports(JNIEnv *env,
     printf("Check #C0:\n");
     exported = is_exported_to(env, baseModule, pkg, thisModule, open);
     if (exported != JNI_FALSE) {
-        sprintf(strbuf, "Check #C0: unexpected export of %s from base to this", pkg);
+        snprintf(strbuf, sizeof(strbuf), "Check #C0: unexpected export of %s from base to this", pkg);
         throw_exc(env, strbuf);
         return FAILED;
     }
@@ -248,7 +248,7 @@ jint check_add_module_exports(JNIEnv *env,
     err = add_module_exports(baseModule, pkg, thisModule, open);
     if (err != JVMTI_ERROR_NONE) {
         printf("#C1: jvmtiError from %s: %d\n", jvmti_fn, err);
-        sprintf(strbuf, "Check #C1: error in add export of %s from base to this", pkg);
+        snprintf(strbuf, sizeof(strbuf), "Check #C1: error in add export of %s from base to this", pkg);
         throw_exc(env, strbuf);
         return FAILED;
     }
@@ -257,7 +257,7 @@ jint check_add_module_exports(JNIEnv *env,
     printf("Check #C2:\n");
     exported = is_exported_to(env, baseModule, pkg, thisModule, open);
     if (exported == JNI_FALSE) {
-        sprintf(strbuf, "Check #C2: failed to export %s from base to this", pkg);
+        snprintf(strbuf, sizeof(strbuf), "Check #C2: failed to export %s from base to this", pkg);
         throw_exc(env, strbuf);
         return FAILED;
     }
@@ -266,7 +266,7 @@ jint check_add_module_exports(JNIEnv *env,
     printf("Check #C3:\n");
     exported = is_exported(env, baseModule, pkg, open);
     if (exported != JNI_FALSE) {
-        sprintf(strbuf, "Check #C3: unexpected export of %s from base to all modules", pkg);
+        snprintf(strbuf, sizeof(strbuf), "Check #C3: unexpected export of %s from base to all modules", pkg);
         throw_exc(env, strbuf);
         return FAILED;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon001/crrawmon001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon001/crrawmon001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon001/drrawmon001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon001/drrawmon001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti_env->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter001/rawmonenter001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter001/rawmonenter001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",
@@ -142,7 +142,7 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorEnter_rawmonenter001_check(JNIEn
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit001/rawmonexit001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit001/rawmonexit001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",
@@ -155,7 +155,7 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorExit_rawmonexit001_check(JNIEnv 
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy001/rawmnntfy001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy001/rawmnntfy001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",
@@ -168,7 +168,7 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorNotify_rawmnntfy001_check(JNIEnv
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall001/rawmnntfyall001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall001/rawmnntfyall001.cpp
@@ -51,7 +51,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",
@@ -168,7 +168,7 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorNotifyAll_rawmnntfyall001_check(
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait001/rawmnwait001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait001/rawmnwait001.cpp
@@ -52,7 +52,7 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",
@@ -169,7 +169,7 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorWait_rawmnwait001_check(JNIEnv *
     }
 
     for (i = 0; i < RAW_MONITORS_NUMBER; i++) {
-        sprintf(name, "RawMonitor-%d", i);
+        snprintf(name, sizeof(name), "RawMonitor-%d", i);
         err = jvmti->CreateRawMonitor(name, &monitors[i]);
         if (err != JVMTI_ERROR_NONE) {
             printf("(CreateRawMonitor#%d) unexpected error: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/bi04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/bi04t002.cpp
@@ -50,10 +50,10 @@ int readNewBytecode(jvmtiEnv* jvmti) {
     jint read_bytes;
 
     if (pathToByteCode)
-        sprintf(filename,"%s/%s/%s.class",
+        snprintf(filename, sizeof(filename), "%s/%s/%s.class",
                     pathToByteCode, "newclass02", TESTED_CLASS_NAME);
     else
-        sprintf(filename,"%s/%s.class",
+        snprintf(filename, sizeof(filename), "%s/%s.class",
                     "newclass02", TESTED_CLASS_NAME);
 
     NSK_DISPLAY1("Reading new bytecode for java.lang.Object\n\tfile name: %s\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/hs201t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/hs201t001.cpp
@@ -392,7 +392,7 @@ int readNewBytecode(jvmtiEnv* jvmti, int testcase) {
         return NSK_FALSE;
     }
 
-    sprintf(filename,"%s/%s%02d/%s.class",
+    snprintf(filename, sizeof(filename), "%s/%s%02d/%s.class",
                 pathToByteCode, "newclass", testcase, EXPECTED_CLASS_NAME);
 
     NSK_DISPLAY1("\treading new bytecode for the tested class\n\tfile name: %s\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/hs201t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/hs201t002.cpp
@@ -385,7 +385,7 @@ int readNewBytecode(jvmtiEnv* jvmti, jint *newClassSize, unsigned char* *newClas
         return NSK_FALSE;
     }
 
-    sprintf(filename,"%s/%s/%s.class",
+    snprintf(filename, sizeof(filename), "%s/%s/%s.class",
                 pathToByteCode, "newclass", EXPECTED_CLASS_NAME);
 
     NSK_DISPLAY1("\treading new bytecode for the tested class\n\tfile name: %s\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001/getallstktr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001/getallstktr001.cpp
@@ -117,7 +117,7 @@ Java_nsk_jvmti_unit_GetAllStackTraces_getallstktr001_CreateRawMonitor(
     jvmtiError ret;
     char sz[128];
 
-    sprintf(sz, "Raw-monitor");
+    snprintf(sz, sizeof(sz), "Raw-monitor");
     ret = jvmti->CreateRawMonitor(sz, &jraw_monitor);
 
     if (ret != JVMTI_ERROR_NONE) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest/JvmtiTest.cpp
@@ -185,7 +185,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_CreateRawMonitor(JNIEnv * env, jclass c
     jvmtiError ret;
     char sz[128];
 
-    sprintf(sz, "Rawmonitor-%d",i);
+    snprintf(sz, sizeof(sz), "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
     ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest/JvmtiTest.cpp
@@ -116,7 +116,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_CreateRawMonitor(JNIEnv * env, jclass k
     jvmtiError ret;
     char sz[128];
 
-    sprintf(sz, "Rawmonitor-%d",i);
+    snprintf(sz, sizeof(sz), "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
     ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest/JvmtiTest.cpp
@@ -154,7 +154,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_CreateRawMonitor(JNI
     jvmtiError ret;
     char sz[128];
 
-    sprintf(sz, "Rawmonitor-%d",i);
+    snprintf(sz, sizeof(sz), "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
     ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
@@ -1,4 +1,5 @@
 /*
+s
  * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -291,7 +292,7 @@ Java_nsk_jvmti_unit_functions_rawmonitor_CreateRawMonitor(JNIEnv * env, jclass k
     jvmtiError ret;
     char sz[128];
 
-    sprintf(sz, "Rawmonitor-%d",i);
+    snprintf(sz, sizeof(sz), "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
     ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
@@ -1150,7 +1150,7 @@ static void getVerdict(JNIEnv *jni_env, const char *evnt) {
     char error_msg[80];
 
     if (vm_death_occured == TRUE) {
-        sprintf(error_msg, "JVMTIagent: getVerdict: %s event occured after VMDeath",
+        snprintf(error_msg, sizeof(error_msg), "JVMTIagent: getVerdict: %s event occured after VMDeath",
             evnt);
 
         if (jni_env==NULL) { /* some event callbacks have no pointer to jni */

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
@@ -237,7 +237,7 @@ int nsk_jvmti_aod_redefineClass(
     {
         char file [1024];
 
-        sprintf(file,"%s/%s.class",
+        snprintf(file, sizeof(file), "%s/%s.class",
                 nsk_aod_getOptionValue(options, PATH_TO_NEW_BYTE_CODE_OPTION),
                 fileName);
         NSK_DISPLAY1("File with new bytecode: '%s'\n", file);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -476,7 +476,7 @@ int nsk_jvmti_redefineClass(jvmtiEnv * jvmti,
     {
         char file [1024];
         //= "DEFAULT";
-        sprintf(file,"%s/%s.class",
+        snprintf(file, sizeof(file), "%s/%s.class",
                 nsk_jvmti_findOptionValue(NSK_JVMTI_OPT_PATH_TO_NEW_BYTE_CODE),
                 fileName);
         nsk_printf("# info :: File = %s \n",file);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.cpp
@@ -279,7 +279,7 @@ void nsk_printHexBytes(const char indent[], int columns,
             char ch = (char)bytes[i + j];
 
             if (!(isascii(ch) && isprint(ch))) ch = '.';
-            sprintf(buf, " %02X", b);
+            snprintf(buf, sizeof(buf), " %02X", b);
             strcat(hex, buf);
             ascii[j] = ch;
         }


### PR DESCRIPTION
Backport of [JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635) as applied to JDK-17, in order to get building on macos-13/Xcode 14/clang 14.

Mostly clean but for these files:

```
src/hotspot/os/aix/os_aix.cpp
src/hotspot/os/linux/os_linux.cpp
src/hotspot/share/opto/cfgnode.cpp
src/hotspot/share/opto/chaitin.cpp
src/hotspot/share/opto/chaitin.hpp
src/hotspot/share/opto/type.cpp
```

In `src/hotspot/share/opto/type.cpp` we restored JDK-17's `nullptr` back to JDK-11's `NULL`.

After this PR the macos-builds are expected to continue failing with error messages similar to:

A) The `-Wdeprecated-non-prototype` flag. This seems JDK-11 specific as these files were later reorganized in next JDK versions. We may need a JDK-11 specific issue for this compilation failure.

```
Compiling main.c (for pack200)
/Users/runner/work/jdk11u-dev/jdk11u-dev/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c:922:48: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
Creating support/modules_cmds/jdk.pack/unpack200 from 7 file(s)
    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
Compiling bands.cpp (for unpack200)
```

B) Some missing `sprintf` in files in the `src/jdk.pack` directory, which is JDK-11 specific as Pack200 was removed in later versions.

```
/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
/Users/runner/work/jdk11u-dev/jdk11u-dev/src/jdk.pack/share/native/common-unpack/bands.cpp:165:25: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    if (le_back != 0) { sprintf(bp, "/back%d", le_back); bp += strlen(bp); }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2842 must be integrated first

### Issue
 * [JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635): Hotspot update for deprecated sprintf in Xcode 14 (**Enhancement** - P4)


### Reviewers
 * [George Adams](https://openjdk.org/census#gdams) (@gdams - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2844/head:pull/2844` \
`$ git checkout pull/2844`

Update a local copy of the PR: \
`$ git checkout pull/2844` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2844`

View PR using the GUI difftool: \
`$ git pr show -t 2844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2844.diff">https://git.openjdk.org/jdk11u-dev/pull/2844.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2844#issuecomment-2217964802)