### PR TITLE
8244966: Add .vscode to .hgignore and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build/
 /dist/
 /.idea/
+/.vscode/
 nbproject/private/
 /webrev
 /.src-rev


### PR DESCRIPTION
Hi all,
This is backport of [JDK-8244966](https://bugs.openjdk.org/browse/JDK-8244966), to add `.vscode` to `.gitignore`.
It's not clean because in jdk11u-dev the `.hgignore` has been deleted by JDK-8254178.
Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8244966](https://bugs.openjdk.org/browse/JDK-8244966) needs maintainer approval

### Issue
 * [JDK-8244966](https://bugs.openjdk.org/browse/JDK-8244966): Add .vscode to .hgignore and .gitignore (**Enhancement** - P5 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2883/head:pull/2883` \
`$ git checkout pull/2883`

Update a local copy of the PR: \
`$ git checkout pull/2883` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2883`

View PR using the GUI difftool: \
`$ git pr show -t 2883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2883.diff">https://git.openjdk.org/jdk11u-dev/pull/2883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2883#issuecomment-2254899393)