### PR TITLE
8312049: runtime/logging/ClassLoadUnloadTest can be improved

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -42,8 +42,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class ClassLoadUnloadTest {
-    private static OutputAnalyzer out;
-    private static ProcessBuilder pb;
     private static class ClassUnloadTestMain {
         public static void main(String... args) throws Exception {
             String className = "test.Empty";
@@ -54,79 +52,78 @@ public class ClassLoadUnloadTest {
         }
     }
 
-    static void checkFor(String... outputStrings) throws Exception {
-        out = new OutputAnalyzer(pb.start());
+    static void checkFor(OutputAnalyzer output, String... outputStrings) throws Exception {
         for (String s: outputStrings) {
-            out.shouldContain(s);
+            output.shouldContain(s);
         }
-        out.shouldHaveExitValue(0);
     }
 
-    static void checkAbsent(String... outputStrings) throws Exception {
-        out = new OutputAnalyzer(pb.start());
+    static void checkAbsent(OutputAnalyzer output, String... outputStrings) throws Exception {
         for (String s: outputStrings) {
-            out.shouldNotContain(s);
+            output.shouldNotContain(s);
         }
-        out.shouldHaveExitValue(0);
     }
 
     // Use the same command-line heap size setting as ../ClassUnload/UnloadTest.java
-    static ProcessBuilder exec(String... args) throws Exception {
+    static OutputAnalyzer exec(String... args) throws Exception {
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
-        Collections.addAll(argsList, "-Xmn8m");
-        Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
-        Collections.addAll(argsList, "-XX:+ClassUnloading");
-        Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
-        return ProcessTools.createJavaProcessBuilder(argsList);
+        Collections.addAll(argsList, "-Xmn8m", "-Dtest.class.path=" + System.getProperty("test.class.path", "."),
+                           "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName());
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(argsList);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        return output;
     }
 
     public static void main(String... args) throws Exception {
 
+        OutputAnalyzer output;
+
         //  -Xlog:class+unload=info
-        pb = exec("-Xlog:class+unload=info");
-        checkFor("[class,unload]", "unloading class");
+        output = exec("-Xlog:class+unload=info");
+        checkFor(output, "[class,unload]", "unloading class");
 
         //  -Xlog:class+unload=off
-        pb = exec("-Xlog:class+unload=off");
-        checkAbsent("[class,unload]");
+        output = exec("-Xlog:class+unload=off");
+        checkAbsent(output,"[class,unload]");
 
         //  -XX:+TraceClassUnloading
-        pb = exec("-XX:+TraceClassUnloading");
-        checkFor("[class,unload]", "unloading class");
+        output = exec("-XX:+TraceClassUnloading");
+        checkFor(output, "[class,unload]", "unloading class");
 
         //  -XX:-TraceClassUnloading
-        pb = exec("-XX:-TraceClassUnloading");
-        checkAbsent("[class,unload]");
+        output = exec("-XX:-TraceClassUnloading");
+        checkAbsent(output, "[class,unload]");
 
         //  -Xlog:class+load=info
-        pb = exec("-Xlog:class+load=info");
-        checkFor("[class,load]", "java.lang.Object", "source:");
+        output = exec("-Xlog:class+load=info");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:");
 
         //  -Xlog:class+load=debug
-        pb = exec("-Xlog:class+load=debug");
-        checkFor("[class,load]", "java.lang.Object", "source:", "klass:", "super:", "loader:", "bytes:");
+        output = exec("-Xlog:class+load=debug");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:", "klass:", "super:", "loader:", "bytes:");
 
         //  -Xlog:class+load=off
-        pb = exec("-Xlog:class+load=off");
-        checkAbsent("[class,load]");
+        output = exec("-Xlog:class+load=off");
+        checkAbsent(output,"[class,load]");
 
         //  -XX:+TraceClassLoading
-        pb = exec("-XX:+TraceClassLoading");
-        checkFor("[class,load]", "java.lang.Object", "source:");
+        output = exec("-XX:+TraceClassLoading");
+        checkFor(output, "[class,load]", "java.lang.Object", "source:");
 
         //  -XX:-TraceClassLoading
-        pb = exec("-XX:-TraceClassLoading");
-        checkAbsent("[class,load]");
+        output = exec("-XX:-TraceClassLoading");
+        checkAbsent(output, "[class,load]");
 
         //  -verbose:class
-        pb = exec("-verbose:class");
-        checkFor("[class,load]", "java.lang.Object", "source:");
-        checkFor("[class,unload]", "unloading class");
+        output = exec("-verbose:class");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:");
+        checkFor(output,"[class,unload]", "unloading class");
 
         //  -Xlog:class+loader+data=trace
-        pb = exec("-Xlog:class+loader+data=trace");
-        checkFor("[class,loader,data]", "create loader data");
+        output = exec("-Xlog:class+loader+data=trace");
+        checkFor(output, "[class,loader,data]", "create loader data");
 
     }
 }


### PR DESCRIPTION
Backport that improves ClassLoadUnloadTest; already backported to [JDK21](https://github.com/openjdk/jdk21u-dev/pull/909) and [JDK17](https://github.com/openjdk/jdk17u-dev/pull/2806). Original commit does not apply cleanly due to the options "-Xlog:class+load+cause" "-Xlog:class+load+cause+native" were not added until a later [version](https://bugs.openjdk.org/browse/JDK-8193513), thus these cases are excluded. Some args in exec() also were not added until a [later version](https://bugs.openjdk.org/browse/JDK-8289184), thus they are excluded. Additionally, [these flags](https://bugs.openjdk.org/browse/JDK-8256718) were deprecated in a later version and thus removed from this test; simple modifications are added so that these later removed cases follow the backport logic. Affected test passes.

MacOS GHA not passing due to unrelated deprecated sprintf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312049](https://bugs.openjdk.org/browse/JDK-8312049) needs maintainer approval

### Issue
 * [JDK-8312049](https://bugs.openjdk.org/browse/JDK-8312049): runtime/logging/ClassLoadUnloadTest can be improved (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2920/head:pull/2920` \
`$ git checkout pull/2920`

Update a local copy of the PR: \
`$ git checkout pull/2920` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2920`

View PR using the GUI difftool: \
`$ git pr show -t 2920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2920.diff">https://git.openjdk.org/jdk11u-dev/pull/2920.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2920#issuecomment-2307793156)
</details>
