### PR TITLE
8210338: Better output for GenerationTests.java

### DIFF
--- a/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
+++ b/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
@@ -352,7 +352,7 @@ public class GenerationTests {
         try (Http server = Http.startServer()) {
             server.start();
 
-            // tests for XML documents
+            System.out.println("\ntests for XML documents");
             Arrays.stream(canonicalizationMethods).forEach(c ->
                 Arrays.stream(allSignatureMethods).forEach(s ->
                     Arrays.stream(allDigestMethods).forEach(d ->
@@ -366,7 +366,7 @@ public class GenerationTests {
                                 }
                         })))));
 
-            // tests for text data with no transform
+            System.out.println("\ntests for text data with no transform");
             Arrays.stream(canonicalizationMethods).forEach(c ->
                 Arrays.stream(allSignatureMethods).forEach(s ->
                     Arrays.stream(allDigestMethods).forEach(d ->
@@ -379,7 +379,7 @@ public class GenerationTests {
                             }
                         }))));
 
-            // tests for base64 data
+            System.out.println("\ntests for base64 data");
             Arrays.stream(canonicalizationMethods).forEach(c ->
                 Arrays.stream(allSignatureMethods).forEach(s ->
                     Arrays.stream(allDigestMethods).forEach(d ->
@@ -396,7 +396,7 @@ public class GenerationTests {
 
             // negative tests
 
-            // unknown CanonicalizationMethod
+            System.out.println("\nunknown CanonicalizationMethod");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE + BOGUS,
                     SignatureMethod.DSA_SHA1,
@@ -408,7 +408,7 @@ public class GenerationTests {
                     true,
                     NoSuchAlgorithmException.class);
 
-            // unknown SignatureMethod
+            System.out.println("\nunknown SignatureMethod");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE,
                     SignatureMethod.DSA_SHA1 + BOGUS,
@@ -419,7 +419,7 @@ public class GenerationTests {
                     true,
                     NoSuchAlgorithmException.class);
 
-            // unknown DigestMethod
+            System.out.println("\nunknown DigestMethod");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE,
                     SignatureMethod.DSA_SHA1,
@@ -430,7 +430,7 @@ public class GenerationTests {
                     true,
                     NoSuchAlgorithmException.class);
 
-            // unknown Transform
+            System.out.println("\nunknown Transform");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE,
                     SignatureMethod.DSA_SHA1,
@@ -441,7 +441,7 @@ public class GenerationTests {
                     true,
                     NoSuchAlgorithmException.class);
 
-            // no source document
+            System.out.println("\nno source document");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE,
                     SignatureMethod.DSA_SHA1,
@@ -453,7 +453,7 @@ public class GenerationTests {
                     true,
                     XMLSignatureException.class);
 
-            // wrong transform for text data
+            System.out.println("\nwrong transform for text data");
             test_create_detached_signature(
                     CanonicalizationMethod.EXCLUSIVE,
                     SignatureMethod.DSA_SHA1,
@@ -1823,6 +1823,7 @@ public class GenerationTests {
             throws Exception {
 
         System.out.print("-S");
+        System.out.flush();
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
@@ -1907,6 +1908,7 @@ public class GenerationTests {
         }
 
         System.out.print("V");
+        System.out.flush();
         try (ByteArrayInputStream bis = new ByteArrayInputStream(
                 signatureString.getBytes())) {
             doc = dbf.newDocumentBuilder().parse(bis);
@@ -1930,12 +1932,14 @@ public class GenerationTests {
         boolean success = signature.validate(vc);
         if (!success) {
             System.out.print("x");
+            System.out.flush();
             return false;
         }
 
         success = signature.getSignatureValue().validate(vc);
         if (!success) {
             System.out.print("X");
+            System.out.flush();
             return false;
         }
 


### PR DESCRIPTION
Backport of [JDK-8210338](https://bugs.openjdk.org/browse/JDK-8210338)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `GenerationTests.java`: Test results: passed: 1
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: SAP nightlies SUCCESSFUL on `2024-08-23`
  - Automated jtreg test: `jtreg_jdk_tier2`, Started at `2024-08-22 21:36:00+01:00`
  - javax/xml/crypto/dsig/GenerationTests.java: SUCCESSFUL GitHub 📊 - [21:59:45.106 -> 127,518 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8210338](https://bugs.openjdk.org/browse/JDK-8210338) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210338](https://bugs.openjdk.org/browse/JDK-8210338): Better output for GenerationTests.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2916/head:pull/2916` \
`$ git checkout pull/2916`

Update a local copy of the PR: \
`$ git checkout pull/2916` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2916`

View PR using the GUI difftool: \
`$ git pr show -t 2916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2916.diff">https://git.openjdk.org/jdk11u-dev/pull/2916.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2916#issuecomment-2299979097)