### PR TITLE
8225045: javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java fails on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -710,7 +710,6 @@ javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all
 javax/swing/JInternalFrame/Test6325652.java 8196467 macosx-all
-javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JLabel/6596966/bug6596966.java 8040914 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all
 javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java 8238085 macosx-all

--- a/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
@@ -30,6 +30,7 @@
  * @build Util
  * @run main JInternalFrameIconTest
  */
+import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -37,6 +38,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JDesktopPane;
@@ -61,7 +63,6 @@ public class JInternalFrameIconTest {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.delay(2000);
         UIManager.LookAndFeelInfo[] lookAndFeelArray
                 = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo lookAndFeelItem : lookAndFeelArray) {
@@ -76,21 +77,28 @@ public class JInternalFrameIconTest {
     private static void executeCase(String lookAndFeelString) throws Exception {
         if (tryLookAndFeel(lookAndFeelString)) {
             createImageIconUI(lookAndFeelString);
+            robot.waitForIdle();
             robot.delay(1000);
             getImageIconBufferedImage();
+            robot.waitForIdle();
             robot.delay(1000);
             cleanUp();
             robot.waitForIdle();
+            robot.delay(1000);
 
             createIconUI(lookAndFeelString);
+            robot.waitForIdle();
             robot.delay(1000);
             getIconBufferedImage();
+            robot.waitForIdle();
             robot.delay(1000);
             cleanUp();
             robot.waitForIdle();
+            robot.delay(1000);
 
             testIfSame(lookAndFeelString);
             robot.waitForIdle();
+            robot.delay(1000);
         }
 
     }
@@ -208,6 +216,8 @@ public class JInternalFrameIconTest {
     private static void testIfSame(final String lookAndFeelString)
             throws Exception {
         if (!bufferedImagesEqual(imageIconImage, iconImage)) {
+            ImageIO.write(imageIconImage, "png", new File("imageicon-fail.png"));
+            ImageIO.write(iconImage, "png", new File("iconImage-fail.png"));
             String error ="[" + lookAndFeelString
                     + "] : ERROR: icon and imageIcon not same.";
             errorString += error;


### PR DESCRIPTION
Backport of [JDK-8225045](https://bugs.openjdk.org/browse/JDK-8225045)
- This PR contains two commits
- `commit 1` is generated by git `patch` command, is a clean backport for `JInternalFrameIconTest.java`
- `commit 2` is the manual merge of `test/jdk/ProblemList.txt.rej` file. The content of the file is bellow.

```diff
@@ -751,7 +751,6 @@
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
-javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/UIDefaults/6302464/bug6302464.java 8199079 macosx-all
```

Testing
- Local on MacOS: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `JInternalFrameIconTest.java`: Test results: passed: 1
- Local on Linux: Test passed on `Ubuntu 22.04.4` by @Harry-Junhua-Huang
  - Passed: `javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java`
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: SAP nightlies **SKIPPED** on `2024-08-23`
  - Automated jtreg test: `jtreg_jdk_tier4`, Started at `2024-08-22 21:03:43+01:00`
  - javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8225045](https://bugs.openjdk.org/browse/JDK-8225045) needs maintainer approval

### Issue
 * [JDK-8225045](https://bugs.openjdk.org/browse/JDK-8225045): javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java fails on linux-x64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2918/head:pull/2918` \
`$ git checkout pull/2918`

Update a local copy of the PR: \
`$ git checkout pull/2918` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2918`

View PR using the GUI difftool: \
`$ git pr show -t 2918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2918.diff">https://git.openjdk.org/jdk11u-dev/pull/2918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2918#issuecomment-2300004353)