### PR TITLE
8316973: GC: Make TestDisableDefaultGC use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,13 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestDisableDefaultGC {
     public static void main(String[] args) throws Exception {
         // Start VM, disabling all possible default GCs
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder("-XX:-UseSerialGC",
-                                                                 "-XX:-UseParallelGC",
-                                                                 "-XX:-UseG1GC",
-                                                                 "-XX:-UseConcMarkSweepGC",
-                                                                 "-XX:+UnlockExperimentalVMOptions",
-                                                                 "-XX:-UseZGC",
-                                                                 "-version");
+        ProcessBuilder pb = GCArguments.createTestJvm("-XX:-UseSerialGC",
+                                                      "-XX:-UseParallelGC",
+                                                      "-XX:-UseG1GC",
+                                                      "-XX:-UseConcMarkSweepGC",
+                                                      "-XX:+UnlockExperimentalVMOptions",
+                                                      "-XX:-UseZGC",
+                                                      "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldMatch("Garbage collector not selected");
         output.shouldHaveExitValue(1);


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
jdk11 use '-XX:-UseZGC', not '-XX:-UseShenandoahGC', so not clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316973](https://bugs.openjdk.org/browse/JDK-8316973) needs maintainer approval

### Issue
 * [JDK-8316973](https://bugs.openjdk.org/browse/JDK-8316973): GC: Make TestDisableDefaultGC use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2904/head:pull/2904` \
`$ git checkout pull/2904`

Update a local copy of the PR: \
`$ git checkout pull/2904` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2904`

View PR using the GUI difftool: \
`$ git pr show -t 2904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2904.diff">https://git.openjdk.org/jdk11u-dev/pull/2904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2904#issuecomment-2277481262)