### PR TITLE
8325022: Incorrect error message on client authentication

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
@@ -388,7 +388,7 @@ final class CertificateMessage {
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
                     throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                        "Empty server certificate chain");
+                        "Empty client certificate chain");
                 } else {
                     return;
                 }
@@ -405,7 +405,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             checkClientCerts(shc, x509Certs);
@@ -1253,7 +1253,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             // find out the types of client authentication used


### PR DESCRIPTION
Backport of [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022)

Testing
- Local: 
  - Build passed on `MacOS 14.6.1` on Apple M1 Max
  - No applicable test case
- Pipeline: 
  - Linux and Windows - passed
  - Mac - `adlparse.cpp:214:11: error: 'sprintf' is deprecated` - this message is not caused by current PR
    - `src/hotspot/share/adlc/archDesc.cpp:813:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.`
    - The line `archDesc.cpp:813` was introduced 13 years ago via https://github.com/openjdk/jdk11u-dev/commit/07d9df5a7fb64f3c7252686d647fa3a5da8e8771
    - See https://github.com/openjdk/jdk11u-dev/blame/master/src/hotspot/share/adlc/archDesc.cpp#L813C5-L813C46
- Testing Machine: SAP nightlies Passed on `2024-08-16` (No side effect caused by this PR found)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022) needs maintainer approval

### Issue
 * [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022): Incorrect error message on client authentication (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2899/head:pull/2899` \
`$ git checkout pull/2899`

Update a local copy of the PR: \
`$ git checkout pull/2899` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2899`

View PR using the GUI difftool: \
`$ git pr show -t 2899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2899.diff">https://git.openjdk.org/jdk11u-dev/pull/2899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2899#issuecomment-2276964406)