### PR TITLE
8316211: Open source several manual applet tests

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+
+/*
+ * @test 4033151
+ * @summary Test that frame default size is minimum possible size
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DefaultSizeTest
+ */
+
+public class DefaultSizeTest {
+
+    private static final String INSTRUCTIONS = "An empty frame is created.\n" +
+            "It should be located to the right of this window\n" +
+            "and should be the minimum size allowed by the window manager.\n" +
+            "For any WM, the frame should be very small.\n" +
+            "If the frame is not large, click Pass or Fail otherwise.";
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("DefaultSizeTest Instructions Frame")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(45)
+                .build();
+
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame("DefaultSize");
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame
+                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.awt.Shape;
+
+/*
+ * @test
+ * @bug 4116029
+ * @summary drawString does not honor clipping regions for lightweight components
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual LightweightCliprect
+ */
+
+public class LightweightCliprect {
+
+    private static final String INSTRUCTIONS = "If some text is drawn outside the red rectangle, press \"Fail\" button.\n" +
+            "Otherwise, press \"Pass\" button.";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("LightweightCliprect Instructions Frame")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(45)
+                .build();
+
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame("DefaultSize");
+
+            Container panel = new MyContainer();
+            MyComponent c = new MyComponent();
+            panel.add(c);
+
+            frame.add(panel);
+            frame.setSize(400, 300);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame
+                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class MyComponent extends Component {
+
+    public void paint(Graphics g) {
+        Color c = g.getColor();
+        g.setColor(Color.red);
+        g.fillRect(20, 20, 400, 200);
+        Shape clip = g.getClip();
+        g.setClip(20, 20, 400, 200);
+        //draw the current java version in the component
+        g.setColor(Color.black);
+        String version = System.getProperty("java.version");
+        String vendor = System.getProperty("java.vendor");
+        int y = 10;
+        for(int i = 0; i < 30; i++) {
+            g.drawString("Lightweight: Java version: " + version +
+                         ", Vendor: " + vendor, 10, y += 20);
+        }
+        g.setColor(c);
+        g.setClip(clip);
+        super.paint(g);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(300, 300);
+    }
+}
+
+class MyContainer extends Container {
+    public MyContainer() {
+        super();
+        setLayout(new FlowLayout());
+    }
+
+    public void paint(Graphics g) {
+        Rectangle bounds = new Rectangle(getSize());
+        g.setColor(Color.cyan);
+        g.drawRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1);
+        super.paint(g);
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/FunctionKeyTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/FunctionKeyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Event;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.event.KeyEvent;
+
+/*
+ * @test
+ * @bug 4011219
+ * @summary Test for function key press/release received by Java client.
+ * @key headful
+ */
+
+public class FunctionKeyTest {
+    private static FunctionKeyTester frame;
+    private static Robot robot;
+
+    static volatile boolean keyPressReceived;
+    static volatile boolean keyReleaseReceived;
+
+    static final StringBuilder failures = new StringBuilder();
+
+    private static void testKey(int keyCode, String keyText) {
+        keyPressReceived = false;
+        keyReleaseReceived = false;
+
+        robot.keyPress(keyCode);
+
+        if (!keyPressReceived) {
+            failures.append(keyText).append(" key press is not received\n");
+        }
+
+        robot.keyRelease(keyCode);
+
+        if (!keyReleaseReceived) {
+            failures.append(keyText).append(" key release is not received\n");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(150);
+
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new FunctionKeyTester();
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            testKey(KeyEvent.VK_F11, "F11");
+            testKey(KeyEvent.VK_F12, "F12");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+
+        if (failures.length() == 0) {
+            System.out.println("Passed");
+        } else {
+            throw new RuntimeException(failures.toString());
+        }
+    }
+}
+
+class FunctionKeyTester extends Frame {
+    Label l = new Label ("NULL");
+    Button b = new Button();
+    TextArea log = new TextArea();
+
+    FunctionKeyTester() {
+        super("Function Key Test");
+        this.setLayout(new BorderLayout());
+        this.add(BorderLayout.NORTH, l);
+        this.add(BorderLayout.SOUTH, b);
+        this.add(BorderLayout.CENTER, log);
+        log.setFocusable(false);
+        log.setEditable(false);
+        l.setBackground(Color.red);
+        setSize(200, 200);
+    }
+
+    public boolean handleEvent(Event e) {
+        String message = "e.id=" + e.id + "\n";
+        System.out.print(message);
+        log.append(message);
+
+        switch (e.id) {
+            case 403:
+                FunctionKeyTest.keyPressReceived = true;
+                break;
+            case 404:
+                FunctionKeyTest.keyReleaseReceived = true;
+                break;
+        }
+
+        return super.handleEvent(e);
+    }
+
+    public boolean keyDown(Event e, int key) {
+        l.setText("e.key=" + Integer.valueOf(e.key).toString());
+        return false;
+    }
+}

--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.FlowLayout;
+import java.awt.Window;
+import java.awt.event.ItemEvent;
+import java.awt.event.WindowEvent;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+/*
+ * @test
+ * @summary test for defaultCloseOperation property for Swing JFrame and JDialog
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DefaultCloseOperation
+ */
+
+public class DefaultCloseOperation extends JPanel {
+
+    private static final String INSTRUCTIONS = "Do the following steps:\n\n" +
+         "-  Click the \"Open Frame\" button (a TestFrame will appear)\n" +
+         "-  On the TestFrame, select \"Close\" from the system menu (the window should go away)\n" +
+         "-  Select \"Do Nothing\" from the \"JFrame Default Close Operation\" ComboBox\n" +
+         "-  Click the \"Open Frame\" button\n" +
+         "-  On the TestFrame, select \"Close\" from the system menu (the window should remain open)\n" +
+         "-  Select \"Dispose\" from the \"JFrame Default Close Operation\" ComboBox\n" +
+         "-  On the TestFrame, select \"Close\" from the system menu (the window should go away)\n\n\n" +
+         "-  Click the \"Open Frame\" button\n" +
+         "-  Click the \"Open Dialog\" button (a TestDialog will appear)\n" +
+         "-  On the TestDialog, select \"Close\" from the system menu (the window should go away)\n" +
+         "-  Select \"Do Nothing\" from the \"JDialog Default Close Operation\" ComboBox\n" +
+         "-  Click the \"Open Dialog\" button\n" +
+         "-  On the TestDialog, select \"Close\" from the system menu (the window should remain open)\n" +
+         "-  Select \"Dispose\" from the \"JDialog Default Close Operation\" ComboBox\n" +
+         "-  On the TestDialog, select \"Close\" from the system menu (the window should go away)";
+
+    JComboBox<String> frameCloseOp;
+
+    CloseOpDialog testDialog;
+    JComboBox<String> dialogCloseOp;
+
+    public static void main(String[] args) throws Exception {
+
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("DefaultCloseOperation Manual Test")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(20)
+                .columns(70)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            DefaultCloseOperation dco = new DefaultCloseOperation();
+            dco.init();
+
+            JFrame frame = new JFrame("DefaultCloseOperation");
+            frame.add(dco);
+            frame.setSize(500,200);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame
+                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+
+    public void init() {
+        setLayout(new FlowLayout());
+
+        CloseOpFrame testFrame = new CloseOpFrame();
+        testFrame.setLocationRelativeTo(null);
+        PassFailJFrame.addTestWindow(testFrame);
+
+        add(new JLabel("JFrame Default Close Operation:"));
+        frameCloseOp = new JComboBox<>();
+        frameCloseOp.addItem("Hide");
+        frameCloseOp.addItem("Do Nothing");
+        frameCloseOp.addItem("Dispose");
+        frameCloseOp.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                String item = (String)e.getItem();
+                switch (item) {
+                    case "Do Nothing":
+                        testFrame
+                            .setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+                        break;
+                    case "Hide":
+                        testFrame
+                            .setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
+                        break;
+                    case "Dispose":
+                        testFrame
+                            .setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+                        break;
+                }
+            }
+        });
+        add(frameCloseOp);
+
+        JButton b = new JButton("Open Frame...");
+        b.addActionListener(e -> testFrame.setVisible(true));
+        add(b);
+
+        testDialog = new CloseOpDialog(testFrame);
+        testDialog.setLocationRelativeTo(null);
+        PassFailJFrame.addTestWindow(testDialog);
+
+        add(new JLabel("JDialog Default Close Operation:"));
+        dialogCloseOp = new JComboBox<>();
+        dialogCloseOp.addItem("Hide");
+        dialogCloseOp.addItem("Do Nothing");
+        dialogCloseOp.addItem("Dispose");
+        dialogCloseOp.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                String item = (String)e.getItem();
+                switch (item) {
+                    case "Do Nothing":
+                        testDialog
+                            .setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+                        break;
+                    case "Hide":
+                        testDialog
+                            .setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
+                        break;
+                    case "Dispose":
+                        testDialog
+                            .setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+                        break;
+                }
+            }
+        });
+        add(dialogCloseOp);
+
+        b = new JButton("Open Dialog...");
+        b.addActionListener(e -> testDialog.setVisible(true));
+        add(b);
+    }
+
+    public static void verifyCloseOperation(Window window, int op) {
+        switch (op) {
+            case WindowConstants.DO_NOTHING_ON_CLOSE:
+                if (!window.isVisible()) {
+                    PassFailJFrame
+                            .forceFail("defaultCloseOperation=DoNothing failed");
+                }
+                break;
+            case WindowConstants.HIDE_ON_CLOSE:
+                if (window.isVisible()) {
+                    PassFailJFrame
+                            .forceFail("defaultCloseOperation=Hide failed");
+                }
+                break;
+            case WindowConstants.DISPOSE_ON_CLOSE:
+                if (window.isVisible() || window.isDisplayable()) {
+                    PassFailJFrame
+                            .forceFail("defaultCloseOperation=Dispose failed");
+                }
+                break;
+        }
+    }
+}
+
+class CloseOpFrame extends JFrame {
+
+    public CloseOpFrame() {
+        super("DefaultCloseOperation Test");
+        getContentPane().add("Center", new JLabel("Test Frame"));
+        pack();
+    }
+
+    protected void processWindowEvent(WindowEvent e) {
+        super.processWindowEvent(e);
+
+        if (e.getID() == WindowEvent.WINDOW_CLOSING) {
+            DefaultCloseOperation
+                    .verifyCloseOperation(this, getDefaultCloseOperation());
+        }
+    }
+}
+
+class CloseOpDialog extends JDialog {
+
+    public CloseOpDialog(Frame owner) {
+        super(owner, "DefaultCloseOperation Test Dialog");
+        getContentPane().add("Center", new JLabel("Test Dialog"));
+        pack();
+    }
+
+    protected void processWindowEvent(WindowEvent e) {
+        super.processWindowEvent(e);
+
+        if (e.getID() == WindowEvent.WINDOW_CLOSING) {
+            DefaultCloseOperation
+                    .verifyCloseOperation(this, getDefaultCloseOperation());
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

text block modified as not supported.
lambda switch modified as not supported.
StringBuilder#isEmpty() modified as not supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316211](https://bugs.openjdk.org/browse/JDK-8316211) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316211](https://bugs.openjdk.org/browse/JDK-8316211): Open source several manual applet tests (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2852/head:pull/2852` \
`$ git checkout pull/2852`

Update a local copy of the PR: \
`$ git checkout pull/2852` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2852`

View PR using the GUI difftool: \
`$ git pr show -t 2852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2852.diff">https://git.openjdk.org/jdk11u-dev/pull/2852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2852#issuecomment-2224857150)