### PR TITLE
8328273: sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java failed with java.rmi.server.ExportException: Port already in use

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public class DefaultAgentFilterTest {
                     AtomicBoolean error = new AtomicBoolean(false);
                     AtomicBoolean bindError = new AtomicBoolean(false);
                     // The predicate below tries to recognise failures.  On a port clash, it sees e.g.
-                    // Error: Exception thrown by the agent : java.rmi.server.ExportException: Port already in use: 46481; nested exception is:
+                    // Error: Exception thrown by the agent: java.rmi.server.ExportException: Port already in use: 46481; nested exception is:
                     // ...and will never see "main enter" from TestApp.
                     p = ProcessTools.startProcess(
                             TEST_APP_NAME + "{" + name + "}",

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ public class RmiRegistrySslTest {
             System.out.println("test output:");
             System.out.println(output.getOutput());
 
-            if (!output.getOutput().contains("Exception thrown by the agent : " +
+            if (!output.getOutput().contains("Exception thrown by the agent: " +
                     "java.rmi.server.ExportException: Port already in use")) {
                 return output.getExitValue();
             }


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328273](https://bugs.openjdk.org/browse/JDK-8328273) needs maintainer approval

### Issue
 * [JDK-8328273](https://bugs.openjdk.org/browse/JDK-8328273): sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java failed with java.rmi.server.ExportException: Port already in use (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2857/head:pull/2857` \
`$ git checkout pull/2857`

Update a local copy of the PR: \
`$ git checkout pull/2857` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2857`

View PR using the GUI difftool: \
`$ git pr show -t 2857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2857.diff">https://git.openjdk.org/jdk11u-dev/pull/2857.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2857#issuecomment-2230132783)