### PR TITLE
8335918: update for deprecated sprintf for jvmti

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
@@ -57,7 +57,7 @@ void JNICALL ThreadEnd(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
     }
     if (inf.name != NULL && strstr(inf.name, prefix) == inf.name) {
         eventsCount++;
-        sprintf(name, "%s%d", prefix, eventsCount);
+        snprintf(name, sizeof(name), "%s%d", prefix, eventsCount);
         if (inf.name == NULL || strcmp(name, inf.name) != 0) {
             printf("(#%d) wrong thread name: \"%s\"",
                    eventsCount, inf.name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
@@ -56,7 +56,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
         printf(">>> %s\n", inf.name);
     }
     if (inf.name != NULL && strstr(inf.name, prefix) == inf.name) {
-        sprintf(name, "%s%d", prefix, eventsCount);
+        snprintf(name, sizeof(name), "%s%d", prefix, eventsCount);
         if (strcmp(name, inf.name) != 0) {
             printf("(#%d) wrong thread name: \"%s\"",
                    eventsCount, inf.name);


### PR DESCRIPTION
Clean backport of [JDK-8335918](https://bugs.openjdk.org/browse/JDK-8335918) from JDK-17 to replace deprecated `sprintf` with `snprintf`.

Despite of this backport the macos build will continue failing until other backports are in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8335918](https://bugs.openjdk.org/browse/JDK-8335918) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2844 must be integrated first

### Issue
 * [JDK-8335918](https://bugs.openjdk.org/browse/JDK-8335918): update for deprecated sprintf for jvmti (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2846/head:pull/2846` \
`$ git checkout pull/2846`

Update a local copy of the PR: \
`$ git checkout pull/2846` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2846`

View PR using the GUI difftool: \
`$ git pr show -t 2846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2846.diff">https://git.openjdk.org/jdk11u-dev/pull/2846.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2846#issuecomment-2221373295)