### PR TITLE
8317343: GC: Make TestHeapFreeRatio use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package gc.arguments;
  * @key gc
  * @bug 8025661
  * @summary Test parsing of -Xminf and -Xmaxf
+ * @requires vm.opt.x.Xminf == null & vm.opt.x.Xmaxf == null & vm.opt.MinHeapFreeRatio == null & vm.opt.MaxHeapFreeRatio == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -49,7 +50,7 @@ public class TestHeapFreeRatio {
   }
 
   private static void testMinMaxFreeRatio(String min, String max, Validation type) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
         "-Xminf" + min,
         "-Xmaxf" + max,
         "-version");


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317343](https://bugs.openjdk.org/browse/JDK-8317343) needs maintainer approval

### Issue
 * [JDK-8317343](https://bugs.openjdk.org/browse/JDK-8317343): GC: Make TestHeapFreeRatio use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2893/head:pull/2893` \
`$ git checkout pull/2893`

Update a local copy of the PR: \
`$ git checkout pull/2893` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2893`

View PR using the GUI difftool: \
`$ git pr show -t 2893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2893.diff">https://git.openjdk.org/jdk11u-dev/pull/2893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2893#issuecomment-2262417664)