### PR TITLE
8336291: [11u] update for deprecated sprintf for jdk.pack

### DIFF
--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.c
@@ -103,29 +103,29 @@ void decodeDeviceID(UINT32 deviceID, int* card, int* device, int* subdevice,
 }
 
 
-void getDeviceString(char* buffer, int card, int device, int subdevice,
-                     int usePlugHw, int isMidi) {
+void getDeviceString(char* buffer, size_t bufferSize, int card, int device,
+                     int subdevice, int usePlugHw, int isMidi) {
     if (needEnumerateSubdevices(isMidi)) {
-        sprintf(buffer, "%s:%d,%d,%d",
+        snprintf(buffer, bufferSize, "%s:%d,%d,%d",
                         usePlugHw ? ALSA_PLUGHARDWARE : ALSA_HARDWARE,
                         card, device, subdevice);
     } else {
-        sprintf(buffer, "%s:%d,%d",
+        snprintf(buffer, bufferSize, "%s:%d,%d",
                         usePlugHw ? ALSA_PLUGHARDWARE : ALSA_HARDWARE,
                         card, device);
     }
 }
 
 
-void getDeviceStringFromDeviceID(char* buffer, UINT32 deviceID,
-                                 int usePlugHw, int isMidi) {
+void getDeviceStringFromDeviceID(char* buffer, size_t bufferSize,
+                                 UINT32 deviceID, int usePlugHw, int isMidi) {
     int card, device, subdevice;
 
     if (deviceID == ALSA_DEFAULT_DEVICE_ID) {
         strcpy(buffer, ALSA_DEFAULT_DEVICE_NAME);
     } else {
         decodeDeviceID(deviceID, &card, &device, &subdevice, isMidi);
-        getDeviceString(buffer, card, device, subdevice, usePlugHw, isMidi);
+        getDeviceString(buffer, bufferSize, card, device, subdevice, usePlugHw, isMidi);
     }
 }
 

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.h
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.h
@@ -73,8 +73,8 @@ UINT32 encodeDeviceID(int card, int device, int subdevice);
 void decodeDeviceID(UINT32 deviceID, int* card, int* device, int* subdevice,
                     int isMidi);
 
-void getDeviceStringFromDeviceID(char* buffer, UINT32 deviceID,
-                                 int usePlugHw, int isMidi);
+void getDeviceStringFromDeviceID(char* buffer, size_t bufferSize,
+                                 UINT32 deviceID, int usePlugHw, int isMidi);
 
 void getALSAVersion(char* buffer, int len);
 

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
@@ -98,7 +98,7 @@ static int iterateRawmidiDevices(snd_rawmidi_stream_t direction,
             // try to get card info
             card = snd_rawmidi_info_get_card(rawmidi_info);
             if (card >= 0) {
-                sprintf(devname, ALSA_HARDWARE_CARD, card);
+                snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, card);
                 if (snd_ctl_open(&handle, devname, SND_CTL_NONBLOCK) >= 0) {
                     if (snd_ctl_card_info(handle, card_info) >= 0) {
                         defcardinfo = card_info;
@@ -121,7 +121,7 @@ static int iterateRawmidiDevices(snd_rawmidi_stream_t direction,
     if (snd_card_next(&card) >= 0) {
         TRACE1("Found card %d\n", card);
         while (doContinue && (card >= 0)) {
-            sprintf(devname, ALSA_HARDWARE_CARD, card);
+            snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, card);
             TRACE1("Opening control for alsa rawmidi device \"%s\"...\n", devname);
             err = snd_ctl_open(&handle, devname, SND_CTL_NONBLOCK);
             if (err < 0) {
@@ -230,7 +230,7 @@ static int deviceInfoIterator(UINT32 deviceID, snd_rawmidi_info_t *rawmidi_info,
 
         buffer[0]=' '; buffer[1]='[';
         // buffer[300] is enough to store the actual device string w/o overrun
-        getDeviceStringFromDeviceID(&buffer[2], deviceID, usePlugHw, ALSA_RAWMIDI);
+        getDeviceStringFromDeviceID(&buffer[2], sizeof(buffer) - 2, deviceID, usePlugHw, ALSA_RAWMIDI);
         strncat(buffer, "]", sizeof(buffer) - strlen(buffer) - 1);
         strncpy(desc->name,
                 (cardinfo != NULL)
@@ -392,7 +392,7 @@ INT32 openMidiDevice(snd_rawmidi_stream_t direction, INT32 deviceIndex,
     // TODO: iterate to get dev ID from index
     err = getMidiDeviceID(direction, deviceIndex, &deviceID);
     TRACE1("  openMidiDevice(): deviceID: %d\n", (int) deviceID);
-    getDeviceStringFromDeviceID(devicename, deviceID,
+    getDeviceStringFromDeviceID(devicename, sizeof(devicename), deviceID,
                                 usePlugHw, ALSA_RAWMIDI);
     TRACE1("  openMidiDevice(): deviceString: %s\n", devicename);
 

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_PCMUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_PCMUtils.c
@@ -75,7 +75,7 @@ int iteratePCMDevices(DeviceIteratorPtr iterator, void* userData) {
             // try to get card info
             card = snd_pcm_info_get_card(pcminfo);
             if (card >= 0) {
-                sprintf(devname, ALSA_HARDWARE_CARD, card);
+                snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, card);
                 if (snd_ctl_open(&handle, devname, SND_CTL_NONBLOCK) >= 0) {
                     if (snd_ctl_card_info(handle, cardinfo) >= 0) {
                         defcardinfo = cardinfo;
@@ -101,7 +101,7 @@ int iteratePCMDevices(DeviceIteratorPtr iterator, void* userData) {
         if (card < 0) {
             break;
         }
-        sprintf(devname, ALSA_HARDWARE_CARD, card);
+        snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, card);
         TRACE1("Opening alsa device \"%s\"...\n", devname);
         err = snd_ctl_open(&handle, devname, SND_CTL_NONBLOCK);
         if (err < 0) {
@@ -185,7 +185,7 @@ int deviceInfoIterator(UINT32 deviceID, snd_pcm_info_t* pcminfo,
         *desc->deviceID = deviceID;
         buffer[0]=' '; buffer[1]='[';
         // buffer[300] is enough to store the actual device string w/o overrun
-        getDeviceStringFromDeviceID(&buffer[2], deviceID, usePlugHw, ALSA_PCM);
+        getDeviceStringFromDeviceID(&buffer[2], sizeof(buffer) - 2, deviceID, usePlugHw, ALSA_PCM);
         strncat(buffer, "]", sizeof(buffer) - strlen(buffer) - 1);
         strncpy(desc->name,
                 (cardinfo != NULL)
@@ -217,7 +217,7 @@ int openPCMfromDeviceID(int deviceID, snd_pcm_t** handle, int isSource, int hard
     int ret;
 
     initAlsaSupport();
-    getDeviceStringFromDeviceID(buffer, deviceID, !hardware, ALSA_PCM);
+    getDeviceStringFromDeviceID(buffer, sizeof(buffer), deviceID, !hardware, ALSA_PCM);
 
     TRACE1("Opening ALSA device %s\n", buffer);
     ret = snd_pcm_open(handle, buffer,

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_Ports.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_Ports.c
@@ -85,7 +85,7 @@ INT32 PORT_GetPortMixerCount() {
     mixerCount = 0;
     if (snd_card_next(&card) >= 0) {
         while (card >= 0) {
-            sprintf(devname, ALSA_HARDWARE_CARD, card);
+            snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, card);
             TRACE1("PORT_GetPortMixerCount: Opening alsa device \"%s\"...\n", devname);
             err = snd_ctl_open(&handle, devname, 0);
             if (err < 0) {
@@ -115,7 +115,7 @@ INT32 PORT_GetPortMixerDescription(INT32 mixerIndex, PortMixerDescription* descr
     TRACE0("> PORT_GetPortMixerDescription\n");
     snd_ctl_card_info_malloc(&card_info);
 
-    sprintf(devname, ALSA_HARDWARE_CARD, (int) mixerIndex);
+    snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, (int) mixerIndex);
     TRACE1("Opening alsa device \"%s\"...\n", devname);
     err = snd_ctl_open(&handle, devname, 0);
     if (err < 0) {
@@ -127,7 +127,7 @@ INT32 PORT_GetPortMixerDescription(INT32 mixerIndex, PortMixerDescription* descr
         ERROR2("ERROR: snd_ctl_card_info, card=%d: %s\n", (int) mixerIndex, snd_strerror(err));
     }
     strncpy(description->name, snd_ctl_card_info_get_id(card_info), PORT_STRING_LENGTH - 1);
-    sprintf(buffer, " [%s]", devname);
+    snprintf(buffer, sizeof(buffer), " [%s]", devname);
     strncat(description->name, buffer, PORT_STRING_LENGTH - 1 - strlen(description->name));
     strncpy(description->vendor, "ALSA (http://www.alsa-project.org)", PORT_STRING_LENGTH - 1);
     strncpy(description->description, snd_ctl_card_info_get_name(card_info), PORT_STRING_LENGTH - 1);
@@ -149,7 +149,7 @@ void* PORT_Open(INT32 mixerIndex) {
     PortMixer* handle;
 
     TRACE0("> PORT_Open\n");
-    sprintf(devname, ALSA_HARDWARE_CARD, (int) mixerIndex);
+    snprintf(devname, sizeof(devname), ALSA_HARDWARE_CARD, (int) mixerIndex);
     if ((err = snd_mixer_open(&mixer_handle, 0)) < 0) {
         ERROR2("Mixer %s open error: %s", devname, snd_strerror(err));
         return NULL;

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -102,7 +102,7 @@ static CGAffineTransform sInverseTX = { 1, 0, 0, -1, 0, 0 };
 #define AWT_FONT_CLEANUP_FINISH                                         \
     if (_fontThrowJavaException == YES) {                               \
         char s[512];                                                    \
-        sprintf(s, "%s-%s:%d", __FILE__, __FUNCTION__, __LINE__);       \
+        snprintf(s, sizeof(s), "%s-%s:%d", __FILE__, __FUNCTION__, __LINE__);       \
         JNU_ThrowByName(env, "java/lang/RuntimeException", s);          \
     }
 

--- a/src/java.desktop/share/native/common/awt/debug/debug_mem.c
+++ b/src/java.desktop/share/native/common/awt/debug/debug_mem.c
@@ -279,7 +279,7 @@ static void DMem_DumpHeader(MemoryBlockHeader * header) {
         "-------";
 
     DMem_VerifyHeader(header);
-    sprintf(report, reportFormat, header->filename, header->linenumber, header->size, header->order);
+    snprintf(report, sizeof(report), reportFormat, header->filename, header->linenumber, header->size, header->order);
     DTRACE_PRINTLN(report);
 }
 

--- a/src/java.desktop/share/native/common/awt/debug/debug_trace.c
+++ b/src/java.desktop/share/native/common/awt/debug/debug_trace.c
@@ -216,7 +216,7 @@ void DTrace_VPrintImpl(const char * fmt, va_list arglist) {
     DASSERT(fmt != NULL);
 
     /* format the trace message */
-    vsprintf(DTraceBuffer, fmt, arglist);
+    vsnprintf(DTraceBuffer, sizeof(DTraceBuffer), fmt, arglist);
     /* not a real great overflow check (memory would already be hammered) but better than nothing */
     DASSERT(strlen(DTraceBuffer) < MAX_TRACE_BUFFER);
     /* output the trace message */

--- a/src/java.desktop/share/native/common/java2d/opengl/OGLBufImgOps.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLBufImgOps.c
@@ -50,7 +50,7 @@
  * Note that this shader source code includes some "holes" marked by "%s".
  * This allows us to build different shader programs (e.g. one for
  * 3x3, one for 5x5, and so on) simply by filling in these "holes" with
- * a call to sprintf().  See the OGLBufImgOps_CreateConvolveProgram() method
+ * a call to snprintf().  See the OGLBufImgOps_CreateConvolveProgram() method
  * for more details.
  *
  * REMIND: Currently this shader (and the supporting code in the
@@ -141,16 +141,16 @@ OGLBufImgOps_CreateConvolveProgram(jint flags)
 
     if (IS_SET(CONVOLVE_EDGE_ZERO_FILL)) {
         // EDGE_ZERO_FILL: fill in zero at the edges
-        sprintf(edge, "sum = vec4(0.0);");
+        snprintf(edge, sizeof(edge), "sum = vec4(0.0);");
     } else {
         // EDGE_NO_OP: use the source pixel color at the edges
-        sprintf(edge,
+        snprintf(edge, sizeof(edge),
                 "sum = texture%s(baseImage, gl_TexCoord[0].st);",
                 target);
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, convolveShaderSource,
+    snprintf(finalSource, sizeof(finalSource), convolveShaderSource,
             kernelMax, target, edge, target);
 
     convolveProgram = OGLContext_CreateFragmentProgram(finalSource);
@@ -296,7 +296,7 @@ OGLBufImgOps_DisableConvolveOp(OGLContext *oglc)
  * Note that this shader source code includes some "holes" marked by "%s".
  * This allows us to build different shader programs (e.g. one for
  * GL_TEXTURE_2D targets, one for GL_TEXTURE_RECTANGLE_ARB targets, and so on)
- * simply by filling in these "holes" with a call to sprintf().  See the
+ * simply by filling in these "holes" with a call to snprintf().  See the
  * OGLBufImgOps_CreateRescaleProgram() method for more details.
  */
 static const char *rescaleShaderSource =
@@ -360,7 +360,7 @@ OGLBufImgOps_CreateRescaleProgram(jint flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, rescaleShaderSource,
+    snprintf(finalSource, sizeof(finalSource), rescaleShaderSource,
             target, target, preRescale, postRescale);
 
     rescaleProgram = OGLContext_CreateFragmentProgram(finalSource);
@@ -502,7 +502,7 @@ OGLBufImgOps_DisableRescaleOp(OGLContext *oglc)
  * Note that this shader source code includes some "holes" marked by "%s".
  * This allows us to build different shader programs (e.g. one for
  * GL_TEXTURE_2D targets, one for GL_TEXTURE_RECTANGLE_ARB targets, and so on)
- * simply by filling in these "holes" with a call to sprintf().  See the
+ * simply by filling in these "holes" with a call to snprintf().  See the
  * OGLBufImgOps_CreateLookupProgram() method for more details.
  */
 static const char *lookupShaderSource =
@@ -592,7 +592,7 @@ OGLBufImgOps_CreateLookupProgram(jint flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, lookupShaderSource,
+    snprintf(finalSource, sizeof(finalSource), lookupShaderSource,
             target, target, preLookup, alpha, postLookup);
 
     lookupProgram = OGLContext_CreateFragmentProgram(finalSource);

--- a/src/java.desktop/share/native/common/java2d/opengl/OGLPaints.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLPaints.c
@@ -578,15 +578,15 @@ OGLPaints_CreateMultiGradProgram(jint flags,
     }
 
     if (cycleMethod == CYCLE_NONE) {
-        sprintf(cycleCode, noCycleCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), noCycleCode, texCoordCalcCode);
     } else if (cycleMethod == CYCLE_REFLECT) {
-        sprintf(cycleCode, reflectCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), reflectCode, texCoordCalcCode);
     } else { // (cycleMethod == CYCLE_REPEAT)
-        sprintf(cycleCode, repeatCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), repeatCode, texCoordCalcCode);
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, multiGradientShaderSource,
+    snprintf(finalSource, sizeof(finalSource), multiGradientShaderSource,
             MAX_COLORS, maxFractions,
             maskVars, paintVars, distCode,
             cycleCode, colorSpaceCode, maskCode);

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -387,7 +387,7 @@ HandleError(Display * disp, XErrorEvent * err) {
     XGetErrorText(disp, err->error_code, msg, sizeof(msg));
     fprintf(stderr, "Xerror %s, XID %x, ser# %d\n", msg, err->resourceid,
         err->serial);
-    sprintf(buf, "%d", err->request_code);
+    snprintf(buf, sizeof(buf), "%d", err->request_code);
     XGetErrorDatabaseText(disp, "XRequest", buf, "Unknown", msg, sizeof(msg));
     fprintf(stderr, "Major opcode %d (%s)\n", err->request_code, msg);
     if (err->request_code > 128) {

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DShaderGen.c
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DShaderGen.c
@@ -79,7 +79,7 @@ D3DShaderGen_WriteShader(char *source, char *target, char *name, int flags)
         PROCESS_INFORMATION pi;
         STARTUPINFO si;
         char pargs[300];
-        sprintf(pargs,
+        snprintf(pargs, sizeof(pargs),
                 "c:\\progra~1\\mi5889~1\\utilit~1\\bin\\x86\\fxc.exe "
                 "/T %s /Vn %s%d /Fh tmp.h tmp.hlsl",
                 // uncomment the following line to generate debug
@@ -144,13 +144,13 @@ D3DShaderGen_WriteShaderArray(char *name, int num)
     char elem[30];
     int i;
 
-    sprintf(array, "const DWORD *%sShaders[] =\n{\n", name);
+    snprintf(array, sizeof(array), "const DWORD *%sShaders[] =\n{\n", name);
     for (i = 0; i < num; i++) {
         if (num == 32 && EXTRACT_CYCLE_METHOD(i) == 3) {
             // REMIND: what a hack!
-            sprintf(elem, "    NULL,\n");
+            snprintf(elem, sizeof(elem), "    NULL,\n");
         } else {
-            sprintf(elem, "    %s%d,\n", name, i);
+            snprintf(elem, sizeof(elem), "    %s%d,\n", name, i);
         }
         strcat(array, elem);
     }
@@ -225,7 +225,7 @@ D3DShaderGen_GenerateConvolveShader(int flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, convolveShaderSource,
+    snprintf(finalSource, sizeof(finalSource), convolveShaderSource,
             kernelMax, edge, kernelMax);
 
     D3DShaderGen_WritePixelShader(finalSource, "convolve", flags);
@@ -283,7 +283,7 @@ D3DShaderGen_GenerateRescaleShader(int flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, rescaleShaderSource,
+    snprintf(finalSource, sizeof(finalSource), rescaleShaderSource,
             preRescale, postRescale);
 
     D3DShaderGen_WritePixelShader(finalSource, "rescale", flags);
@@ -357,7 +357,7 @@ D3DShaderGen_GenerateLookupShader(int flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, lookupShaderSource,
+    snprintf(finalSource, sizeof(finalSource), lookupShaderSource,
             preLookup, alpha, postLookup);
 
     D3DShaderGen_WritePixelShader(finalSource, "lookup", flags);
@@ -452,7 +452,7 @@ D3DShaderGen_GenerateBasicGradShader(int flags)
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, basicGradientShaderSource,
+    snprintf(finalSource, sizeof(finalSource), basicGradientShaderSource,
             maskVars, maskInput, colorSampler, cycleCode, maskCode);
 
     D3DShaderGen_WritePixelShader(finalSource, "grad", flags);
@@ -665,15 +665,15 @@ D3DShaderGen_GenerateMultiGradShader(int flags, char *name,
     }
 
     if (cycleMethod == CYCLE_NONE) {
-        sprintf(cycleCode, noCycleCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), noCycleCode, texCoordCalcCode);
     } else if (cycleMethod == CYCLE_REFLECT) {
-        sprintf(cycleCode, reflectCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), reflectCode, texCoordCalcCode);
     } else { // (cycleMethod == CYCLE_REPEAT)
-        sprintf(cycleCode, repeatCode, texCoordCalcCode);
+        snprintf(cycleCode, sizeof(cycleCode), repeatCode, texCoordCalcCode);
     }
 
     // compose the final source code string from the various pieces
-    sprintf(finalSource, multiGradientShaderSource,
+    snprintf(finalSource, sizeof(finalSource), multiGradientShaderSource,
             MAX_COLORS, maxFractions, colorSampler,
             maskVars, paintVars, maskInput, colorSampler,
             distCode, cycleCode, colorSpaceCode, maskCode);

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -300,7 +300,7 @@ JNIEXPORT void JNICALL Java_sun_awt_shell_Win32ShellFolderManager2_initializeCom
     HRESULT hr = ::CoInitialize(NULL);
     if (FAILED(hr)) {
         char c[64];
-        sprintf(c, "Could not initialize COM: HRESULT=0x%08X", hr);
+        snprintf(c, sizeof(c), "Could not initialize COM: HRESULT=0x%08X", hr);
         JNU_ThrowInternalError(env, c);
     }
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1334,7 +1334,7 @@ void SpyWinMessage(HWND hwnd, UINT message, LPCTSTR szComment) {
         WIN_MSG(WM_AWT_CREATE_PRINTED_PIXELS)
         WIN_MSG(WM_AWT_OBJECTLISTCLEANUP)
         default:
-            sprintf(szBuf, "0x%8.8x(%s):Unknown message 0x%8.8x\n",
+            snprintf(szBuf, sizeof(szBuf), "0x%8.8x(%s):Unknown message 0x%8.8x\n",
                 hwnd, szComment, message);
             break;
     }

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
@@ -282,7 +282,7 @@ INT32 MIDI_IN_GetDeviceVersion(INT32 deviceID, char *name, UINT32 nameLength) {
 
     memset(&midiInCaps, 0, sizeof(midiInCaps));
     if (getMidiInCaps(deviceID, &midiInCaps, &err) && (nameLength>7)) {
-        sprintf(name, "%d.%d", (midiInCaps.vDriverVersion & 0xFF00) >> 8, midiInCaps.vDriverVersion & 0xFF);
+        snprintf(name, nameLength + 1, "%d.%d", (midiInCaps.vDriverVersion & 0xFF00) >> 8, midiInCaps.vDriverVersion & 0xFF);
         return MIDI_SUCCESS;
     }
     MIDIIN_CHECK_ERROR;

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiOut.c
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiOut.c
@@ -139,7 +139,7 @@ INT32 MIDI_OUT_GetDeviceVersion(INT32 deviceID, char *name, UINT32 nameLength) {
 
     memset(&midiOutCaps, 0, sizeof(midiOutCaps));
     if (getMidiOutCaps(deviceID, &midiOutCaps, &err) && nameLength>7) {
-        sprintf(name, "%d.%d", (midiOutCaps.vDriverVersion & 0xFF00) >> 8, midiOutCaps.vDriverVersion & 0xFF);
+        snprintf(name, nameLength + 1, "%d.%d", (midiOutCaps.vDriverVersion & 0xFF00) >> 8, midiOutCaps.vDriverVersion & 0xFF);
         return MIDI_SUCCESS;
     }
     MIDIOUT_CHECK_ERROR;

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
@@ -113,8 +113,9 @@ char* getLineFlags(DWORD flags) {
     }
     if (flags!=0) {
         UINT_PTR r = (UINT_PTR) ret;
-        r += strlen(ret);
-        sprintf((char*) r, "%d", flags);
+        size_t usedLen = strlen(ret);
+        r += usedLen;
+        snprintf((char*) r, sizeof(ret) - usedLen, "%d", flags);
     }
     return ret;
 }
@@ -219,8 +220,9 @@ char* getControlState(DWORD controlState) {
     }
     if (controlState!=0) {
         UINT_PTR r = (UINT_PTR) ret;
-        r += strlen(ret);
-        sprintf((char*) r, "%d", controlState);
+        size_t usedLen = strlen(ret);
+        r += usedLen;
+        snprintf((char*) r, sizeof(ret) - usedLen, "%d", controlState);
     }
     return ret;
 }
@@ -359,7 +361,7 @@ INT32 PORT_GetPortMixerDescription(INT32 mixerIndex, PortMixerDescription* descr
     MIXERCAPSW mixerCaps;
     if (mixerGetDevCapsW(mixerIndex, &mixerCaps, sizeof(MIXERCAPSW)) == MMSYSERR_NOERROR) {
         UnicodeToUTF8AndCopy(description->name, mixerCaps.szPname, PORT_STRING_LENGTH);
-        sprintf(description->version, "%d.%d", (mixerCaps.vDriverVersion & 0xFF00) >> 8, mixerCaps.vDriverVersion & 0xFF);
+        snprintf(description->version, sizeof(description->version), "%d.%d", (mixerCaps.vDriverVersion & 0xFF00) >> 8, mixerCaps.vDriverVersion & 0xFF);
         strncpy(description->description, "Port Mixer", PORT_STRING_LENGTH-1);
         return TRUE;
     }

--- a/src/jdk.pack/share/native/common-unpack/bands.cpp
+++ b/src/jdk.pack/share/native/common-unpack/bands.cpp
@@ -160,10 +160,10 @@ void band::dump() {
   if (b_name == null) {
     char* bp = &b_name_buf[0];
     b_name = bp;
-    sprintf(bp, "#%d/%d", bn, le_kind); bp += strlen(bp);
-    if (le_bci != 0)  { sprintf(bp, "/bci%d",  le_bci);  bp += strlen(bp); }
-    if (le_back != 0) { sprintf(bp, "/back%d", le_back); bp += strlen(bp); }
-    if (le_len != 0)  { sprintf(bp, "/len%d",  le_len);  bp += strlen(bp); }
+    int nbytes = snprintf(bp, sizeof(b_name_buf), "#%d/%d", bn, le_kind); bp += nbytes;
+    if (le_bci != 0)  { nbytes += snprintf(bp, sizeof(b_name_buf) - nbytes, "/bci%d",  le_bci);  bp += nbytes; }
+    if (le_back != 0) { nbytes += snprintf(bp, sizeof(b_name_buf) - nbytes, "/back%d", le_back); bp += nbytes; }
+    if (le_len != 0)  { nbytes += snprintf(bp, sizeof(b_name_buf) - nbytes, "/len%d",  le_len);  bp += nbytes; }
   }
   fprintf(u->errstrm, "band %s[%d]%s", b_name, length, (length==0?"\n":" {"));
   if (length > 0) {

--- a/src/jdk.pack/share/native/common-unpack/coding.cpp
+++ b/src/jdk.pack/share/native/common-unpack/coding.cpp
@@ -976,13 +976,14 @@ coding* coding::findByIndex(int idx) {
 const char* coding::string() {
   CODING_PRIVATE(spec);
   bytes buf;
-  buf.malloc(100);
+  int buf_len = 100;
+  buf.malloc(buf_len);
   char maxS[20], minS[20];
-  sprintf(maxS, "%d", max);
-  sprintf(minS, "%d", min);
-  if (max == INT_MAX_VALUE)  strcpy(maxS, "max");
-  if (min == INT_MIN_VALUE)  strcpy(minS, "min");
-  sprintf((char*)buf.ptr, "(%d,%d,%d,%d) L=%d r=[%s,%s]",
+  int nmax = snprintf(maxS, sizeof(maxS), "%d", max);
+  int nmin = snprintf(minS, sizeof(minS), "%d", min);
+  if (max == INT_MAX_VALUE)  snprintf(maxS + nmax, sizeof(maxS) - nmax, "max");
+  if (min == INT_MIN_VALUE)  snprintf(minS + nmin, sizeof(minS) - nmin, "min");
+  snprintf((char*)buf.ptr, buf_len, "(%d,%d,%d,%d) L=%d r=[%s,%s]",
           B,H,S,D,L,minS,maxS);
   return (const char*) buf.ptr;
 }

--- a/src/jdk.pack/share/native/common-unpack/unpack.cpp
+++ b/src/jdk.pack/share/native/common-unpack/unpack.cpp
@@ -671,7 +671,7 @@ void unpacker::read_file_header() {
   }
   if (majminfound == null) {
     char message[200];
-    sprintf(message, "@" ERROR_FORMAT ": magic/ver = "
+    snprintf(message, sizeof(message), "@" ERROR_FORMAT ": magic/ver = "
             "%08X/%d.%d should be %08X/%d.%d OR %08X/%d.%d OR %08X/%d.%d OR %08X/%d.%d\n",
             magic, majver, minver,
             JAVA_PACKAGE_MAGIC, JAVA5_PACKAGE_MAJOR_VERSION, JAVA5_PACKAGE_MINOR_VERSION,
@@ -3720,12 +3720,12 @@ const char* entry::string() {
   case CONSTANT_Integer:
   case CONSTANT_Float:
     buf = getbuf(12);
-    sprintf((char*)buf.ptr, "0x%08x", value.i);
+    snprintf((char*)buf.ptr, 12, "0x%08x", value.i);
     break;
   case CONSTANT_Long:
   case CONSTANT_Double:
     buf = getbuf(24);
-    sprintf((char*)buf.ptr, "0x" LONG_LONG_HEX_FORMAT, value.l);
+    snprintf((char*)buf.ptr, 24, "0x" LONG_LONG_HEX_FORMAT, value.l);
     break;
   default:
     if (nrefs == 0) {

--- a/src/jdk.pack/share/native/common-unpack/unpack.h
+++ b/src/jdk.pack/share/native/common-unpack/unpack.h
@@ -418,7 +418,7 @@ struct unpacker {
   void         saveTo(bytes& b, bytes& data) { saveTo(b, data.ptr, data.len); }
   void         saveTo(bytes& b, byte* ptr, size_t len); //{ b.ptr = U_NEW...}
   const char*  saveStr(const char* str) { bytes buf; saveTo(buf, str); return buf.strval(); }
-  const char*  saveIntStr(int num) { char buf[30]; sprintf(buf, "%d", num); return saveStr(buf); }
+  const char*  saveIntStr(int num) { char buf[30]; snprintf(buf, 30, "%d", num); return saveStr(buf); }
 #ifndef PRODUCT
   int printcr_if_verbose(int level, const char* fmt,...);
 #endif

--- a/src/jdk.pack/share/native/common-unpack/utils.cpp
+++ b/src/jdk.pack/share/native/common-unpack/utils.cpp
@@ -82,7 +82,7 @@ void mkdirs(int oklen, char* path) {
 void breakpoint() { }  // hook for debugger
 int assert_failed(const char* p) {
   char message[1<<12];
-  sprintf(message, "@assert failed: %s\n", p);
+  snprintf(message, sizeof(message), "@assert failed: %s\n", p);
   fprintf(stdout, "%s", 1+message);
   breakpoint();
   unpack_abort(message);
@@ -126,7 +126,7 @@ void mtrace(char c, void* ptr, size_t size) {
       return;
     }
     char fname[1024];
-    sprintf(fname, "mtr%d.txt", getpid());
+    snprintf(fname, sizeof(fname), "mtr%d.txt", getpid());
     mtfp = fopen(fname, "w");
     if (mtfp == null)
       mtfp = stdout;

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "logging/logDecorators.hpp"
+#include "runtime/os.hpp"
 #include "unittest.hpp"
 
 static LogDecorators::Decorator decorator_array[] = {
@@ -173,7 +174,7 @@ TEST(LogDecorators, combine_with) {
 
   // Select first and third decorator for dec1
   char input[64];
-  sprintf(input, "%s,%s", decorator_name_array[0], decorator_name_array[3]);
+  os::snprintf_checked(input, sizeof(input), "%s,%s", decorator_name_array[0], decorator_name_array[3]);
   dec1.parse(input);
   EXPECT_TRUE(dec1.is_decorator(decorator_array[0]));
   EXPECT_TRUE(dec1.is_decorator(decorator_array[3]));

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -144,11 +144,12 @@ TEST_VM_F(LogMessageTest, long_message) {
   char* data = NEW_C_HEAP_ARRAY(char, size, mtLogging);
 
   // fill buffer with start_marker...some data...end_marker
-  sprintf(data, "%s", start_marker);
+  os::snprintf_checked(data, size, "%s", start_marker);
   for (size_t i = strlen(start_marker); i < size; i++) {
     data[i] = '0' + (i % 10);
   }
-  sprintf(data + size - strlen(end_marker) - 1, "%s", end_marker);
+  size_t remaining_size = strlen(end_marker) + 1;
+  os::snprintf_checked(data + size - remaining_size, remaining_size, "%s", end_marker);
 
   msg.trace("%s", data); // Adds a newline, making the message exactly 10K in length.
   _log.write(msg);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
@@ -57,7 +57,7 @@ void JNICALL ThreadEnd(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
     }
     if (inf.name != NULL && strstr(inf.name, prefix) == inf.name) {
         eventsCount++;
-        sprintf(name, "%s%d", prefix, eventsCount);
+        snprintf(name, sizeof(name), "%s%d", prefix, eventsCount);
         if (inf.name == NULL || strcmp(name, inf.name) != 0) {
             printf("(#%d) wrong thread name: \"%s\"",
                    eventsCount, inf.name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
@@ -56,7 +56,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
         printf(">>> %s\n", inf.name);
     }
     if (inf.name != NULL && strstr(inf.name, prefix) == inf.name) {
-        sprintf(name, "%s%d", prefix, eventsCount);
+        snprintf(name, sizeof(name), "%s%d", prefix, eventsCount);
         if (strcmp(name, inf.name) != 0) {
             printf("(#%d) wrong thread name: \"%s\"",
                    eventsCount, inf.name);


### PR DESCRIPTION
This fixes [JDK-8336291](https://bugs.openjdk.org/browse/JDK-8336291) by replacing the deprecated `sprintf` with `snprintf` in different files `jdk.pack`. Low risk.

This is a 11u specific issue, as `jdk.pack` was removed in [JDK-8234596](https://bugs.openjdk.org/browse/JDK-8234596)  in OpenJDK 14.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8336291](https://bugs.openjdk.org/browse/JDK-8336291) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2844 must be integrated first

### Issue
 * [JDK-8336291](https://bugs.openjdk.org/browse/JDK-8336291): [11u] update for deprecated sprintf for jdk.pack (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2853/head:pull/2853` \
`$ git checkout pull/2853`

Update a local copy of the PR: \
`$ git checkout pull/2853` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2853`

View PR using the GUI difftool: \
`$ git pr show -t 2853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2853.diff">https://git.openjdk.org/jdk11u-dev/pull/2853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2853#issuecomment-2224971748)