### PR TITLE
8266154: mark hotspot compiler/oracle tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
+++ b/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.flagless
  * @run driver compiler.oracle.CheckCompileCommandOption
  */
 

--- a/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.flagless
  * @run driver compiler.oracle.TestCompileCommand
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
TestInvalidCompileCommand.java not found in jdk11

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8266154](https://bugs.openjdk.org/browse/JDK-8266154) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266154](https://bugs.openjdk.org/browse/JDK-8266154): mark hotspot compiler/oracle tests which ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2880/head:pull/2880` \
`$ git checkout pull/2880`

Update a local copy of the PR: \
`$ git checkout pull/2880` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2880`

View PR using the GUI difftool: \
`$ git pr show -t 2880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2880.diff">https://git.openjdk.org/jdk11u-dev/pull/2880.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2880#issuecomment-2244398046)