### PR TITLE
8249097: test/lib/jdk/test/lib/util/JarBuilder.java has a bad copyright

### DIFF
--- a/test/jdk/lib/testlibrary/java/util/jar/JarBuilder.java
+++ b/test/jdk/lib/testlibrary/java/util/jar/JarBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

As [JDK-8211974](https://bugs.openjdk.org/browse/JDK-8211974) is not backported, so fix the origin flie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8249097](https://bugs.openjdk.org/browse/JDK-8249097) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249097](https://bugs.openjdk.org/browse/JDK-8249097): test/lib/jdk/test/lib/util/JarBuilder.java has a bad copyright (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2855/head:pull/2855` \
`$ git checkout pull/2855`

Update a local copy of the PR: \
`$ git checkout pull/2855` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2855`

View PR using the GUI difftool: \
`$ git pr show -t 2855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2855.diff">https://git.openjdk.org/jdk11u-dev/pull/2855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2855#issuecomment-2225224788)