### PR TITLE
8266149: mark hotspot compiler/startup tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8034775
  * @summary Ensures correct minimal number of compiler threads (provided by -XX:CICompilerCount=)
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
+++ b/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  *          to initialize all compiler threads. The option -Xcomp gives the VM more time to
  *          trigger the old bug.
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/startup/StartupOutput.java
+++ b/test/hotspot/jtreg/compiler/startup/StartupOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8026949 8164091
  * @summary Test ensures correct VM output during startup
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8266149](https://bugs.openjdk.org/browse/JDK-8266149) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266149](https://bugs.openjdk.org/browse/JDK-8266149): mark hotspot compiler/startup tests which ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2874/head:pull/2874` \
`$ git checkout pull/2874`

Update a local copy of the PR: \
`$ git checkout pull/2874` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2874`

View PR using the GUI difftool: \
`$ git pr show -t 2874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2874.diff">https://git.openjdk.org/jdk11u-dev/pull/2874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2874#issuecomment-2242444799)