### PR TITLE
8253207: enable problemlists jcheck's check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -4,7 +4,7 @@ jbs=JDK
 version=11.0.25
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
@@ -29,3 +29,6 @@ role=committer
 
 [checks "issues"]
 pattern=^([124-8][0-9]{6}): (\S.*)$
+
+[checks "problemlists"]
+dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8253207](https://bugs.openjdk.org/browse/JDK-8253207) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253207](https://bugs.openjdk.org/browse/JDK-8253207): enable problemlists jcheck's check (**Enhancement** - P4 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2876/head:pull/2876` \
`$ git checkout pull/2876`

Update a local copy of the PR: \
`$ git checkout pull/2876` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2876`

View PR using the GUI difftool: \
`$ git pr show -t 2876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2876.diff">https://git.openjdk.org/jdk11u-dev/pull/2876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2876#issuecomment-2242737255)