### PR TITLE
8334166: Enable binary check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,6 +5,7 @@ version=11.0.25
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+warning=issuestitle,binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332008](https://bugs.openjdk.org/browse/JDK-8332008) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8334166](https://bugs.openjdk.org/browse/JDK-8334166) needs maintainer approval

### Issues
 * [JDK-8334166](https://bugs.openjdk.org/browse/JDK-8334166): Enable binary check (**Bug** - P4 - Approved)
 * [JDK-8332008](https://bugs.openjdk.org/browse/JDK-8332008): Enable issuestitle check (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2907/head:pull/2907` \
`$ git checkout pull/2907`

Update a local copy of the PR: \
`$ git checkout pull/2907` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2907`

View PR using the GUI difftool: \
`$ git pr show -t 2907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2907.diff">https://git.openjdk.org/jdk11u-dev/pull/2907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2907#issuecomment-2288127412)