### PR TITLE
8273135: java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7

### DIFF
--- a/src/java.desktop/share/native/liblcms/cmsio0.c
+++ b/src/java.desktop/share/native/liblcms/cmsio0.c
@@ -1660,7 +1660,7 @@ cmsBool IsTypeSupported(cmsTagDescriptor* TagDescriptor, cmsTagTypeSignature Typ
 void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 {
     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) hProfile;
-    cmsIOHANDLER* io = Icc ->IOhandler;
+    cmsIOHANDLER* io;
     cmsTagTypeHandler* TypeHandler;
     cmsTagTypeHandler LocalTypeHandler;
     cmsTagDescriptor*  TagDescriptor;
@@ -1704,6 +1704,8 @@ void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
     TagSize   = Icc -> TagSizes[n];
 
     if (TagSize < 8) goto Error;
+
+    io = Icc ->IOhandler;
 
     if (io == NULL) { // This is a built-in profile that has been manipulated, abort early
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1017a2c2](https://github.com/openjdk/jdk/commit/1017a2c2d7ae99e0076abcfaf5e730fec3cb9c6c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

This backport contains a patch imported to openjdk/jdk from the lcms 2.14 library in advance. Unfortunately this backport was not pushed to the jdk11u-dev as is, and not as part of the lcms update to 2.14(see https://github.com/openjdk/jdk11u-dev/pull/1659) as a result the implementation of the lcms library in jdk11u-dev is incomplete.

The patch is not clean, the change in the MTTransformReplacedProfile test is dropped, that test does not exist in the jdk11 and I have no plans to backport the patch which added that test.

@GoeLin please take a look.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273135](https://bugs.openjdk.org/browse/JDK-8273135) needs maintainer approval

### Issue
 * [JDK-8273135](https://bugs.openjdk.org/browse/JDK-8273135): java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2914/head:pull/2914` \
`$ git checkout pull/2914`

Update a local copy of the PR: \
`$ git checkout pull/2914` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2914`

View PR using the GUI difftool: \
`$ git pr show -t 2914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2914.diff">https://git.openjdk.org/jdk11u-dev/pull/2914.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2914#issuecomment-2297316402)