### PR TITLE
8206440: Remove javac -source/-target 6 from jdk regression tests

### DIFF
--- a/test/jdk/java/lang/reflect/OldenCompilingWithDefaults.java
+++ b/test/jdk/java/lang/reflect/OldenCompilingWithDefaults.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8009267
  * @summary Verify uses of isAnnotationPresent compile under older source versions
- * @compile -source 1.6 -target 1.6 OldenCompilingWithDefaults.java
  * @compile -source 1.7 -target 1.7 OldenCompilingWithDefaults.java
  * @compile                         OldenCompilingWithDefaults.java
  */


### PR DESCRIPTION
Backport of [JDK-8206440](https://bugs.openjdk.org/browse/JDK-8206440)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `OldenCompilingWithDefaults.java`: Test results: passed: 1
- Pipeline: All passed except `macOS`
  -`macOS`:  `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: SAP nightlies SUCCESSFUL on `2024-08-23`
  - Automated jtreg test: `jtreg_jdk_tier1`, Started at `2024-08-22 20:22:52+01:00`
  - java/lang/reflect/OldenCompilingWithDefaults.java: SUCCESSFUL GitHub 📊 - [20:28:58.734 -> 249 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8206440](https://bugs.openjdk.org/browse/JDK-8206440) needs maintainer approval

### Issue
 * [JDK-8206440](https://bugs.openjdk.org/browse/JDK-8206440): Remove javac -source/-target 6 from jdk regression tests (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2915/head:pull/2915` \
`$ git checkout pull/2915`

Update a local copy of the PR: \
`$ git checkout pull/2915` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2915`

View PR using the GUI difftool: \
`$ git pr show -t 2915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2915.diff">https://git.openjdk.org/jdk11u-dev/pull/2915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2915#issuecomment-2299965132)