### PR TITLE
8317112: Add screenshot for Frame/DefaultSizeTest.java

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -48,6 +48,7 @@ public class DefaultSizeTest {
                 .testTimeOut(5)
                 .rows(10)
                 .columns(45)
+                .screenCapture()
                 .build();
 
         EventQueue.invokeAndWait(() -> {


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8317112](https://bugs.openjdk.org/browse/JDK-8317112) needs maintainer approval

### Issue
 * [JDK-8317112](https://bugs.openjdk.org/browse/JDK-8317112): Add screenshot for Frame/DefaultSizeTest.java (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2894/head:pull/2894` \
`$ git checkout pull/2894`

Update a local copy of the PR: \
`$ git checkout pull/2894` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2894`

View PR using the GUI difftool: \
`$ git pr show -t 2894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2894.diff">https://git.openjdk.org/jdk11u-dev/pull/2894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2894#issuecomment-2262428451)