### PR TITLE
8299058: AssertionError in sun.net.httpserver.ServerImpl when connection is idle

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -515,14 +515,15 @@ class ServerImpl {
 
                                     key.cancel();
                                     chan.configureBlocking (true);
+                                    // check if connection is being closed
                                     if (newlyAcceptedConnections.remove(conn)
                                             || idleConnections.remove(conn)) {
                                         // was either a newly accepted connection or an idle
                                         // connection. In either case, we mark that the request
                                         // has now started on this connection.
                                         requestStarted(conn);
+                                        handle (chan, conn);
                                     }
-                                    handle (chan, conn);
                                 } else {
                                     assert false : "Unexpected non-readable key:" + key;
                                 }
@@ -981,35 +982,30 @@ class ServerImpl {
      */
     class IdleTimeoutTask extends TimerTask {
         public void run () {
-            ArrayList<HttpConnection> toClose = new ArrayList<>();
-            final long currentTime = System.currentTimeMillis();
-            synchronized (idleConnections) {
-                final Iterator<HttpConnection> it = idleConnections.iterator();
-                while (it.hasNext()) {
-                    final HttpConnection c = it.next();
-                    if (currentTime - c.idleStartTime >= IDLE_INTERVAL) {
-                        toClose.add(c);
-                        it.remove();
-                    }
-                }
-            }
+            closeConnections(idleConnections, IDLE_INTERVAL);
             // if any newly accepted connection has been idle (i.e. no byte has been sent on that
             // connection during the configured idle timeout period) then close it as well
-            synchronized (newlyAcceptedConnections) {
-                final Iterator<HttpConnection> it = newlyAcceptedConnections.iterator();
-                while (it.hasNext()) {
-                    final HttpConnection c = it.next();
-                    if (currentTime - c.idleStartTime >= NEWLY_ACCEPTED_CONN_IDLE_INTERVAL) {
-                        toClose.add(c);
-                        it.remove();
-                    }
+            closeConnections(newlyAcceptedConnections, NEWLY_ACCEPTED_CONN_IDLE_INTERVAL);
+        }
+
+        private void closeConnections(Set<HttpConnection> connections, long idleInterval) {
+            long currentTime = System.currentTimeMillis();
+            ArrayList<HttpConnection> toClose = new ArrayList<>();
+
+            connections.forEach(c -> {
+                if (currentTime - c.idleStartTime >= idleInterval) {
+                    toClose.add(c);
                 }
-            }
+            });
             for (HttpConnection c : toClose) {
-                allConnections.remove(c);
-                c.close();
-                if (logger.isLoggable(Level.TRACE)) {
-                    logger.log(Level.TRACE, "Closed idle connection " + c);
+                // check if connection still idle
+                if (currentTime - c.idleStartTime >= idleInterval &&
+                        connections.remove(c)) {
+                    allConnections.remove(c);
+                    c.close();
+                    if (logger.isLoggable(Level.TRACE)) {
+                        logger.log(Level.TRACE, "Closed idle connection " + c);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299058](https://bugs.openjdk.org/browse/JDK-8299058) needs maintainer approval

### Issue
 * [JDK-8299058](https://bugs.openjdk.org/browse/JDK-8299058): AssertionError in sun.net.httpserver.ServerImpl when connection is idle (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2867/head:pull/2867` \
`$ git checkout pull/2867`

Update a local copy of the PR: \
`$ git checkout pull/2867` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2867`

View PR using the GUI difftool: \
`$ git pr show -t 2867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2867.diff">https://git.openjdk.org/jdk11u-dev/pull/2867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2867#issuecomment-2238560252)