### PR TITLE
8336451: [11u] GHA macos-13 builder is unable to resolve local hostname

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,15 @@ jobs:
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'
 
+      - name: 'Update /etc/hosts on macos-13'
+        run: |
+          # On macos-13 we need to update /etc/hosts for getaddrinfo 
+          # So that JDI/JDWP socket connectors are able to resolve local names
+          # See JDK-8336451
+          echo -e "127.0.0.1     $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+          echo -e "" | sudo tee -a /etc/hosts
+        if: runner.os == 'macOS'
+
       - name: 'Set PATH'
         id: path
         run: |


### PR DESCRIPTION
This fixes [JDK-8336451](https://bugs.openjdk.org/browse/JDK-8336451).

This is a problem with the latest Github macos runners (see https://github.com/actions/runner-images/issues/8649) that makes it impossible for `getaddrinfo` to properly resolve the builder's hostname. The issue has been opened since late 2023.

Not being able to resolve the local hostname makes `jdk/tier1` and `langtools/tier1` to fail on this platform, as the [socket transport ](https://github.com/openjdk/jdk11u-dev/blob/697d8566b1d4801cb7926fa35bbf471f8f4ba066/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c#L329) cannot establish a connection.

There are still some other `sprintf`s in the codebase, but these do not affect the macos builds, and can be possibly  backported later on, once the macos builds are again in place.

The macos builds and tests are expected to succeed after this fix is in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8336451](https://bugs.openjdk.org/browse/JDK-8336451) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2854 must be integrated first

### Issue
 * [JDK-8336451](https://bugs.openjdk.org/browse/JDK-8336451): [11u] GHA macos-13 builder is unable to resolve local hostname (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2861/head:pull/2861` \
`$ git checkout pull/2861`

Update a local copy of the PR: \
`$ git checkout pull/2861` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2861`

View PR using the GUI difftool: \
`$ git pr show -t 2861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2861.diff">https://git.openjdk.org/jdk11u-dev/pull/2861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2861#issuecomment-2231268992)