### PR TITLE
8266150: mark hotspot compiler/arguments tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8130858 8132525 8162881
  * @summary Check that correct range of values for CICompilerCount are allowed depending on whether tiered is enabled or not
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver compiler.arguments.CheckCICompilerCount

--- a/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
  * @bug 8059604
  * @summary Add CompileThresholdScaling flag to control when methods are first compiled (with +/-TieredCompilation)
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @run driver compiler.arguments.CheckCompileThresholdScaling
  */
 

--- a/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnSupportedCPU.java
@@ -27,8 +27,10 @@
  * @summary Verify processing of UseBMI1Instructions option on CPU with
  *          BMI1 feature support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnUnsupportedCPU.java
@@ -27,8 +27,10 @@
  * @summary Verify processing of UseBMI1Instructions option on CPU without
  *          BMI1 feature support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountLeadingZerosInstruction option
  *          on CPU with LZCNT support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountLeadingZerosInstruction option
  *          on CPU without LZCNT support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountTrailingZerosInstruction option
  *          on CPU with TZCNT (BMI1 feature) support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountTrailingZerosInstruction option
  *          on CPU without TZCNT instruction (BMI1 feature) support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java this file not found in jdk11u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8266150](https://bugs.openjdk.org/browse/JDK-8266150) needs maintainer approval

### Issue
 * [JDK-8266150](https://bugs.openjdk.org/browse/JDK-8266150): mark hotspot compiler/arguments tests which ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2875/head:pull/2875` \
`$ git checkout pull/2875`

Update a local copy of the PR: \
`$ git checkout pull/2875` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2875`

View PR using the GUI difftool: \
`$ git pr show -t 2875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2875.diff">https://git.openjdk.org/jdk11u-dev/pull/2875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2875#issuecomment-2242445243)