### PR TITLE
8266153: mark hotspot compiler/onSpinWait tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Azul Systems, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,8 +27,10 @@
  * @summary (x86 only) checks that java.lang.Thread.onSpinWait is intrinsified
  * @bug 8147844
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
+ *
+ * @requires vm.flagless
  * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
+ *
  * @run driver compiler.onSpinWait.TestOnSpinWait
  */
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Azul Systems, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,9 +27,11 @@
  * @summary (x86 only) checks that java.lang.Thread.onSpinWait is intrinsified
  * @bug 8147844
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
+ *
+ * @requires vm.flagless
  * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
  * @requires vm.compiler1.enabled
+ *
  * @run driver compiler.onSpinWait.TestOnSpinWaitC1
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8266153](https://bugs.openjdk.org/browse/JDK-8266153) needs maintainer approval

### Issue
 * [JDK-8266153](https://bugs.openjdk.org/browse/JDK-8266153): mark hotspot compiler/onSpinWait tests which ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2879/head:pull/2879` \
`$ git checkout pull/2879`

Update a local copy of the PR: \
`$ git checkout pull/2879` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2879`

View PR using the GUI difftool: \
`$ git pr show -t 2879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2879.diff">https://git.openjdk.org/jdk11u-dev/pull/2879.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2879#issuecomment-2244397489)