### PR TITLE
8320602: Lock contention in SchemaDVFactory.getInstance()

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
@@ -53,7 +53,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance() throws DVFactoryException {
+    public static final SchemaDVFactory getInstance() throws DVFactoryException {
         return getInstance(DEFAULT_FACTORY_CLASS);
     } //getInstance():  SchemaDVFactory
 
@@ -66,7 +66,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
+    public static final SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
 
         try {
             // if the class name is not specified, use the default one
@@ -78,7 +78,7 @@ public abstract class SchemaDVFactory {
     }
 
     // can't create a new object of this class
-    protected SchemaDVFactory(){}
+    protected SchemaDVFactory() {}
 
     /**
      * Get a built-in simple type of the given name


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320602](https://bugs.openjdk.org/browse/JDK-8320602) needs maintainer approval

### Issue
 * [JDK-8320602](https://bugs.openjdk.org/browse/JDK-8320602): Lock contention in SchemaDVFactory.getInstance() (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2851/head:pull/2851` \
`$ git checkout pull/2851`

Update a local copy of the PR: \
`$ git checkout pull/2851` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2851`

View PR using the GUI difftool: \
`$ git pr show -t 2851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2851.diff">https://git.openjdk.org/jdk11u-dev/pull/2851.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2851#issuecomment-2222997549)