### PR TITLE
8336854: CAInterop.java#actalisauthenticationrootca conflicted with /manual and /timeout

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -26,13 +26,10 @@
  * @bug 8189131
  * @summary Interoperability tests with Actalis CA
  * Before this test set to manual, the original timeout
- * value if 180
+ * value is 180
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
- *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
- *  -Dcom.sun.security.ocsp.useget=false
  *  CAInterop actalisauthenticationrootca OCSP
  * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca CRL

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -25,11 +25,16 @@
  * @test id=actalisauthenticationrootca
  * @bug 8189131
  * @summary Interoperability tests with Actalis CA
+ * Before this test set to manual, the original timeout
+ * value if 180
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/manual/timeout=180 -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
+ *  -Dcom.sun.security.ocsp.useget=false
+ *  CAInterop actalisauthenticationrootca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca CRL
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f132b347](https://github.com/openjdk/jdk/commit/f132b347e13a57d9654f0ab11db0636999576036) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 13 Aug 2024 and was reviewed by Rajan Halade.

This PR not clean, because this file has changed by JDK-8328638 and JDK-8329213 which not backported to jdk11u-dev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8336854](https://bugs.openjdk.org/browse/JDK-8336854) needs maintainer approval

### Issue
 * [JDK-8336854](https://bugs.openjdk.org/browse/JDK-8336854): CAInterop.java#actalisauthenticationrootca conflicted with /manual and /timeout (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2919/head:pull/2919` \
`$ git checkout pull/2919`

Update a local copy of the PR: \
`$ git checkout pull/2919` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2919`

View PR using the GUI difftool: \
`$ git pr show -t 2919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2919.diff">https://git.openjdk.org/jdk11u-dev/pull/2919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2919#issuecomment-2304691948)
</details>
