### PR TITLE
8331466: Problemlist serviceability/dcmd/gc/RunFinalizationTest.java on generic-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -162,6 +162,7 @@ runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 
 # :hotspot_serviceability
 
+serviceability/dcmd/gc/RunFinalizationTest.java 8227120 generic-all
 serviceability/sa/ClhsdbAttach.java 8193639 solaris-all
 serviceability/sa/ClhsdbCDSCore.java 8294316,8193639,8267433 solaris-all,macosx-x64
 serviceability/sa/ClhsdbCDSJstackPrintAll.java 8193639 solaris-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [61e2dba5](https://github.com/openjdk/jdk17u-dev/commit/61e2dba5000fc46930bc09d6a47c026adb008e7d) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by SendaoYan on 12 Jul 2024 and was reviewed by Paul Hohensee.

It's backport from jdk17u-dev, this testcase also intermittent fails with jdk11u. So I think it's necessary backport to jdk11u-dev. It's not clean backport beause jdk11u-dev has different context to jdk17u-dev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331466](https://bugs.openjdk.org/browse/JDK-8331466) needs maintainer approval

### Issue
 * [JDK-8331466](https://bugs.openjdk.org/browse/JDK-8331466): Problemlist serviceability/dcmd/gc/RunFinalizationTest.java on generic-all (**Sub-task** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2856/head:pull/2856` \
`$ git checkout pull/2856`

Update a local copy of the PR: \
`$ git checkout pull/2856` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2856`

View PR using the GUI difftool: \
`$ git pr show -t 2856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2856.diff">https://git.openjdk.org/jdk11u-dev/pull/2856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2856#issuecomment-2226708352)