### PR TITLE
8259274: Increase timeout duration in sun/nio/ch/TestMaxCachedBufferSize.java

### DIFF
--- a/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
+++ b/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,11 +44,11 @@ import jdk.test.lib.RandomFactory;
  * @modules java.management
  * @library /test/lib
  * @build TestMaxCachedBufferSize
- * @run main/othervm TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=0 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=2000 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=100000 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=10000000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=0 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=2000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=100000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=10000000 TestMaxCachedBufferSize
  * @summary Test the implementation of the jdk.nio.maxCachedBufferSize property
  * (use -Dseed=X to set PRNG seed)
  * @key randomness


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8259274](https://bugs.openjdk.org/browse/JDK-8259274) needs maintainer approval

### Issue
 * [JDK-8259274](https://bugs.openjdk.org/browse/JDK-8259274): Increase timeout duration in sun/nio/ch/TestMaxCachedBufferSize.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2886/head:pull/2886` \
`$ git checkout pull/2886`

Update a local copy of the PR: \
`$ git checkout pull/2886` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2886`

View PR using the GUI difftool: \
`$ git pr show -t 2886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2886.diff">https://git.openjdk.org/jdk11u-dev/pull/2886.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2886#issuecomment-2257772000)