### PR TITLE
8317316: G1: Make TestG1PercentageOptions use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package gc.arguments;
  * @test TestG1PercentageOptions
  * @key gc
  * @bug 8068942
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.G1ConfidencePercent == null
  * @summary Test argument processing of various percentage options
  * @library /test/lib
  * @library /
@@ -65,8 +65,7 @@ public class TestG1PercentageOptions {
     };
 
     private static void check(String flag, boolean is_valid) throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
-                "-XX:+UseG1GC", flag, "-version");
+        ProcessBuilder pb = GCArguments.createTestJvm("-XX:+UseG1GC", flag, "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (is_valid) {
             output.shouldHaveExitValue(0);
@@ -75,8 +74,7 @@ public class TestG1PercentageOptions {
         }
     }
 
-    private static
-    void check(String name, String value, boolean is_valid) throws Exception {
+    private static void check(String name, String value, boolean is_valid) throws Exception {
         check("-XX:" + name + "=" + value, is_valid);
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317316](https://bugs.openjdk.org/browse/JDK-8317316) needs maintainer approval

### Issue
 * [JDK-8317316](https://bugs.openjdk.org/browse/JDK-8317316): G1: Make TestG1PercentageOptions use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2859/head:pull/2859` \
`$ git checkout pull/2859`

Update a local copy of the PR: \
`$ git checkout pull/2859` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2859`

View PR using the GUI difftool: \
`$ git pr show -t 2859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2859.diff">https://git.openjdk.org/jdk11u-dev/pull/2859.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2859#issuecomment-2230133036)