### PR TITLE
8224081: SOCKS v4 tests require IPv4

### DIFF
--- a/test/jdk/java/net/Socks/SocksProxyVersion.java
+++ b/test/jdk/java/net/Socks/SocksProxyVersion.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6964547 5001942 8129444
+ * @library /test/lib
  * @run main/othervm SocksProxyVersion
  * @summary test socksProxyVersion system property
  */
@@ -35,6 +36,7 @@ import java.net.SocketException;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Proxy;
+import jdk.test.lib.net.IPSupport;
 
 public class SocksProxyVersion implements Runnable {
     final ServerSocket ss;
@@ -80,14 +82,16 @@ public class SocksProxyVersion implements Runnable {
         Proxy proxy = new Proxy(Proxy.Type.SOCKS,
                                 new InetSocketAddress(addr, port));
 
-        // SOCKS V4
-        System.setProperty("socksProxyVersion", Integer.toString(4));
-        this.expected = 4;
-        check(new Socket(), addr, port);
-        check(new Socket(proxy), addr, port);
+        if (IPSupport.hasIPv4()) {
+            // SOCKS V4 (requires IPv4)
+            System.setProperty("socksProxyVersion", "4");
+            this.expected = 4;
+            check(new Socket(), addr, port);
+            check(new Socket(proxy), addr, port);
+        }
 
         // SOCKS V5
-        System.setProperty("socksProxyVersion", Integer.toString(5));
+        System.setProperty("socksProxyVersion", "5");
         this.expected = 5;
         check(new Socket(), addr, port);
         check(new Socket(proxy), addr, port);

--- a/test/jdk/sun/security/x509/URICertStore/SocksProxy.java
+++ b/test/jdk/sun/security/x509/URICertStore/SocksProxy.java
@@ -22,6 +22,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import java.util.function.Consumer;
 import javax.net.ServerSocketFactory;
 
 /*
- * A simple socks4 proxy for traveling socket.
+ * A simple socks proxy for traveling socket.
  */
 class SocksProxy implements Runnable, AutoCloseable {
 
@@ -49,10 +50,11 @@ class SocksProxy implements Runnable, AutoCloseable {
         ServerSocket server
                 = ServerSocketFactory.getDefault().createServerSocket(0);
 
-        System.setProperty("socksProxyHost", "127.0.0.1");
+        System.setProperty("socksProxyHost",
+                InetAddress.getLoopbackAddress().getHostAddress());
         System.setProperty("socksProxyPort",
                 String.valueOf(server.getLocalPort()));
-        System.setProperty("socksProxyVersion", "4");
+        System.setProperty("socksProxyVersion", "5");
 
         SocksProxy proxy = new SocksProxy(server, socketConsumer);
         Thread proxyThread = new Thread(proxy, "Proxy");


### PR DESCRIPTION
Backport of [JDK-8224081](https://bugs.openjdk.org/browse/JDK-8224081)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `SocksProxyVersion.java`: Test results: passed: 1
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: SAP nightlies SUCCESSFUL on `2024-08-23`
  - Automated jtreg test: `jtreg_jdk_tier2`, Started at `2024-08-22 21:36:00+01:00`
  - java/net/Socks/SocksProxyVersion.java: SUCCESSFUL GitHub 📊 - [21:49:09.044 -> 548 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8224081](https://bugs.openjdk.org/browse/JDK-8224081) needs maintainer approval

### Issue
 * [JDK-8224081](https://bugs.openjdk.org/browse/JDK-8224081): SOCKS v4 tests require IPv4 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2917/head:pull/2917` \
`$ git checkout pull/2917`

Update a local copy of the PR: \
`$ git checkout pull/2917` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2917`

View PR using the GUI difftool: \
`$ git pr show -t 2917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2917.diff">https://git.openjdk.org/jdk11u-dev/pull/2917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2917#issuecomment-2299990379)