### PR TITLE
8220673: Add test library support for determining platform IP support

### DIFF
--- a/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
+++ b/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
@@ -112,7 +112,7 @@ public class UnreferencedDatagramSockets {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         // Create and close a DatagramSocket to warm up the FD count for side effects.
         try (DatagramSocket s = new DatagramSocket(0, lookupLocalHost())) {

--- a/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
+++ b/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /test/lib
  * @modules java.management java.base/java.io:+open java.base/java.net:+open
  * @run main/othervm UnreferencedDatagramSockets
  * @run main/othervm -Djava.net.preferIPv4Stack=true UnreferencedDatagramSockets
@@ -51,6 +52,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CountDownLatch;
 
 import com.sun.management.UnixOperatingSystemMXBean;
+
+import jdk.test.lib.net.IPSupport;
 
 public class UnreferencedDatagramSockets {
 
@@ -109,6 +112,7 @@ public class UnreferencedDatagramSockets {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         // Create and close a DatagramSocket to warm up the FD count for side effects.
         try (DatagramSocket s = new DatagramSocket(0, lookupLocalHost())) {

--- a/test/jdk/java/net/IPSupport/MinimumPermissions.java
+++ b/test/jdk/java/net/IPSupport/MinimumPermissions.java
@@ -34,7 +34,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class MinimumPermissions {
     public static void main(String[] args) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
     }
 }
 

--- a/test/jdk/java/net/IPSupport/MinimumPermissions.java
+++ b/test/jdk/java/net/IPSupport/MinimumPermissions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8220673
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
+ * @summary Ensure IPSupport works under a security manager.
+ * @run main/othervm/policy=MinimumPermissions.policy MinimumPermissions
+ */
+
+import jdk.test.lib.net.IPSupport;
+
+public class MinimumPermissions {
+    public static void main(String[] args) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+    }
+}
+

--- a/test/jdk/java/net/IPSupport/MinimumPermissions.policy
+++ b/test/jdk/java/net/IPSupport/MinimumPermissions.policy
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+grant codeBase "file:${test.classes}/../../../../test/lib/-" {
+    permission java.net.SocketPermission "localhost:0", "listen,resolve";
+    permission java.util.PropertyPermission "java.net.preferIPv4Stack", "read";
+};
+

--- a/test/jdk/java/net/IPSupport/MinimumPermissions.policy
+++ b/test/jdk/java/net/IPSupport/MinimumPermissions.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -24,5 +24,6 @@
 grant codeBase "file:${test.classes}/../../../../test/lib/-" {
     permission java.net.SocketPermission "localhost:0", "listen,resolve";
     permission java.util.PropertyPermission "java.net.preferIPv4Stack", "read";
+    permission java.util.PropertyPermission "java.net.preferIPv6Addresses", "read";
 };
 

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -27,6 +27,7 @@
 
 /* @test
  * @bug 7163874 8133015
+ * @library /test/lib
  * @summary InetAddress.isReachable is returning false
  *          for InetAdress 0.0.0.0 and ::0
  * @run main PingThis
@@ -40,41 +41,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import jdk.test.lib.net.IPSupport;
 
 public class PingThis {
-    private static boolean hasIPv6() throws Exception {
-        List<NetworkInterface> nics = Collections.list(NetworkInterface
-                .getNetworkInterfaces());
-        for (NetworkInterface nic : nics) {
-            List<InetAddress> addrs = Collections.list(nic.getInetAddresses());
-            for (InetAddress addr : addrs) {
-                if (addr instanceof Inet6Address)
-                    return true;
-            }
-        }
-
-        return false;
-    }
-
     public static void main(String args[]) throws Exception {
         if (System.getProperty("os.name").startsWith("Windows")) {
             return;
         }
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
-        boolean preferIPv4Stack = "true".equals(System
-                .getProperty("java.net.preferIPv4Stack"));
         List<String> addrs = new ArrayList<String>();
-        InetAddress inetAddress = null;
 
-        addrs.add("0.0.0.0");
-        if (!preferIPv4Stack) {
-            if (hasIPv6()) {
-                addrs.add("::0");
-            }
+        if (IPSupport.hasIPv4()) {
+            addrs.add("0.0.0.0");
+        }
+        if (IPSupport.hasIPv6()) {
+            addrs.add("::0");
         }
 
         for (String addr : addrs) {
-            inetAddress = InetAddress.getByName(addr);
+            InetAddress inetAddress = InetAddress.getByName(addr);
             System.out.println("The target ip is "
                     + inetAddress.getHostAddress());
             boolean isReachable = inetAddress.isReachable(3000);

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -48,7 +48,7 @@ public class PingThis {
         if (System.getProperty("os.name").startsWith("Windows")) {
             return;
         }
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         List<String> addrs = new ArrayList<String>();
 

--- a/test/jdk/java/net/Inet6Address/PreferIPv6AddressesTest.java
+++ b/test/jdk/java/net/Inet6Address/PreferIPv6AddressesTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8016521
+ * @library /test/lib
  * @summary InetAddress should not always re-order addresses returned from name
  *          service
  * @run main/othervm -Djava.net.preferIPv6Addresses=false PreferIPv6AddressesTest
@@ -38,6 +39,7 @@ import java.nio.channels.DatagramChannel;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import static java.lang.System.out;
+import jdk.test.lib.net.IPSupport;
 
 public class PreferIPv6AddressesTest {
 
@@ -50,7 +52,6 @@ public class PreferIPv6AddressesTest {
             System.getProperty("java.net.preferIPv6Addresses", "false");
 
     public static void main(String args[]) throws IOException {
-
         InetAddress addrs[];
         try {
             addrs = InetAddress.getAllByName(HOST_NAME);
@@ -66,7 +67,7 @@ public class PreferIPv6AddressesTest {
                 .filter(x -> addrs[x] instanceof Inet6Address)
                 .findFirst().orElse(-1);
 
-        out.println("IPv6 supported: " + IPv6Supported());
+        out.println("IPv6 supported: " + IPSupport.hasIPv6());
         out.println("Addresses: " + Arrays.asList(addrs));
 
         if (preferIPV6Address.equalsIgnoreCase("true") && firstIPv6Address != -1) {
@@ -81,10 +82,10 @@ public class PreferIPv6AddressesTest {
             assertAllv6Addresses(addrs, off, addrs.length);
             assertLoopbackAddress(Inet4Address.class);
             assertAnyLocalAddress(Inet4Address.class);
-        } else if (preferIPV6Address.equalsIgnoreCase("system") && IPv6Supported()) {
+        } else if (preferIPV6Address.equalsIgnoreCase("system") && IPSupport.hasIPv6()) {
             assertLoopbackAddress(Inet6Address.class);
             assertAnyLocalAddress(Inet6Address.class);
-        } else if (preferIPV6Address.equalsIgnoreCase("system") && !IPv6Supported()) {
+        } else if (preferIPV6Address.equalsIgnoreCase("system") && !IPSupport.hasIPv6()) {
             assertLoopbackAddress(Inet4Address.class);
             assertAnyLocalAddress(Inet4Address.class);
         }
@@ -119,14 +120,5 @@ public class PreferIPv6AddressesTest {
         if (!anyAddr.getClass().isAssignableFrom(expectedType))
             throw new RuntimeException("Expected " + expectedType
                     + ", got " + anyAddr.getClass());
-    }
-
-    static boolean IPv6Supported() throws IOException {
-        try {
-            DatagramChannel.open(StandardProtocolFamily.INET6);
-            return true;
-        } catch (UnsupportedOperationException x) {
-            return false;
-        }
     }
 }

--- a/test/jdk/java/net/InetAddress/GetLocalHostWithSM.java
+++ b/test/jdk/java/net/InetAddress/GetLocalHostWithSM.java
@@ -44,7 +44,7 @@ import jdk.test.lib.net.IPSupport;
 public class GetLocalHostWithSM {
 
         public static void main(String[] args) throws Exception {
-            IPSupport.skipIfCurrentConfigurationIsInvalid();
+            IPSupport.throwSkippedExceptionIfNonOperational();
 
             // try setting the local hostname
             InetAddress localHost = InetAddress.getLocalHost();

--- a/test/jdk/java/net/InetAddress/GetLocalHostWithSM.java
+++ b/test/jdk/java/net/InetAddress/GetLocalHostWithSM.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4531817 8026245
+ * @library /test/lib
  * @summary Inet[46]Address.localHost need doPrivileged
  * @run main/othervm GetLocalHostWithSM
  * @run main/othervm -Djava.net.preferIPv4Stack=true GetLocalHostWithSM
@@ -38,9 +39,12 @@ import java.security.Principal;
 import java.security.PrivilegedExceptionAction;
 import java.util.*;
 
+import jdk.test.lib.net.IPSupport;
+
 public class GetLocalHostWithSM {
 
         public static void main(String[] args) throws Exception {
+            IPSupport.skipIfCurrentConfigurationIsInvalid();
 
             // try setting the local hostname
             InetAddress localHost = InetAddress.getLocalHost();

--- a/test/jdk/java/net/MulticastSocket/JoinLeave.java
+++ b/test/jdk/java/net/MulticastSocket/JoinLeave.java
@@ -43,7 +43,7 @@ import jdk.test.lib.net.IPSupport;
 public class JoinLeave {
 
     public static void main(String args[]) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         InetAddress ip4Group = InetAddress.getByName("224.80.80.80");
         InetAddress ip6Group = InetAddress.getByName("ff02::a");
 

--- a/test/jdk/java/net/MulticastSocket/JoinLeave.java
+++ b/test/jdk/java/net/MulticastSocket/JoinLeave.java
@@ -28,6 +28,7 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 
 import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 /**
  * @test
@@ -42,6 +43,7 @@ import jdk.test.lib.NetworkConfiguration;
 public class JoinLeave {
 
     public static void main(String args[]) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         InetAddress ip4Group = InetAddress.getByName("224.80.80.80");
         InetAddress ip6Group = InetAddress.getByName("ff02::a");
 

--- a/test/jdk/java/net/MulticastSocket/Promiscuous.java
+++ b/test/jdk/java/net/MulticastSocket/Promiscuous.java
@@ -35,6 +35,7 @@ import static java.lang.System.out;
 
 import java.io.UncheckedIOException;
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 import jdk.test.lib.NetworkConfiguration;
 
@@ -170,6 +171,8 @@ public class Promiscuous {
     }
 
     public static void main(String args[]) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         String os = System.getProperty("os.name");
 
         // Requires IP_MULTICAST_ALL on Linux (new since 2.6.31) so skip

--- a/test/jdk/java/net/MulticastSocket/Promiscuous.java
+++ b/test/jdk/java/net/MulticastSocket/Promiscuous.java
@@ -171,7 +171,7 @@ public class Promiscuous {
     }
 
     public static void main(String args[]) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         String os = System.getProperty("os.name");
 

--- a/test/jdk/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
+++ b/test/jdk/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
@@ -27,6 +27,7 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 
 import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 /**
  * @test
@@ -41,6 +42,7 @@ import jdk.test.lib.NetworkConfiguration;
 public class SetGetNetworkInterfaceTest {
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         NetworkConfiguration nc = NetworkConfiguration.probe();
         try (MulticastSocket ms = new MulticastSocket()) {
             nc.multicastInterfaces(true).forEach(nif -> setGetNetworkInterface(ms, nif));

--- a/test/jdk/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
+++ b/test/jdk/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.net.IPSupport;
 public class SetGetNetworkInterfaceTest {
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         NetworkConfiguration nc = NetworkConfiguration.probe();
         try (MulticastSocket ms = new MulticastSocket()) {
             nc.multicastInterfaces(true).forEach(nif -> setGetNetworkInterface(ms, nif));

--- a/test/jdk/java/net/MulticastSocket/Test.java
+++ b/test/jdk/java/net/MulticastSocket/Test.java
@@ -159,7 +159,7 @@ public class Test {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         Test t = new Test();
 

--- a/test/jdk/java/net/MulticastSocket/Test.java
+++ b/test/jdk/java/net/MulticastSocket/Test.java
@@ -29,6 +29,7 @@ import java.net.MulticastSocket;
 import java.net.SocketTimeoutException;
 
 import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 /**
  * @test
@@ -158,6 +159,8 @@ public class Test {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         Test t = new Test();
 
         if (args.length == 0) {

--- a/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
+++ b/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
@@ -107,7 +107,7 @@ public class UnreferencedMulticastSockets {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         // Create and close a MulticastSocket to warm up the FD count for side effects.
         try (MulticastSocket s = new MulticastSocket(0)) {

--- a/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
+++ b/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /test/lib
  * @modules java.management java.base/java.io:+open java.base/java.net:+open
  * @run main/othervm -Djava.net.preferIPv4Stack=true UnreferencedMulticastSockets
  * @run main/othervm UnreferencedMulticastSockets
@@ -49,6 +50,8 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
+import jdk.test.lib.net.IPSupport;
 
 import com.sun.management.UnixOperatingSystemMXBean;
 
@@ -104,6 +107,7 @@ public class UnreferencedMulticastSockets {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         // Create and close a MulticastSocket to warm up the FD count for side effects.
         try (MulticastSocket s = new MulticastSocket(0)) {

--- a/test/jdk/java/net/NetworkInterface/NetworkInterfaceStreamTest.java
+++ b/test/jdk/java/net/NetworkInterface/NetworkInterfaceStreamTest.java
@@ -52,7 +52,7 @@ public class NetworkInterfaceStreamTest extends OpTestCase {
 
     @BeforeTest
     void setup() {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
     }
 
     @Test

--- a/test/jdk/java/net/NetworkInterface/NetworkInterfaceStreamTest.java
+++ b/test/jdk/java/net/NetworkInterface/NetworkInterfaceStreamTest.java
@@ -24,12 +24,13 @@
 /* @test
  * @bug 8081678 8131155
  * @summary Tests for stream returning methods
- * @library /lib/testlibrary/bootlib
+ * @library /lib/testlibrary/bootlib /test/lib
  * @build java.base/java.util.stream.OpTestCase
  * @run testng/othervm NetworkInterfaceStreamTest
  * @run testng/othervm -Djava.net.preferIPv4Stack=true NetworkInterfaceStreamTest
  */
 
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
@@ -43,9 +44,16 @@ import java.util.stream.OpTestCase;
 import java.util.stream.Stream;
 import java.util.stream.TestData;
 
+import jdk.test.lib.net.IPSupport;
+
 public class NetworkInterfaceStreamTest extends OpTestCase {
 
     private final static boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
+    @BeforeTest
+    void setup() {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+    }
 
     @Test
     public void testNetworkInterfaces() throws SocketException {

--- a/test/jdk/java/net/NetworkInterface/Test.java
+++ b/test/jdk/java/net/NetworkInterface/Test.java
@@ -37,7 +37,7 @@ public class Test {
     static final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         Enumeration nifs = NetworkInterface.getNetworkInterfaces();
 

--- a/test/jdk/java/net/NetworkInterface/Test.java
+++ b/test/jdk/java/net/NetworkInterface/Test.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4405354 6594296 8058216
+ * @library /test/lib
  * @run main/othervm -Xcheck:jni Test
  * @run main/othervm -Xcheck:jni -Djava.net.preferIPv4Stack=true Test
  * @summary Basic tests for NetworkInterface
@@ -30,11 +31,13 @@
 import java.net.NetworkInterface;
 import java.net.InetAddress;
 import java.util.Enumeration;
+import jdk.test.lib.net.IPSupport;
 
 public class Test {
     static final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         Enumeration nifs = NetworkInterface.getNetworkInterfaces();
 

--- a/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
+++ b/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8067105
+ * @library /test/lib
  * @summary Socket returned by ServerSocket.accept() is inherited by child process on Windows
  * @author Chris Hegarty
  */
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import jdk.test.lib.net.IPSupport;
 
 public class AcceptInheritHandle {
 
@@ -81,7 +83,9 @@ public class AcceptInheritHandle {
 
     static void testJavaNetServerSocket() throws Exception {
         test(ServerSocketProducer.JAVA_NET);
-        test(ServerSocketProducer.JAVA_NET, "-Djava.net.preferIPv4Stack=true");
+        if (IPSupport.hasIPv4()) {
+            test(ServerSocketProducer.JAVA_NET, "-Djava.net.preferIPv4Stack=true");
+        }
     }
     static void testNioServerSocketChannel() throws Exception {
         test(ServerSocketProducer.NIO_CHANNELS);

--- a/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
+++ b/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
@@ -110,7 +110,7 @@ public class UnreferencedSockets {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         InetAddress lba = InetAddress.getLoopbackAddress();
         // Create and close a ServerSocket to warm up the FD count for side effects.

--- a/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
+++ b/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /test/lib
  * @modules java.management java.base/java.io:+open java.base/java.net:+open
  * @run main/othervm UnreferencedSockets
  * @run main/othervm -Djava.net.preferIPv4Stack=true UnreferencedSockets
@@ -51,6 +52,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.management.UnixOperatingSystemMXBean;
+
+import jdk.test.lib.net.IPSupport;
 
 public class UnreferencedSockets {
 
@@ -107,6 +110,7 @@ public class UnreferencedSockets {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         InetAddress lba = InetAddress.getLoopbackAddress();
         // Create and close a ServerSocket to warm up the FD count for side effects.

--- a/test/jdk/java/net/Socket/AddressTest.java
+++ b/test/jdk/java/net/Socket/AddressTest.java
@@ -155,7 +155,7 @@ public class AddressTest {
     }
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         new AddressTest();
     }
 }

--- a/test/jdk/java/net/Socket/AddressTest.java
+++ b/test/jdk/java/net/Socket/AddressTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4507501
+ * @library /test/lib
  * @summary Test various methods that should throw IAE when passed improper
  *          SocketAddress
  * @run main AddressTest
@@ -31,6 +32,7 @@
  */
 
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class AddressTest {
     class MySocketAddress extends SocketAddress {
@@ -153,6 +155,7 @@ public class AddressTest {
     }
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         new AddressTest();
     }
 }

--- a/test/jdk/java/net/Socket/B6210227.java
+++ b/test/jdk/java/net/Socket/B6210227.java
@@ -37,7 +37,7 @@ import jdk.test.lib.net.IPSupport;
 public class B6210227 {
     public static void main(String[] args) throws Exception
     {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket ss = new ServerSocket(0);
         int port = ss.getLocalPort();

--- a/test/jdk/java/net/Socket/B6210227.java
+++ b/test/jdk/java/net/Socket/B6210227.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6210227
+ * @library /test/lib
  * @summary  REGRESSION: Socket.getLocalAddress() returns address of 0.0.0.0 on outbound TCP
  * @run main B6210227
  * @run main/othervm -Djava.net.preferIPv4Stack=true B6210227
@@ -31,10 +32,13 @@
 
 import java.util.*;
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class B6210227 {
     public static void main(String[] args) throws Exception
     {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket ss = new ServerSocket(0);
         int port = ss.getLocalPort();
 

--- a/test/jdk/java/net/Socket/CloseAvailable.java
+++ b/test/jdk/java/net/Socket/CloseAvailable.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4091859
+ * @library /test/lib
  * @summary Test Socket.available()
  * @run main CloseAvailable
  * @run main/othervm -Djava.net.preferIPv4Stack=true CloseAvailable
@@ -31,7 +32,7 @@
 
 import java.net.*;
 import java.io.*;
-
+import jdk.test.lib.net.IPSupport;
 
 public class CloseAvailable implements Runnable {
     static ServerSocket ss;
@@ -39,6 +40,8 @@ public class CloseAvailable implements Runnable {
     static int port;
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         boolean error = true;
         addr = InetAddress.getLocalHost();
         ss = new ServerSocket(0);

--- a/test/jdk/java/net/Socket/CloseAvailable.java
+++ b/test/jdk/java/net/Socket/CloseAvailable.java
@@ -40,7 +40,7 @@ public class CloseAvailable implements Runnable {
     static int port;
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         boolean error = true;
         addr = InetAddress.getLocalHost();

--- a/test/jdk/java/net/Socket/DeadlockTest.java
+++ b/test/jdk/java/net/Socket/DeadlockTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class DeadlockTest {
     public static void main(String [] argv) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket ss = new ServerSocket(0);
         Socket clientSocket = new Socket();

--- a/test/jdk/java/net/Socket/DeadlockTest.java
+++ b/test/jdk/java/net/Socket/DeadlockTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4176738
+ * @library /test/lib
  * @summary Make sure a deadlock situation
  *     would not occur
  * @run main DeadlockTest
@@ -32,9 +33,12 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class DeadlockTest {
     public static void main(String [] argv) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket ss = new ServerSocket(0);
         Socket clientSocket = new Socket();
 

--- a/test/jdk/java/net/Socket/GetLocalAddress.java
+++ b/test/jdk/java/net/Socket/GetLocalAddress.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4106601 8026245 8071424
+ * @library /test/lib
  * @run main/othervm GetLocalAddress
  * @run main/othervm -Djava.net.preferIPv4Stack=true GetLocalAddress
  * @run main/othervm -Djava.net.preferIPv6Addresses=true GetLocalAddress
@@ -32,6 +33,7 @@
  */
 
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class GetLocalAddress implements Runnable {
     static ServerSocket ss;
@@ -39,6 +41,8 @@ public class GetLocalAddress implements Runnable {
     static int port;
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         testBindNull();
 
         boolean      error = true;

--- a/test/jdk/java/net/Socket/GetLocalAddress.java
+++ b/test/jdk/java/net/Socket/GetLocalAddress.java
@@ -41,7 +41,7 @@ public class GetLocalAddress implements Runnable {
     static int port;
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         testBindNull();
 

--- a/test/jdk/java/net/Socket/HttpProxy.java
+++ b/test/jdk/java/net/Socket/HttpProxy.java
@@ -50,7 +50,7 @@ public class HttpProxy {
     static final int SO_TIMEOUT = 15000;
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         String host;
         int port;

--- a/test/jdk/java/net/Socket/HttpProxy.java
+++ b/test/jdk/java/net/Socket/HttpProxy.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6370908
+ * @library /test/lib
  * @summary Add support for HTTP_CONNECT proxy in Socket class
  * @modules java.base/sun.net.www
  * @run main HttpProxy
@@ -40,6 +41,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
+import jdk.test.lib.net.IPSupport;
 import sun.net.www.MessageHeader;
 
 public class HttpProxy {
@@ -48,6 +50,8 @@ public class HttpProxy {
     static final int SO_TIMEOUT = 15000;
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         String host;
         int port;
         if (args.length == 0) {

--- a/test/jdk/java/net/Socket/InheritHandle.java
+++ b/test/jdk/java/net/Socket/InheritHandle.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug  6598160
+ * @library /test/lib
  * @summary Windows IPv6 Socket implementation doesn't set the handle to not inherit
  * @author Chris Hegarty
  * @run main InheritHandle
@@ -33,6 +34,7 @@ import java.net.BindException;
 import java.net.ServerSocket;
 import java.io.File;
 import java.io.IOException;
+import jdk.test.lib.net.IPSupport;
 
 /**
  * This test is only really applicable to Windows machines that are running IPv6, but
@@ -45,6 +47,8 @@ public class InheritHandle
                          "bin" + File.separator + "java";
 
     public static void main(String[] args) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         if (args.length == 1) {
             doWait();
         } else {

--- a/test/jdk/java/net/Socket/InheritHandle.java
+++ b/test/jdk/java/net/Socket/InheritHandle.java
@@ -47,7 +47,7 @@ public class InheritHandle
                          "bin" + File.separator + "java";
 
     public static void main(String[] args) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         if (args.length == 1) {
             doWait();

--- a/test/jdk/java/net/Socket/InheritTimeout.java
+++ b/test/jdk/java/net/Socket/InheritTimeout.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4508149
+ * @library /test/lib
  * @summary Setting ServerSocket.setSoTimeout shouldn't cause
  *          the timeout to be inherited by accepted connections
  * @run main InheritTimeout
@@ -32,6 +33,7 @@
 
 import java.net.*;
 import java.io.InputStream;
+import jdk.test.lib.net.IPSupport;
 
 public class InheritTimeout {
 
@@ -92,6 +94,7 @@ public class InheritTimeout {
    }
 
    public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         new InheritTimeout();
    }
 }

--- a/test/jdk/java/net/Socket/InheritTimeout.java
+++ b/test/jdk/java/net/Socket/InheritTimeout.java
@@ -94,7 +94,7 @@ public class InheritTimeout {
    }
 
    public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         new InheritTimeout();
    }
 }

--- a/test/jdk/java/net/Socket/LingerTest.java
+++ b/test/jdk/java/net/Socket/LingerTest.java
@@ -107,7 +107,7 @@ public class LingerTest {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         InetAddress loopback = InetAddress.getLoopbackAddress();
         ServerSocket ss = new ServerSocket(0, 50, loopback);

--- a/test/jdk/java/net/Socket/LingerTest.java
+++ b/test/jdk/java/net/Socket/LingerTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4796166
+ * @library /test/lib
  * @summary Linger interval delays usage of released file descriptor
  * @run main LingerTest
  * @run main/othervm -Djava.net.preferIPv4Stack=true LingerTest
@@ -31,6 +32,7 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class LingerTest {
 
@@ -105,6 +107,8 @@ public class LingerTest {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         InetAddress loopback = InetAddress.getLoopbackAddress();
         ServerSocket ss = new ServerSocket(0, 50, loopback);
 

--- a/test/jdk/java/net/Socket/LinkLocal.java
+++ b/test/jdk/java/net/Socket/LinkLocal.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4469866
+ * @library /test/lib
  * @summary Connecting to a link-local IPv6 address should not
  *          causes a SocketException to be thrown.
  * @library /test/lib
@@ -33,11 +34,12 @@
  * @run main/othervm -Djava.net.preferIPv4Stack=true LinkLocal
  */
 
-import jdk.test.lib.NetworkConfiguration;
-
 import java.net.*;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 public class LinkLocal {
 
@@ -120,6 +122,7 @@ public class LinkLocal {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         /*
          * If an argument is provided ensure that it's

--- a/test/jdk/java/net/Socket/LinkLocal.java
+++ b/test/jdk/java/net/Socket/LinkLocal.java
@@ -122,7 +122,7 @@ public class LinkLocal {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         /*
          * If an argument is provided ensure that it's

--- a/test/jdk/java/net/Socket/ProxyCons.java
+++ b/test/jdk/java/net/Socket/ProxyCons.java
@@ -82,7 +82,7 @@ public class ProxyCons {
     }
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ProxyCons c = new ProxyCons();
         c.test();

--- a/test/jdk/java/net/Socket/ProxyCons.java
+++ b/test/jdk/java/net/Socket/ProxyCons.java
@@ -24,12 +24,15 @@
 /*
  * @test
  * @bug 4097826
+ * @library /test/lib
  * @summary SOCKS support inadequate
  * @run main/timeout=40/othervm -DsocksProxyHost=nonexistant ProxyCons
  * @run main/timeout=40/othervm -DsocksProxyHost=nonexistant -Djava.net.preferIPv4Stack=true ProxyCons
  */
 
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
+
 public class ProxyCons {
     class Server extends Thread {
         ServerSocket server;
@@ -79,6 +82,8 @@ public class ProxyCons {
     }
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ProxyCons c = new ProxyCons();
         c.test();
     }

--- a/test/jdk/java/net/Socket/RST.java
+++ b/test/jdk/java/net/Socket/RST.java
@@ -82,7 +82,7 @@ public class RST implements Runnable {
 
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         new RST();
     }

--- a/test/jdk/java/net/Socket/RST.java
+++ b/test/jdk/java/net/Socket/RST.java
@@ -22,13 +22,16 @@
  */
 
 /*
+ * @test
  * @bug 4468997
+ * @library /test/lib
  * @summary SO_LINGER is ignored on Windows with Winsock 2
  * @run main RST
  * @run main/othervm -Djava.net.preferIPv4Stack=true RST
  */
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class RST implements Runnable {
 
@@ -79,6 +82,8 @@ public class RST implements Runnable {
 
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         new RST();
     }
 }

--- a/test/jdk/java/net/Socket/ReadTimeout.java
+++ b/test/jdk/java/net/Socket/ReadTimeout.java
@@ -36,7 +36,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class ReadTimeout  {
     public static void main(String args[]) throws Exception {
-    IPSupport.skipIfCurrentConfigurationIsInvalid();
+    IPSupport.throwSkippedExceptionIfNonOperational();
 
     InetAddress  sin = null;
     Socket       soc = null,soc1 = null;

--- a/test/jdk/java/net/Socket/ReadTimeout.java
+++ b/test/jdk/java/net/Socket/ReadTimeout.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4169831
+ * @library /test/lib
  * @summary test timeout on a socket read
  * @run main/timeout=15 ReadTimeout
  * @run main/othervm/timeout=15 -Djava.net.preferIPv4Stack=true ReadTimeout
@@ -31,9 +32,12 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class ReadTimeout  {
     public static void main(String args[]) throws Exception {
+    IPSupport.skipIfCurrentConfigurationIsInvalid();
+
     InetAddress  sin = null;
     Socket       soc = null,soc1 = null;
     InputStream  is = null;

--- a/test/jdk/java/net/Socket/RejectIPv6.java
+++ b/test/jdk/java/net/Socket/RejectIPv6.java
@@ -39,7 +39,7 @@ import jdk.test.lib.net.IPSupport;
 public class RejectIPv6 {
 
     public static void main(String [] argv) throws Throwable {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket serverSocket = new ServerSocket(0);
         serverSocket.setSoTimeout(1000);

--- a/test/jdk/java/net/Socket/RejectIPv6.java
+++ b/test/jdk/java/net/Socket/RejectIPv6.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8201510
+ * @library /test/lib
  * @summary Make sure IPv6 addresses are rejected when the System option
  *          java.net.preferIPv4Stack is set to true
  * @run main/othervm -Djava.net.preferIPv4Stack=true RejectIPv6
@@ -33,10 +34,13 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import jdk.test.lib.net.IPSupport;
 
 public class RejectIPv6 {
 
     public static void main(String [] argv) throws Throwable {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket serverSocket = new ServerSocket(0);
         serverSocket.setSoTimeout(1000);
         int serverPort = serverSocket.getLocalPort();

--- a/test/jdk/java/net/Socket/SetSoLinger.java
+++ b/test/jdk/java/net/Socket/SetSoLinger.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4151834
+ * @library /test/lib
  * @summary Test Socket.setSoLinger
  * @run main SetSoLinger
  * @run main/othervm -Djava.net.preferIPv4Stack=true SetSoLinger
@@ -31,11 +32,14 @@
  */
 
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class SetSoLinger {
     static final int LINGER = 65546;
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         int value;
         InetAddress addr = InetAddress.getLocalHost();
         ServerSocket ss = new ServerSocket();

--- a/test/jdk/java/net/Socket/SetSoLinger.java
+++ b/test/jdk/java/net/Socket/SetSoLinger.java
@@ -38,7 +38,7 @@ public class SetSoLinger {
     static final int LINGER = 65546;
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         int value;
         InetAddress addr = InetAddress.getLocalHost();

--- a/test/jdk/java/net/Socket/ShutdownInput.java
+++ b/test/jdk/java/net/Socket/ShutdownInput.java
@@ -45,7 +45,7 @@ public class ShutdownInput {
     static boolean failed = false;
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         InetAddress iaddr = InetAddress.getLocalHost();
 

--- a/test/jdk/java/net/Socket/ShutdownInput.java
+++ b/test/jdk/java/net/Socket/ShutdownInput.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 7014860
+ * @library /test/lib
  * @summary Socket.getInputStream().available() not clear for
  *          case that connection is shutdown for reading
  * @run main ShutdownInput
@@ -38,11 +39,14 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import jdk.test.lib.net.IPSupport;
 
 public class ShutdownInput {
     static boolean failed = false;
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         InetAddress iaddr = InetAddress.getLocalHost();
 
         try ( ServerSocket ss = new ServerSocket(0);

--- a/test/jdk/java/net/Socket/SocksConnectTimeout.java
+++ b/test/jdk/java/net/Socket/SocksConnectTimeout.java
@@ -50,7 +50,7 @@ public class SocksConnectTimeout {
     static int failed, passed;
 
     public static void main(String[] args) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         try {
             serverSocket = new ServerSocket();

--- a/test/jdk/java/net/Socket/SocksConnectTimeout.java
+++ b/test/jdk/java/net/Socket/SocksConnectTimeout.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6223635
+ * @library /test/lib
  * @summary Code hangs at connect call even when Timeout is specified
  * @run main SocksConnectTimeout
  * @run main/othervm -Djava.net.preferIPv4Stack=true SocksConnectTimeout
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.io.Closeable;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import jdk.test.lib.net.IPSupport;
 
 public class SocksConnectTimeout {
     static ServerSocket serverSocket;
@@ -48,6 +50,8 @@ public class SocksConnectTimeout {
     static int failed, passed;
 
     public static void main(String[] args) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         try {
             serverSocket = new ServerSocket();
             InetAddress localHost = InetAddress.getLocalHost();

--- a/test/jdk/java/net/Socket/TestAfterClose.java
+++ b/test/jdk/java/net/Socket/TestAfterClose.java
@@ -40,7 +40,7 @@ public class TestAfterClose
     static int failCount;
 
     public static void main(String[] args) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         try {
             InetAddress loopback = InetAddress.getLoopbackAddress();

--- a/test/jdk/java/net/Socket/TestAfterClose.java
+++ b/test/jdk/java/net/Socket/TestAfterClose.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6505016
+ * @library /test/lib
  * @summary Socket spec should clarify what getInetAddress/getPort/etc return
  *          after the Socket is closed
  * @run main TestAfterClose
@@ -32,12 +33,15 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class TestAfterClose
 {
     static int failCount;
 
     public static void main(String[] args) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         try {
             InetAddress loopback = InetAddress.getLoopbackAddress();
             ServerSocket ss = new ServerSocket(0, 0, loopback);

--- a/test/jdk/java/net/Socket/TestClose.java
+++ b/test/jdk/java/net/Socket/TestClose.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 4408755
+ * @library /test/lib
  * @summary This tests whether it's possible to get some informations
  *          out of a closed socket. This is for backward compatibility
  *          purposes.
@@ -31,10 +32,13 @@
  */
 
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class TestClose {
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket ss;
         Socket s;
         InetAddress ad1, ad2;

--- a/test/jdk/java/net/Socket/TestClose.java
+++ b/test/jdk/java/net/Socket/TestClose.java
@@ -37,7 +37,7 @@ import jdk.test.lib.net.IPSupport;
 public class TestClose {
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket ss;
         Socket s;

--- a/test/jdk/java/net/Socket/TestTcpNoDelay.java
+++ b/test/jdk/java/net/Socket/TestTcpNoDelay.java
@@ -37,7 +37,7 @@ import jdk.test.lib.net.IPSupport;
 public class TestTcpNoDelay
 {
     public static void main(String[] args) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         try {
             Socket socket = new Socket();

--- a/test/jdk/java/net/Socket/TestTcpNoDelay.java
+++ b/test/jdk/java/net/Socket/TestTcpNoDelay.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6404388
+ * @library /test/lib
  * @summary VISTA: Socket setTcpNoDelay & setKeepAlive working incorrectly
  * @run main TestTcpNoDelay
  * @run main/othervm -Djava.net.preferIPv4Stack=true TestTcpNoDelay
@@ -31,10 +32,13 @@
 
 import java.net.*;
 import java.io.IOException;
+import jdk.test.lib.net.IPSupport;
 
 public class TestTcpNoDelay
 {
     public static void main(String[] args) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         try {
             Socket socket = new Socket();
             boolean on = socket.getTcpNoDelay();

--- a/test/jdk/java/net/Socket/Timeout.java
+++ b/test/jdk/java/net/Socket/Timeout.java
@@ -35,7 +35,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class Timeout {
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         boolean success = false;
         ServerSocket sock = new ServerSocket(0);

--- a/test/jdk/java/net/Socket/Timeout.java
+++ b/test/jdk/java/net/Socket/Timeout.java
@@ -24,15 +24,19 @@
 /**
  * @test
  * @bug 4163126
+ * @library /test/lib
  * @summary  test to see if timeout hangs
  * @run main/timeout=15 Timeout
  * @run main/othervm/timeout=15 -Djava.net.preferIPv4Stack=true Timeout
  */
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class Timeout {
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         boolean success = false;
         ServerSocket sock = new ServerSocket(0);
         try {

--- a/test/jdk/java/net/Socket/TrafficClass.java
+++ b/test/jdk/java/net/Socket/TrafficClass.java
@@ -63,7 +63,7 @@ public class TrafficClass {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         DatagramSocket ds = new DatagramSocket();
         testDatagramSocket(ds);

--- a/test/jdk/java/net/Socket/TrafficClass.java
+++ b/test/jdk/java/net/Socket/TrafficClass.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4511783
+ * @library /test/lib
  * @summary Test that setTrafficClass/getTraffiClass don't
  *          throw an exception
  * @run main TrafficClass
@@ -32,6 +33,7 @@
 import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
+import jdk.test.lib.net.IPSupport;
 
 public class TrafficClass {
 
@@ -61,6 +63,7 @@ public class TrafficClass {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         DatagramSocket ds = new DatagramSocket();
         testDatagramSocket(ds);

--- a/test/jdk/java/net/Socket/UrgentDataTest.java
+++ b/test/jdk/java/net/Socket/UrgentDataTest.java
@@ -53,7 +53,7 @@ public class UrgentDataTest {
     }
 
     public static void main (String args[]) {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         try {
             UrgentDataTest test = new UrgentDataTest ();

--- a/test/jdk/java/net/Socket/UrgentDataTest.java
+++ b/test/jdk/java/net/Socket/UrgentDataTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4092038
+ * @library /test/lib
  * @summary TCP Urgent data support
  * @run main UrgentDataTest
  * @run main/othervm -Djava.net.preferIPv4Stack=true UrgentDataTest
@@ -31,6 +32,7 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class UrgentDataTest {
 
@@ -51,6 +53,8 @@ public class UrgentDataTest {
     }
 
     public static void main (String args[]) {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         try {
             UrgentDataTest test = new UrgentDataTest ();
             if (args.length == 0) {

--- a/test/jdk/java/net/Socket/asyncClose/AsyncClose.java
+++ b/test/jdk/java/net/Socket/asyncClose/AsyncClose.java
@@ -40,7 +40,7 @@ import static java.util.concurrent.CompletableFuture.*;
 public class AsyncClose {
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         AsyncCloseTest tests[] = {
             new Socket_getInputStream_read(),

--- a/test/jdk/java/net/Socket/asyncClose/AsyncClose.java
+++ b/test/jdk/java/net/Socket/asyncClose/AsyncClose.java
@@ -24,11 +24,13 @@
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import jdk.test.lib.net.IPSupport;
 import static java.util.concurrent.CompletableFuture.*;
 
 /*
  * @test
  * @bug 4344135
+ * @library /test/lib
  * @summary Check that {Socket,ServerSocket,DatagramSocket}.close will
  *          cause any thread blocked on the socket to throw a SocketException.
  * @run main AsyncClose
@@ -38,6 +40,7 @@ import static java.util.concurrent.CompletableFuture.*;
 public class AsyncClose {
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
 
         AsyncCloseTest tests[] = {
             new Socket_getInputStream_read(),

--- a/test/jdk/java/net/Socket/asyncClose/BrokenPipe.java
+++ b/test/jdk/java/net/Socket/asyncClose/BrokenPipe.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4511404
+ * @library /test/lib
  * @summary Check that a broken pipe error doesn't throw an exception
  *          indicating the socket is closed.
  * @run main BrokenPipe
@@ -31,6 +32,7 @@
  */
 import java.io.*;
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class BrokenPipe {
 
@@ -53,6 +55,8 @@ public class BrokenPipe {
     }
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket ss = new ServerSocket(0);
         Socket client = new Socket(InetAddress.getLocalHost(),
                                    ss.getLocalPort());

--- a/test/jdk/java/net/Socket/asyncClose/BrokenPipe.java
+++ b/test/jdk/java/net/Socket/asyncClose/BrokenPipe.java
@@ -55,7 +55,7 @@ public class BrokenPipe {
     }
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket ss = new ServerSocket(0);
         Socket client = new Socket(InetAddress.getLocalHost(),

--- a/test/jdk/java/net/Socket/setReuseAddress/Basic.java
+++ b/test/jdk/java/net/Socket/setReuseAddress/Basic.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4476378
+ * @library /test/lib
  * @summary Check the specific behaviour of the setReuseAddress(boolean)
  *          method.
  * @run main Basic
@@ -36,6 +37,7 @@
  *                   -Djava.net.preferIPv4Stack=true Basic
  */
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class Basic {
 
@@ -226,6 +228,7 @@ public class Basic {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         new Basic();
     }
 

--- a/test/jdk/java/net/Socket/setReuseAddress/Basic.java
+++ b/test/jdk/java/net/Socket/setReuseAddress/Basic.java
@@ -228,7 +228,7 @@ public class Basic {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         new Basic();
     }
 

--- a/test/jdk/java/net/Socket/setReuseAddress/Restart.java
+++ b/test/jdk/java/net/Socket/setReuseAddress/Restart.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4476378
+ * @library /test/lib
  * @summary Check that SO_REUSEADDR allows a server to restart
  *          after a crash.
  * @run main Restart
@@ -36,6 +37,7 @@
  *                   -Djava.net.preferIPv4Stack=true Restart
  */
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class Restart {
 
@@ -47,6 +49,8 @@ public class Restart {
      */
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ServerSocket ss = new ServerSocket(0);
         Socket s1 = null, s2 = null;
         try {

--- a/test/jdk/java/net/Socket/setReuseAddress/Restart.java
+++ b/test/jdk/java/net/Socket/setReuseAddress/Restart.java
@@ -49,7 +49,7 @@ public class Restart {
      */
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ServerSocket ss = new ServerSocket(0);
         Socket s1 = null, s2 = null;

--- a/test/jdk/java/net/SocketInputStream/SocketClosedException.java
+++ b/test/jdk/java/net/SocketInputStream/SocketClosedException.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4681556
+ * @library /test/lib
  * @summary Wrong text if a read is performed on a socket after it
  *      has been closed
  * @run main SocketClosedException
@@ -32,6 +33,7 @@
 
 import java.io.*;
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class SocketClosedException {
     static void doServerSide() throws Exception {
@@ -61,6 +63,7 @@ public class SocketClosedException {
     static Exception serverException = null;
 
     public static void main(String[] args) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         serverSocket = new ServerSocket(0);
         startServer();
         try {

--- a/test/jdk/java/net/SocketInputStream/SocketClosedException.java
+++ b/test/jdk/java/net/SocketInputStream/SocketClosedException.java
@@ -63,7 +63,7 @@ public class SocketClosedException {
     static Exception serverException = null;
 
     public static void main(String[] args) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         serverSocket = new ServerSocket(0);
         startServer();
         try {

--- a/test/jdk/java/net/SocketInputStream/SocketTimeout.java
+++ b/test/jdk/java/net/SocketInputStream/SocketTimeout.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4158021
+ * @library /test/lib
  * @summary cannot distinguish Thread.interrupt and Socket.setSoTimeout exceptions
  * @run main SocketTimeout
  * @run main/othervm -Djava.net.preferIPv4Stack=true SocketTimeout
@@ -31,11 +32,13 @@
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.IPSupport;
 
 public class SocketTimeout  {
     static final int TIMEOUT = 1000;
 
     public static void main(String args[]) throws Exception {
+    IPSupport.skipIfCurrentConfigurationIsInvalid();
     InetAddress  sin = InetAddress.getLocalHost();
     Socket       soc = null,soc1 = null;
     InputStream  is = null;

--- a/test/jdk/java/net/SocketInputStream/SocketTimeout.java
+++ b/test/jdk/java/net/SocketInputStream/SocketTimeout.java
@@ -38,7 +38,7 @@ public class SocketTimeout  {
     static final int TIMEOUT = 1000;
 
     public static void main(String args[]) throws Exception {
-    IPSupport.skipIfCurrentConfigurationIsInvalid();
+    IPSupport.throwSkippedExceptionIfNonOperational();
     InetAddress  sin = InetAddress.getLocalHost();
     Socket       soc = null,soc1 = null;
     InputStream  is = null;

--- a/test/jdk/java/net/SocketOption/ImmutableOptions.java
+++ b/test/jdk/java/net/SocketOption/ImmutableOptions.java
@@ -44,7 +44,7 @@ public class ImmutableOptions {
 
     @BeforeTest
     void setupServerSocketFactory() throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         ServerSocket.setSocketFactory(new ServerSocketImplFactory());
     }
 

--- a/test/jdk/java/net/SocketOption/ImmutableOptions.java
+++ b/test/jdk/java/net/SocketOption/ImmutableOptions.java
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 8148609
+ * @library /test/lib
  * @summary Assert that the set of socket options are immutable
  * @run testng/othervm ImmutableOptions
  * @run testng/othervm -Djava.net.preferIPv4Stack=true ImmutableOptions
@@ -34,6 +35,8 @@ import java.io.OutputStream;
 import java.net.*;
 import java.util.Set;
 
+import jdk.test.lib.net.IPSupport;
+
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -41,6 +44,7 @@ public class ImmutableOptions {
 
     @BeforeTest
     void setupServerSocketFactory() throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         ServerSocket.setSocketFactory(new ServerSocketImplFactory());
     }
 

--- a/test/jdk/java/net/SocketOption/MinimumRcvBufferSize.java
+++ b/test/jdk/java/net/SocketOption/MinimumRcvBufferSize.java
@@ -36,7 +36,7 @@ import jdk.test.lib.net.IPSupport;
 public class MinimumRcvBufferSize {
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         boolean error = false;
         ServerSocketChannel channel = ServerSocketChannel.open();

--- a/test/jdk/java/net/SocketOption/MinimumRcvBufferSize.java
+++ b/test/jdk/java/net/SocketOption/MinimumRcvBufferSize.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @library /test/lib
  * @bug 8170920
  * @run main MinimumRcvBufferSize
  * @run main/othervm -Djava.net.preferIPv4Stack=true MinimumRcvBufferSize
@@ -30,10 +31,13 @@
 
 import java.nio.channels.*;
 import java.net.*;
+import jdk.test.lib.net.IPSupport;
 
 public class MinimumRcvBufferSize {
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         boolean error = false;
         ServerSocketChannel channel = ServerSocketChannel.open();
         int before = channel.getOption(StandardSocketOptions.SO_RCVBUF);

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8036979 8072384 8044773
+ * @library /test/lib
  * @requires !vm.graal.enabled
  * @run main/othervm -Xcheck:jni OptionsTest
  * @run main/othervm -Xcheck:jni -Djava.net.preferIPv4Stack=true OptionsTest
@@ -33,6 +34,7 @@
 import java.lang.reflect.Method;
 import java.net.*;
 import java.util.*;
+import jdk.test.lib.net.IPSupport;
 
 public class OptionsTest {
 
@@ -278,6 +280,7 @@ public class OptionsTest {
     }
 
     public static void main(String args[]) throws Exception {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
         doSocketTests();
         doServerSocketTests();
         doDgSocketTests();

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -280,7 +280,7 @@ public class OptionsTest {
     }
 
     public static void main(String args[]) throws Exception {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
         doSocketTests();
         doServerSocketTests();
         doDgSocketTests();

--- a/test/jdk/java/net/SocketOption/SupportedOptionsSet.java
+++ b/test/jdk/java/net/SocketOption/SupportedOptionsSet.java
@@ -44,7 +44,7 @@ import jdk.test.lib.net.IPSupport;
 public class SupportedOptionsSet {
 
     public static void main(String[] args) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         if (args[0].equals("first"))
             first();

--- a/test/jdk/java/net/SocketOption/SupportedOptionsSet.java
+++ b/test/jdk/java/net/SocketOption/SupportedOptionsSet.java
@@ -25,10 +25,12 @@ import java.io.IOException;
 import java.net.*;
 import java.util.Set;
 import static java.lang.System.out;
+import jdk.test.lib.net.IPSupport;
 
 /*
  * @test
  * @bug 8143923
+ * @library /test/lib
  * @summary java.net socket supportedOptions set depends on call order
  * @run main/othervm SupportedOptionsSet first
  * @run main/othervm SupportedOptionsSet second
@@ -42,6 +44,8 @@ import static java.lang.System.out;
 public class SupportedOptionsSet {
 
     public static void main(String[] args) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         if (args[0].equals("first"))
             first();
         else if (args[0].equals("second"))

--- a/test/jdk/java/net/SocketOption/UnsupportedOptionsTest.java
+++ b/test/jdk/java/net/SocketOption/UnsupportedOptionsTest.java
@@ -27,9 +27,12 @@ import java.net.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import jdk.test.lib.net.IPSupport;
+
 /*
  * @test
  * @bug 8143554 8044773
+ * @library /test/lib
  * @summary Test checks that UnsupportedOperationException for unsupported
  *          SOCKET_OPTIONS is thrown by both getOption() and setOption() methods.
  * @requires !vm.graal.enabled
@@ -69,6 +72,8 @@ public class UnsupportedOptionsTest {
     }
 
     public static void main(String[] args) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         Socket s = new Socket();
         ServerSocket ss = new ServerSocket();
         DatagramSocket ds = new DatagramSocket();

--- a/test/jdk/java/net/SocketOption/UnsupportedOptionsTest.java
+++ b/test/jdk/java/net/SocketOption/UnsupportedOptionsTest.java
@@ -72,7 +72,7 @@ public class UnsupportedOptionsTest {
     }
 
     public static void main(String[] args) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         Socket s = new Socket();
         ServerSocket ss = new ServerSocket();

--- a/test/jdk/java/nio/channels/DatagramChannel/BindNull.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/BindNull.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 7161881
+ * @library /test/lib
  * @run main/othervm -Djava.net.preferIPv6Addresses=true BindNull
  * @summary Make sure the bind method uses an ipv4 address for the null case
  *          when the DatagramChannel is connected to an IPv4 socket and
@@ -32,19 +33,22 @@
 import java.io.*;
 import java.net.*;
 import java.nio.channels.*;
+import jdk.test.lib.net.IPSupport;
 
 public class BindNull {
     public static void main(String[] args) throws IOException {
         try (DatagramChannel dc = DatagramChannel.open()) {
             dc.bind(null);
         }
-        try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-            dc.bind(null);
+        if (IPSupport.hasIPv4()) {
+            try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
+                dc.bind(null);
+            }
         }
-        try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
-            dc.bind(null);
-        } catch (UnsupportedOperationException uoe) {
-            // IPv6 not available
+        if (IPSupport.hasIPv6()) {
+            try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
+                dc.bind(null);
+            }
         }
     }
 }

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -38,7 +38,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class Disconnect {
     public static void main(String[] args) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         // test with default protocol family
         try (DatagramChannel dc = DatagramChannel.open()) {

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 7132924 8285515
+ * @library /test/lib
  * @key intermittent
  * @summary Test DatagramChannel.disconnect when DatagramChannel is connected to an IPv4 socket
  * @run main Disconnect
@@ -33,19 +34,32 @@ import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
 import java.io.IOException;
+import jdk.test.lib.net.IPSupport;
 
 public class Disconnect {
     public static void main(String[] args) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         // test with default protocol family
         try (DatagramChannel dc = DatagramChannel.open()) {
             test(dc);
             test(dc);
         }
 
-        // test with IPv4 only
-        try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-            test(dc);
-            test(dc);
+        if (IPSupport.hasIPv4()) {
+            // test with IPv4 only
+            try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
+                test(dc);
+                test(dc);
+            }
+        }
+
+        if (IPSupport.hasIPv6()) {
+            // test with IPv6 only
+            try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
+                test(dc);
+                test(dc);
+            }
         }
     }
 

--- a/test/jdk/java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java
@@ -240,7 +240,7 @@ public class MulticastSendReceiveTests {
     }
 
     public static void main(String[] args) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         NetworkConfiguration config = NetworkConfiguration.probe();
 

--- a/test/jdk/java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 
 import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 public class MulticastSendReceiveTests {
 
@@ -239,6 +240,8 @@ public class MulticastSendReceiveTests {
     }
 
     public static void main(String[] args) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         NetworkConfiguration config = NetworkConfiguration.probe();
 
         // multicast groups used for the test

--- a/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 
 import jdk.test.lib.NetworkConfiguration;
+import jdk.test.lib.net.IPSupport;
 
 public class Promiscuous {
 
@@ -192,6 +193,8 @@ public class Promiscuous {
     }
 
     public static void main(String[] args) throws IOException {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         String os = System.getProperty("os.name");
 
         // Requires IP_MULTICAST_ALL on Linux (new since 2.6.31) so skip

--- a/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
@@ -193,7 +193,7 @@ public class Promiscuous {
     }
 
     public static void main(String[] args) throws IOException {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         String os = System.getProperty("os.name");
 

--- a/test/jdk/java/nio/channels/DatagramChannel/UseDGWithIPv6.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/UseDGWithIPv6.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @library /test/lib
  * @bug 6435300
  * @summary Check using IPv6 address does not crash the VM
  * @run main/othervm UseDGWithIPv6
@@ -35,6 +36,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.UnsupportedAddressTypeException;
 
+import jdk.test.lib.net.IPSupport;
+
 public class UseDGWithIPv6 {
     static String[] targets = {
         "3ffe:e00:811:b::21:5",
@@ -45,6 +48,8 @@ public class UseDGWithIPv6 {
 
     public static void main(String[] args) throws IOException
     {
+        IPSupport.skipIfCurrentConfigurationIsInvalid();
+
         ByteBuffer data = ByteBuffer.wrap("TESTING DATA".getBytes());
         DatagramChannel dgChannel = DatagramChannel.open();
 

--- a/test/jdk/java/nio/channels/DatagramChannel/UseDGWithIPv6.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/UseDGWithIPv6.java
@@ -48,7 +48,7 @@ public class UseDGWithIPv6 {
 
     public static void main(String[] args) throws IOException
     {
-        IPSupport.skipIfCurrentConfigurationIsInvalid();
+        IPSupport.throwSkippedExceptionIfNonOperational();
 
         ByteBuffer data = ByteBuffer.wrap("TESTING DATA".getBytes());
         DatagramChannel dgChannel = DatagramChannel.open();

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,10 +62,6 @@ public class ConfigFileTest {
             copyJDK(jdkTestDir, copyJdkDir);
             String extraPropsFile = Path.of(System.getProperty("test.src"), "override.props").toString();
 
-            // sanity test -XshowSettings:security option
-            exerciseShowSettingsSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
-                    "-Djava.security.debug=all", "-XshowSettings:security", "ConfigFileTest", "runner");
-
             // exercise some debug flags while we're here
             // regular JDK install - should expect success
             exerciseSecurity(0, "java",
@@ -110,16 +106,6 @@ public class ConfigFileTest {
         ProcessBuilder process = new ProcessBuilder(args);
         OutputAnalyzer oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(exitCode).shouldContain(output);
-    }
-
-    // exercise the -XshowSettings:security launcher
-    private static void exerciseShowSettingsSecurity(String... args) throws Exception {
-        ProcessBuilder process = new ProcessBuilder(args);
-        OutputAnalyzer oa = ProcessTools.executeProcess(process);
-        oa.shouldHaveExitValue(0)
-                .shouldContain("Security properties:")
-                .shouldContain("Security provider static configuration:")
-                .shouldContain("Security TLS configuration");
     }
 
     private static void copyJDK(Path src, Path dst) throws Exception {

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,10 @@ public class ConfigFileTest {
             copyJDK(jdkTestDir, copyJdkDir);
             String extraPropsFile = Path.of(System.getProperty("test.src"), "override.props").toString();
 
+            // sanity test -XshowSettings:security option
+            exerciseShowSettingsSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-XshowSettings:security", "ConfigFileTest", "runner");
+
             // exercise some debug flags while we're here
             // regular JDK install - should expect success
             exerciseSecurity(0, "java",
@@ -106,6 +110,16 @@ public class ConfigFileTest {
         ProcessBuilder process = new ProcessBuilder(args);
         OutputAnalyzer oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(exitCode).shouldContain(output);
+    }
+
+    // exercise the -XshowSettings:security launcher
+    private static void exerciseShowSettingsSecurity(String... args) throws Exception {
+        ProcessBuilder process = new ProcessBuilder(args);
+        OutputAnalyzer oa = ProcessTools.executeProcess(process);
+        oa.shouldHaveExitValue(0)
+                .shouldContain("Security properties:")
+                .shouldContain("Security provider static configuration:")
+                .shouldContain("Security TLS configuration");
     }
 
     private static void copyJDK(Path src, Path dst) throws Exception {

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -151,54 +151,6 @@ public class Settings extends TestHelper {
         checkContains(tr, TZDATA_SETTINGS);
     }
 
-    static void runTestOptionSecurity() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security");
-        checkNotContains(tr, VM_SETTINGS);
-        checkNotContains(tr, PROP_SETTINGS);
-        checkContains(tr, SEC_PROPS_SETTINGS);
-        checkContains(tr, SEC_PROVIDER_SETTINGS);
-        checkContains(tr, SEC_TLS_SETTINGS);
-    }
-
-    static void runTestOptionSecurityProps() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:properties");
-        checkContains(tr, SEC_PROPS_SETTINGS);
-        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
-        checkNotContains(tr, SEC_TLS_SETTINGS);
-        // test a well known property for sanity
-        checkContains(tr, "keystore.type=pkcs12");
-    }
-
-    static void runTestOptionSecurityProv() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:providers");
-        checkNotContains(tr, SEC_PROPS_SETTINGS);
-        checkContains(tr, SEC_PROVIDER_SETTINGS);
-        checkNotContains(tr, SEC_TLS_SETTINGS);
-        // test a well known Provider for sanity
-        checkContains(tr, "Provider name: SUN");
-        // test for a well known alias (SunJCE: AlgorithmParameterGenerator.DiffieHellman)
-        checkContains(tr, "aliases: [1.2.840.113549.1.3.1, " +
-                "DH, OID.1.2.840.113549.1.3.1]");
-    }
-
-    static void runTestOptionSecurityTLS() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:tls");
-        checkNotContains(tr, SEC_PROPS_SETTINGS);
-        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
-        checkContains(tr, SEC_TLS_SETTINGS);
-        // test a well known TLS config for sanity
-        checkContains(tr, "TLSv1.2");
-    }
-
-    // ensure error message is printed when unrecognized option used
-    static void runTestOptionBadSecurityOption() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:bad");
-        checkContains(tr, BAD_SEC_OPTION_MSG);
-        // we print all security settings in such scenario
-        checkNotContains(tr, SEC_PROPS_SETTINGS);
-        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
-        checkNotContains(tr, SEC_TLS_SETTINGS);
-    }
     static void runTestOptionSystem() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:system");
         if (System.getProperty("os.name").contains("Linux")) {
@@ -236,11 +188,6 @@ public class Settings extends TestHelper {
         runTestOptionVM();
         runTestOptionProperty();
         runTestOptionLocale();
-        runTestOptionSecurity();
-        runTestOptionSecurityProps();
-        runTestOptionSecurityProv();
-        runTestOptionSecurityTLS();
-        runTestOptionBadSecurityOption();
         runTestOptionSystem();
         runTestBadOptions();
         runTest7123582();

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -151,6 +151,54 @@ public class Settings extends TestHelper {
         checkContains(tr, TZDATA_SETTINGS);
     }
 
+    static void runTestOptionSecurity() throws IOException {
+        TestResult tr = doExec(javaCmd, "-XshowSettings:security");
+        checkNotContains(tr, VM_SETTINGS);
+        checkNotContains(tr, PROP_SETTINGS);
+        checkContains(tr, SEC_PROPS_SETTINGS);
+        checkContains(tr, SEC_PROVIDER_SETTINGS);
+        checkContains(tr, SEC_TLS_SETTINGS);
+    }
+
+    static void runTestOptionSecurityProps() throws IOException {
+        TestResult tr = doExec(javaCmd, "-XshowSettings:security:properties");
+        checkContains(tr, SEC_PROPS_SETTINGS);
+        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
+        checkNotContains(tr, SEC_TLS_SETTINGS);
+        // test a well known property for sanity
+        checkContains(tr, "keystore.type=pkcs12");
+    }
+
+    static void runTestOptionSecurityProv() throws IOException {
+        TestResult tr = doExec(javaCmd, "-XshowSettings:security:providers");
+        checkNotContains(tr, SEC_PROPS_SETTINGS);
+        checkContains(tr, SEC_PROVIDER_SETTINGS);
+        checkNotContains(tr, SEC_TLS_SETTINGS);
+        // test a well known Provider for sanity
+        checkContains(tr, "Provider name: SUN");
+        // test for a well known alias (SunJCE: AlgorithmParameterGenerator.DiffieHellman)
+        checkContains(tr, "aliases: [1.2.840.113549.1.3.1, " +
+                "DH, OID.1.2.840.113549.1.3.1]");
+    }
+
+    static void runTestOptionSecurityTLS() throws IOException {
+        TestResult tr = doExec(javaCmd, "-XshowSettings:security:tls");
+        checkNotContains(tr, SEC_PROPS_SETTINGS);
+        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
+        checkContains(tr, SEC_TLS_SETTINGS);
+        // test a well known TLS config for sanity
+        checkContains(tr, "TLSv1.2");
+    }
+
+    // ensure error message is printed when unrecognized option used
+    static void runTestOptionBadSecurityOption() throws IOException {
+        TestResult tr = doExec(javaCmd, "-XshowSettings:security:bad");
+        checkContains(tr, BAD_SEC_OPTION_MSG);
+        // we print all security settings in such scenario
+        checkNotContains(tr, SEC_PROPS_SETTINGS);
+        checkNotContains(tr, SEC_PROVIDER_SETTINGS);
+        checkNotContains(tr, SEC_TLS_SETTINGS);
+    }
     static void runTestOptionSystem() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:system");
         if (System.getProperty("os.name").contains("Linux")) {
@@ -188,6 +236,11 @@ public class Settings extends TestHelper {
         runTestOptionVM();
         runTestOptionProperty();
         runTestOptionLocale();
+        runTestOptionSecurity();
+        runTestOptionSecurityProps();
+        runTestOptionSecurityProv();
+        runTestOptionSecurityTLS();
+        runTestOptionBadSecurityOption();
         runTestOptionSystem();
         runTestBadOptions();
         runTest7123582();

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -55,7 +55,7 @@ public class IPSupport {
 
             InetAddress loopbackIPv6 = InetAddress.getByAddress(
                     new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
 
             hasIPv4 = runPrivilegedAction(() -> hasAddress(loopbackIPv4));
             hasIPv6 = runPrivilegedAction(() -> hasAddress(loopbackIPv6));
@@ -63,9 +63,9 @@ public class IPSupport {
             throw new AssertionError(e);
         }
         preferIPv4Stack = runPrivilegedAction(() -> Boolean.parseBoolean(
-                System.getProperty("java.net.preferIPv4Stack")));
+            System.getProperty("java.net.preferIPv4Stack")));
         preferIPv6Addresses = runPrivilegedAction(() -> Boolean.parseBoolean(
-                System.getProperty("java.net.preferIPv6Addresses")));
+            System.getProperty("java.net.preferIPv6Addresses")));
         if (!preferIPv4Stack && !hasIPv4 && !hasIPv6) {
             throw new AssertionError("IPv4 and IPv6 both not available and java.net.preferIPv4Stack is not true");
         }

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -46,7 +47,6 @@ public class IPSupport {
     private static final boolean hasIPv4;
     private static final boolean hasIPv6;
     private static final boolean preferIPv4Stack;
-    private static final boolean preferIPv6Addresses;
 
     static {
         try {
@@ -55,7 +55,7 @@ public class IPSupport {
 
             InetAddress loopbackIPv6 = InetAddress.getByAddress(
                     new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
 
             hasIPv4 = runPrivilegedAction(() -> hasAddress(loopbackIPv4));
             hasIPv6 = runPrivilegedAction(() -> hasAddress(loopbackIPv6));
@@ -63,9 +63,7 @@ public class IPSupport {
             throw new AssertionError(e);
         }
         preferIPv4Stack = runPrivilegedAction(() -> Boolean.parseBoolean(
-            System.getProperty("java.net.preferIPv4Stack")));
-        preferIPv6Addresses = runPrivilegedAction(() -> Boolean.parseBoolean(
-            System.getProperty("java.net.preferIPv6Addresses")));
+                System.getProperty("java.net.preferIPv4Stack")));
         if (!preferIPv4Stack && !hasIPv4 && !hasIPv6) {
             throw new AssertionError("IPv4 and IPv6 both not available and java.net.preferIPv4Stack is not true");
         }
@@ -114,13 +112,6 @@ public class IPSupport {
         return preferIPv4Stack;
     }
 
-    /**
-     * Whether or not the "java.net.preferIPv6Addresses" system property is set.
-     */
-    public static final boolean preferIPv6Addresses() {
-        return preferIPv6Addresses;
-    }
-
 
     /**
      * Whether or not the current networking configuration is valid or not.
@@ -132,19 +123,9 @@ public class IPSupport {
     }
 
     /**
-     * Ensures that the platform supports the ability to create a
-     * minimally-operational socket whose protocol is either one of IPv4
-     * or IPv6.
-     *
-     * <p> A minimally-operation socket is one that can be created and
-     * bound to an IP-specific loopback address. IP support is
-     * considered non-operational if a socket cannot be bound to either
-     * one of, an IPv4 loopback address, or the IPv6 loopback address.
-     *
-     * @throws SkippedException if the current networking configuration
-     *         is non-operational
+     * Throws a jtreg.SkippedException if the current networking configuration is invalid.
      */
-    public static void throwSkippedExceptionIfNonOperational() throws SkippedException {
+    public static void skipIfCurrentConfigurationIsInvalid() throws SkippedException {
         if (!currentConfigurationIsValid()) {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             PrintStream ps = new PrintStream(os);
@@ -161,7 +142,6 @@ public class IPSupport {
         out.println("IPSupport - IPv4: " + hasIPv4());
         out.println("IPSupport - IPv6: " + hasIPv6());
         out.println("preferIPv4Stack: " + preferIPv4Stack());
-        out.println("preferIPv6Addresses: " + preferIPv6Addresses());
     }
 
 }

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -47,6 +46,7 @@ public class IPSupport {
     private static final boolean hasIPv4;
     private static final boolean hasIPv6;
     private static final boolean preferIPv4Stack;
+    private static final boolean preferIPv6Addresses;
 
     static {
         try {
@@ -64,6 +64,8 @@ public class IPSupport {
         }
         preferIPv4Stack = runPrivilegedAction(() -> Boolean.parseBoolean(
                 System.getProperty("java.net.preferIPv4Stack")));
+        preferIPv6Addresses = runPrivilegedAction(() -> Boolean.parseBoolean(
+                System.getProperty("java.net.preferIPv6Addresses")));
         if (!preferIPv4Stack && !hasIPv4 && !hasIPv6) {
             throw new AssertionError("IPv4 and IPv6 both not available and java.net.preferIPv4Stack is not true");
         }
@@ -112,6 +114,13 @@ public class IPSupport {
         return preferIPv4Stack;
     }
 
+    /**
+     * Whether or not the "java.net.preferIPv6Addresses" system property is set.
+     */
+    public static final boolean preferIPv6Addresses() {
+        return preferIPv6Addresses;
+    }
+
 
     /**
      * Whether or not the current networking configuration is valid or not.
@@ -123,9 +132,19 @@ public class IPSupport {
     }
 
     /**
-     * Throws a jtreg.SkippedException if the current networking configuration is invalid.
+     * Ensures that the platform supports the ability to create a
+     * minimally-operational socket whose protocol is either one of IPv4
+     * or IPv6.
+     *
+     * <p> A minimally-operation socket is one that can be created and
+     * bound to an IP-specific loopback address. IP support is
+     * considered non-operational if a socket cannot be bound to either
+     * one of, an IPv4 loopback address, or the IPv6 loopback address.
+     *
+     * @throws SkippedException if the current networking configuration
+     *         is non-operational
      */
-    public static void skipIfCurrentConfigurationIsInvalid() throws SkippedException {
+    public static void throwSkippedExceptionIfNonOperational() throws SkippedException {
         if (!currentConfigurationIsValid()) {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             PrintStream ps = new PrintStream(os);
@@ -142,6 +161,7 @@ public class IPSupport {
         out.println("IPSupport - IPv4: " + hasIPv4());
         out.println("IPSupport - IPv6: " + hasIPv6());
         out.println("preferIPv4Stack: " + preferIPv4Stack());
+        out.println("preferIPv6Addresses: " + preferIPv6Addresses());
     }
 
 }


### PR DESCRIPTION
I backport this for parity with 11.0.25-oracle.
these tests are not clean, but all added code is clean
test/jdk/java/net/NetworkInterface/Test.java
test/jdk/java/net/Socket/CloseAvailable.java
test/jdk/java/net/Socket/HttpProxy.java
test/jdk/java/net/Socket/SetSoLinger.java
test/jdk/java/nio/channels/DatagramChannel/Disconnect.java

this class is not exist, ignore, other classes are clean
test/jdk/java/nio/channels/etc/PrintSupportedOptions.java

As https://bugs.openjdk.org/browse/JDK-8239355 is already backported, https://github.com/openjdk/jdk11u-dev/commit/f4288be071133267f3647475c510be4d77dcf608
so not modify the test/lib/jdk/test/lib/net/IPSupport.java
it missed to backported to modify the test/jdk/java/net/IPSupport/MinimumPermissions.policy
so here edit it.

also add backport for https://bugs.openjdk.org/browse/JDK-8223652
otherwise other tests will fail due to the throwSkippedExceptionIfNonOperational() change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8220673](https://bugs.openjdk.org/browse/JDK-8220673) needs maintainer approval
- [ ] [JDK-8223652](https://bugs.openjdk.org/browse/JDK-8223652) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8220673](https://bugs.openjdk.org/browse/JDK-8220673): Add test library support for determining platform IP support (**Sub-task** - P3)
 * [JDK-8223652](https://bugs.openjdk.org/browse/JDK-8223652): Rename IPSupport.skipIfCurrentConfigurationIsInvalid() (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2910/head:pull/2910` \
`$ git checkout pull/2910`

Update a local copy of the PR: \
`$ git checkout pull/2910` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2910`

View PR using the GUI difftool: \
`$ git pr show -t 2910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2910.diff">https://git.openjdk.org/jdk11u-dev/pull/2910.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2910#issuecomment-2290693439)