### PR TITLE
8229822: ThrowingPushPromises tests sometimes fail due to EOF

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -329,7 +329,11 @@ class Http2Connection  {
         Log.logTrace("Connection send window size {0} ", windowController.connectionWindowSize());
 
         Stream<?> initialStream = createStream(exchange);
-        initialStream.registerStream(1);
+        boolean opened = initialStream.registerStream(1, true);
+        if (debug.on() && !opened) {
+            debug.log("Initial stream was cancelled - but connection is maintained: " +
+                    "reset frame will need to be sent later");
+        }
         windowController.registerStream(1, getInitialSendWindowSize());
         initialStream.requestSent();
         // Upgrading:
@@ -338,6 +342,11 @@ class Http2Connection  {
         this.initial = initial;
         connectFlows(connection);
         sendConnectionPreface();
+        if (!opened) {
+            debug.log("ensure reset frame is sent to cancel initial stream");
+            initialStream.sendCancelStreamFrame();
+        }
+
     }
 
     // Used when upgrading an HTTP/1.1 connection to HTTP/2 after receiving
@@ -847,7 +856,7 @@ class Http2Connection  {
         Exchange<T> pushExch = new Exchange<>(pushReq, parent.exchange.multi);
         Stream.PushedStream<T> pushStream = createPushStream(parent, pushExch);
         pushExch.exchImpl = pushStream;
-        pushStream.registerStream(promisedStreamid);
+        pushStream.registerStream(promisedStreamid, true);
         parent.incoming_pushPromise(pushReq, pushStream);
     }
 
@@ -872,7 +881,7 @@ class Http2Connection  {
         }
     }
 
-    void resetStream(int streamid, int code) throws IOException {
+    void resetStream(int streamid, int code) {
         try {
             if (connection.channel().isOpen()) {
                 // no need to try & send a reset frame if the
@@ -880,6 +889,7 @@ class Http2Connection  {
                 Log.logError(
                         "Resetting stream {0,number,integer} with error code {1,number,integer}",
                         streamid, code);
+                markStream(streamid, code);
                 ResetFrame frame = new ResetFrame(streamid, code);
                 sendFrame(frame);
             } else if (debug.on()) {
@@ -890,6 +900,11 @@ class Http2Connection  {
             decrementStreamsCount(streamid);
             closeStream(streamid);
         }
+    }
+
+    private void markStream(int streamid, int code) {
+        Stream<?> s = streams.get(streamid);
+        if (s != null) s.markStream(code);
     }
 
     // reduce count of streams by 1 if stream still exists
@@ -1193,12 +1208,19 @@ class Http2Connection  {
         Stream<?> stream = oh.getAttachment();
         assert stream.streamid == 0;
         int streamid = nextstreamid;
-        nextstreamid += 2;
-        stream.registerStream(streamid);
-        // set outgoing window here. This allows thread sending
-        // body to proceed.
-        windowController.registerStream(streamid, getInitialSendWindowSize());
-        return stream;
+        if (stream.registerStream(streamid, false)) {
+            // set outgoing window here. This allows thread sending
+            // body to proceed.
+            nextstreamid += 2;
+            windowController.registerStream(streamid, getInitialSendWindowSize());
+            return stream;
+        } else {
+            stream.cancelImpl(new IOException("Request cancelled"));
+            if (finalStream() && streams.isEmpty()) {
+                close();
+            }
+            return null;
+        }
     }
 
     private final Object sendlock = new Object();
@@ -1212,7 +1234,9 @@ class Http2Connection  {
                     OutgoingHeaders<Stream<?>> oh = (OutgoingHeaders<Stream<?>>) frame;
                     Stream<?> stream = registerNewStream(oh);
                     // provide protection from inserting unordered frames between Headers and Continuation
-                    publisher.enqueue(encodeHeaders(oh, stream));
+                    if (stream != null) {
+                        publisher.enqueue(encodeHeaders(oh, stream));
+                    }
                 } else {
                     publisher.enqueue(encodeFrame(frame));
                 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -28,6 +28,8 @@ package jdk.internal.net.http;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -134,11 +136,17 @@ class Stream<T> extends ExchangeImpl<T> {
     private volatile boolean remotelyClosed;
     private volatile boolean closed;
     private volatile boolean endStreamSent;
-
-    final AtomicBoolean deRegistered = new AtomicBoolean(false);
+    // Indicates the first reason that was invoked when sending a ResetFrame
+    // to the server. A streamState of 0 indicates that no reset was sent.
+    // (see markStream(int code)
+    private volatile int streamState; // assigned using STREAM_STATE varhandle.
+    private volatile boolean deRegistered; // assigned using DEREGISTERED varhandle.
 
     // state flags
     private boolean requestSent, responseReceived;
+
+    // send lock: prevent sending DataFrames after reset occurred.
+    private final Object sendLock = new Object();
 
     /**
      * A reference to this Stream's connection Send Window controller. The
@@ -293,7 +301,7 @@ class Stream<T> extends ExchangeImpl<T> {
     }
 
     boolean deRegister() {
-        return deRegistered.compareAndSet(false, true);
+        return DEREGISTERED.compareAndSet(this, false, true);
     }
 
     @Override
@@ -334,6 +342,36 @@ class Stream<T> extends ExchangeImpl<T> {
     private void receiveResetFrame(ResetFrame frame) {
         inputQ.add(frame);
         sched.runOrSchedule();
+    }
+
+    /**
+     * Records the first reason which was invoked when sending a ResetFrame
+     * to the server in the streamState, and return the previous value
+     * of the streamState. This is an atomic operation.
+     * A possible use of this method would be to send a ResetFrame only
+     * if no previous reset frame has been sent.
+     * For instance: <pre>{@code
+     *  if (markStream(ResetFrame.CANCEL) == 0) {
+     *      connection.sendResetFrame(streamId, ResetFrame.CANCEL);
+     *  }
+     *  }</pre>
+     * @param code the reason code as per HTTP/2 protocol
+     * @return the previous value of the stream state.
+     */
+    int  markStream(int code) {
+        if (code == 0) return streamState;
+        synchronized (sendLock) {
+            return (int) STREAM_STATE.compareAndExchange(this, 0, code);
+        }
+    }
+
+    private void sendDataFrame(DataFrame frame) {
+         synchronized (sendLock) {
+             // must not send DataFrame after reset.
+             if (streamState == 0) {
+                connection.sendDataFrame(frame);
+             }
+        }
     }
 
     // pushes entire response body into response subscriber
@@ -392,6 +430,7 @@ class Stream<T> extends ExchangeImpl<T> {
      */
     void incoming(Http2Frame frame) throws IOException {
         if (debug.on()) debug.log("incoming: %s", frame);
+        var cancelled = closed || streamState != 0;
         if ((frame instanceof HeaderFrame)) {
             HeaderFrame hframe = (HeaderFrame)frame;
             if (hframe.endHeaders()) {
@@ -403,9 +442,10 @@ class Stream<T> extends ExchangeImpl<T> {
                 receiveDataFrame(new DataFrame(streamid, DataFrame.END_STREAM, List.of()));
             }
         } else if (frame instanceof DataFrame) {
-            receiveDataFrame((DataFrame)frame);
+            if (cancelled) connection.dropDataFrame((DataFrame) frame);
+            else receiveDataFrame((DataFrame) frame);
         } else {
-            otherFrame(frame);
+            if (!cancelled) otherFrame(frame);
         }
     }
 
@@ -734,6 +774,16 @@ class Stream<T> extends ExchangeImpl<T> {
         } else {
             requestContentLen = 0;
         }
+
+        // At this point the stream doesn't have a streamid yet.
+        // It will be allocated if we send the request headers.
+        Throwable t = errorRef.get();
+        if (t != null) {
+            if (debug.on()) debug.log("stream already cancelled, headers not sent: %s", (Object)t);
+            return MinimalFuture.failedFuture(t);
+        }
+
+        // sending the headers will cause the allocation of the stream id
         OutgoingHeaders<Stream<T>> f = headerFrame(requestContentLen);
         connection.sendFrame(f);
         CompletableFuture<ExchangeImpl<T>> cf = new MinimalFuture<>();
@@ -759,10 +809,17 @@ class Stream<T> extends ExchangeImpl<T> {
         // been already closed (or will be closed shortly after).
     }
 
-    void registerStream(int id) {
-        this.streamid = id;
-        connection.putStream(this, streamid);
-        if (debug.on()) debug.log("Registered stream %d", id);
+    boolean registerStream(int id, boolean registerIfCancelled) {
+        boolean cancelled = closed;
+        if (!cancelled || registerIfCancelled) {
+            this.streamid = id;
+            connection.putStream(this, streamid);
+            if (debug.on()) {
+                debug.log("Stream %d registered (cancelled: %b, registerIfCancelled: %b)",
+                        streamid, cancelled, registerIfCancelled);
+            }
+        }
+        return !cancelled;
     }
 
     void signalWindowUpdate() {
@@ -867,6 +924,7 @@ class Stream<T> extends ExchangeImpl<T> {
                     cancelImpl(t);
                     return;
                 }
+                int state = streamState;
 
                 do {
                     // handle COMPLETED;
@@ -879,7 +937,7 @@ class Stream<T> extends ExchangeImpl<T> {
                     }
 
                     // handle bytes to send downstream
-                    while (item.hasRemaining()) {
+                    while (item.hasRemaining() && state == 0) {
                         if (debug.on()) debug.log("trySend: %d", item.remaining());
                         DataFrame df = getDataFrame(item);
                         if (df == null) {
@@ -897,6 +955,7 @@ class Stream<T> extends ExchangeImpl<T> {
                                         + "Too many bytes in request body. Expected: "
                                         + contentLength + ", got: "
                                         + (contentLength - remainingContentLength);
+                                assert streamid > 0;
                                 connection.resetStream(streamid, ResetFrame.PROTOCOL_ERROR);
                                 throw new IOException(msg);
                             } else if (remainingContentLength == 0) {
@@ -907,14 +966,25 @@ class Stream<T> extends ExchangeImpl<T> {
                         } else {
                             assert !endStreamSent : "internal error, send data after END_STREAM flag";
                         }
+                        if ((state = streamState) != 0) {
+                            if (debug.on()) debug.log("trySend: cancelled: %s", String.valueOf(t));
+                            break;
+                        }
                         if (debug.on())
                             debug.log("trySend: sending: %d", df.getDataLength());
-                        connection.sendDataFrame(df);
+                        sendDataFrame(df);
                     }
+                    if (state != 0) break;
                     assert !item.hasRemaining();
                     ByteBuffer b = outgoing.removeFirst();
                     assert b == item;
                 } while (outgoing.peekFirst() != null);
+
+                if (state != 0) {
+                    t = errorRef.get();
+                    if (t == null) t = new IOException(ResetFrame.stringForCode(streamState));
+                    throw t;
+                }
 
                 if (debug.on()) debug.log("trySend: request 1");
                 subscription.request(1);
@@ -1118,7 +1188,11 @@ class Stream<T> extends ExchangeImpl<T> {
 
     @Override
     void cancel() {
-        cancel(new IOException("Stream " + streamid + " cancelled"));
+        if ((streamid == 0)) {
+            cancel(new IOException("Stream cancelled before streamid assigned"));
+        } else {
+            cancel(new IOException("Stream " + streamid + " cancelled"));
+        }
     }
 
     void onSubscriptionError(Throwable t) {
@@ -1151,9 +1225,13 @@ class Stream<T> extends ExchangeImpl<T> {
     // This method sends a RST_STREAM frame
     void cancelImpl(Throwable e) {
         errorRef.compareAndSet(null, e);
-        if (debug.on()) debug.log("cancelling stream {0}: {1}", streamid, e);
+        if (debug.on()) {
+            if (streamid == 0) debug.log("cancelling stream: %s", (Object)e);
+            else debug.log("cancelling stream %d: %s", streamid, e);
+        }
         if (Log.trace()) {
-            Log.logTrace("cancelling stream {0}: {1}\n", streamid, e);
+            if (streamid == 0) Log.logTrace("cancelling stream: {0}\n", e);
+            else Log.logTrace("cancelling stream {0}: {1}\n", streamid, e);
         }
         boolean closing;
         if (closing = !closed) { // assigning closing to !closed
@@ -1176,19 +1254,28 @@ class Stream<T> extends ExchangeImpl<T> {
         }
         try {
             // will send a RST_STREAM frame
-            if (streamid != 0) {
-                connection.decrementStreamsCount(streamid);
+            if (streamid != 0 && streamState == 0) {
                 e = Utils.getCompletionCause(e);
                 if (e instanceof EOFException) {
                     // read EOF: no need to try & send reset
+                    connection.decrementStreamsCount(streamid);
                     connection.closeStream(streamid);
                 } else {
-                    connection.resetStream(streamid, ResetFrame.CANCEL);
+                    // no use to send CANCEL if already closed.
+                    sendCancelStreamFrame();
                 }
             }
         } catch (Throwable ex) {
             Log.logError(ex);
         }
+    }
+
+    void sendCancelStreamFrame() {
+        // do not reset a stream until it has a streamid.
+        if (streamid > 0 && markStream(ResetFrame.CANCEL) == 0) {
+            connection.resetStream(streamid, ResetFrame.CANCEL);
+        }
+        close();
     }
 
     // This method doesn't send any frame
@@ -1404,6 +1491,19 @@ class Stream<T> extends ExchangeImpl<T> {
                 Log.logTrace("RECEIVED HEADER (streamid={0}): {1}: {2}",
                              streamid, n, v);
             }
+        }
+    }
+
+    private static final VarHandle STREAM_STATE;
+    private static final VarHandle DEREGISTERED;
+    static {
+        try {
+            STREAM_STATE = MethodHandles.lookup()
+                    .findVarHandle(Stream.class, "streamState", int.class);
+            DEREGISTERED = MethodHandles.lookup()
+                    .findVarHandle(Stream.class, "deRegistered", boolean.class);
+        } catch (Exception x) {
+            throw new ExceptionInInitializerError(x);
         }
     }
 }

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamCustom.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamIO.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesCustom.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesIO.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringCustom.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringIO.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesSanity.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesSanity.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8229822
  * @summary Tests what happens when push promise handlers and their
  *          response body handlers and subscribers throw unexpected exceptions.
  * @library /test/lib http2/server


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8229822](https://bugs.openjdk.org/browse/JDK-8229822) needs maintainer approval

### Issue
 * [JDK-8229822](https://bugs.openjdk.org/browse/JDK-8229822): ThrowingPushPromises tests sometimes fail due to EOF (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2895/head:pull/2895` \
`$ git checkout pull/2895`

Update a local copy of the PR: \
`$ git checkout pull/2895` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2895`

View PR using the GUI difftool: \
`$ git pr show -t 2895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2895.diff">https://git.openjdk.org/jdk11u-dev/pull/2895.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2895#issuecomment-2264985935)