### PR TITLE
8249697: remove temporary fixes from java/lang/invoke/RicochetTest.java

### DIFF
--- a/test/jdk/java/lang/invoke/RicochetTest.java
+++ b/test/jdk/java/lang/invoke/RicochetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,9 @@
  * questions.
  */
 
-/* @test
- * @summary unit tests for recursive method handles
- * @run junit/othervm/timeout=3600 -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies -DRicochetTest.MAX_ARITY=10 test.java.lang.invoke.RicochetTest
- */
 /*
- * @ignore The following test creates an unreasonable number of adapters in -Xcomp mode (7049122)
+ * @test
+ * @summary unit tests for recursive method handles
  * @run junit/othervm -DRicochetTest.MAX_ARITY=255 test.java.lang.invoke.RicochetTest
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8249697](https://bugs.openjdk.org/browse/JDK-8249697) needs maintainer approval

### Issue
 * [JDK-8249697](https://bugs.openjdk.org/browse/JDK-8249697): remove temporary fixes from java/lang/invoke/RicochetTest.java (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2870/head:pull/2870` \
`$ git checkout pull/2870`

Update a local copy of the PR: \
`$ git checkout pull/2870` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2870`

View PR using the GUI difftool: \
`$ git pr show -t 2870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2870.diff">https://git.openjdk.org/jdk11u-dev/pull/2870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2870#issuecomment-2242435569)