### PR TITLE
8255969: Improve java/io/BufferedInputStream/LargeCopyWithMark.java using jtreg tags

### DIFF
--- a/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
+++ b/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,65 +23,42 @@
 
 /* @test
  * @bug 7129312
+ * @requires (sun.arch.data.model == "64"  & os.maxMemory > 4g)
  * @summary BufferedInputStream calculates negative array size with large
  *          streams and mark
- * @library /test/lib
- * @run main/othervm LargeCopyWithMark
+ * @run main/othervm -Xmx4G LargeCopyWithMark
  */
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import static jdk.test.lib.process.ProcessTools.*;
-
 
 public class LargeCopyWithMark {
 
-    public static void main(String[] args) throws Exception {
-        if (! System.getProperty("os.arch").contains("64")) {
-            System.out.println("Test runs on 64 bit platforms");
-            return;
-        }
-        ProcessBuilder pb = createJavaProcessBuilder("-Xmx4G",
-                "-ea:LargeCopyWithMark$Child",
-                "LargeCopyWithMark$Child");
-        int res = pb.inheritIO().start().waitFor();
-        if (res != 0) {
-            throw new AssertionError("Test failed: exit code = " + res);
-        }
+    static final int BUFF_SIZE = 8192;
+    static final int BIS_BUFF_SIZE = Integer.MAX_VALUE / 2 + 100;
+    static final long BYTES_TO_COPY = 2L * Integer.MAX_VALUE;
+
+    static {
+        assert BIS_BUFF_SIZE * 2 < 0 : "doubling must overflow";
     }
 
-    public static class Child {
-        static final int BUFF_SIZE = 8192;
-        static final int BIS_BUFF_SIZE = Integer.MAX_VALUE / 2 + 100;
-        static final long BYTES_TO_COPY = 2L * Integer.MAX_VALUE;
+    public static void main(String[] args) throws Exception {
+        byte[] buff = new byte[BUFF_SIZE];
 
-        static {
-            assert BIS_BUFF_SIZE * 2 < 0 : "doubling must overflow";
-        }
+        try (InputStream myis = new MyInputStream(BYTES_TO_COPY);
+             InputStream bis = new BufferedInputStream(myis, BIS_BUFF_SIZE);
+             OutputStream myos = new MyOutputStream()) {
 
-        public static void main(String[] args) throws Exception {
-            byte[] buff = new byte[BUFF_SIZE];
+            // will require a buffer bigger than BIS_BUFF_SIZE
+            bis.mark(BIS_BUFF_SIZE + 100);
 
-            try (InputStream myis = new MyInputStream(BYTES_TO_COPY);
-                 InputStream bis = new BufferedInputStream(myis, BIS_BUFF_SIZE);
-                 OutputStream myos = new MyOutputStream()) {
-
-                // will require a buffer bigger than BIS_BUFF_SIZE
-                bis.mark(BIS_BUFF_SIZE + 100);
-
-                for (;;) {
-                    int count = bis.read(buff, 0, BUFF_SIZE);
-                    if (count == -1)
-                        break;
-                    myos.write(buff, 0, count);
-                }
-            } catch (java.lang.NegativeArraySizeException e) {
-                e.printStackTrace();
-                System.exit(11);
-            } catch (Exception e) {
-                e.printStackTrace();
+            for (;;) {
+                int count = bis.read(buff, 0, BUFF_SIZE);
+                if (count == -1)
+                    break;
+                myos.write(buff, 0, count);
             }
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255969](https://bugs.openjdk.org/browse/JDK-8255969) needs maintainer approval

### Issue
 * [JDK-8255969](https://bugs.openjdk.org/browse/JDK-8255969): Improve java/io/BufferedInputStream/LargeCopyWithMark.java using jtreg tags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2873/head:pull/2873` \
`$ git checkout pull/2873`

Update a local copy of the PR: \
`$ git checkout pull/2873` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2873`

View PR using the GUI difftool: \
`$ git pr show -t 2873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2873.diff">https://git.openjdk.org/jdk11u-dev/pull/2873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2873#issuecomment-2242445387)