### PR TITLE
8255913: Decrease number of iterations in TestMaxCachedBufferSize

### DIFF
--- a/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
+++ b/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
@@ -54,7 +54,7 @@ import jdk.test.lib.RandomFactory;
  * @key randomness
  */
 public class TestMaxCachedBufferSize {
-    private static final int DEFAULT_ITERS = 10 * 1000;
+    private static final int DEFAULT_ITERS = 5 * 1000;
     private static final int DEFAULT_THREAD_NUM = 4;
 
     private static final int SMALL_BUFFER_MIN_SIZE =  4 * 1024;


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255913](https://bugs.openjdk.org/browse/JDK-8255913) needs maintainer approval

### Issue
 * [JDK-8255913](https://bugs.openjdk.org/browse/JDK-8255913): Decrease number of iterations in TestMaxCachedBufferSize (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2885/head:pull/2885` \
`$ git checkout pull/2885`

Update a local copy of the PR: \
`$ git checkout pull/2885` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2885`

View PR using the GUI difftool: \
`$ git pr show -t 2885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2885.diff">https://git.openjdk.org/jdk11u-dev/pull/2885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2885#issuecomment-2257758300)