### PR TITLE
7156347: javax/swing/JList/6462008/bug6462008.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -696,7 +696,6 @@ javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
 javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
 javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
-javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JPopupMenu/6675802/bug6675802.java 8196097 windows-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all

--- a/test/jdk/javax/swing/JList/6462008/bug6462008.java
+++ b/test/jdk/javax/swing/JList/6462008/bug6462008.java
@@ -61,6 +61,7 @@ public class bug6462008 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             setAnchorLead(-1);
             robot.waitForIdle();
@@ -366,6 +367,7 @@ public class bug6462008 {
         frame.getContentPane().add(panel);
 
         frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
     }
 
     private static void checkSelection(int... sels) throws Exception {


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-7156347](https://bugs.openjdk.org/browse/JDK-7156347) needs maintainer approval

### Issue
 * [JDK-7156347](https://bugs.openjdk.org/browse/JDK-7156347): javax/swing/JList/6462008/bug6462008.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2900/head:pull/2900` \
`$ git checkout pull/2900`

Update a local copy of the PR: \
`$ git checkout pull/2900` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2900`

View PR using the GUI difftool: \
`$ git pr show -t 2900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2900.diff">https://git.openjdk.org/jdk11u-dev/pull/2900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2900#issuecomment-2277417278)