### PR TITLE
8232367: Update Reactive Streams to 1.0.3 -- tests only

### DIFF
--- a/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/test/jdk/java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -278,8 +278,9 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
       @Override
       public void run(WhiteboxTestStage stage) throws InterruptedException {
         stage.puppet().triggerRequest(1);
-        stage.puppet().signalCancel();
         stage.expectRequest();
+        stage.puppet().signalCancel();
+        stage.expectCancelling();
         stage.signalNext();
 
         stage.puppet().triggerRequest(1);
@@ -824,11 +825,17 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
      * Before sending any element to the subscriber, the TCK must wait for the subscriber to request that element, and
      * must be prepared for the subscriber to only request one element at a time, it is not enough for the TCK to
      * simply invoke this method before sending elements.
+     * <p>
+     * An invocation of {@link #signalCancel()} may be coalesced into any elements that have not yet been requested,
+     * such that only a cancel signal is emitted.
      */
     void triggerRequest(long elements);
 
     /**
-     * Trigger {@code cancel()} on your {@link Subscriber}
+     * Trigger {@code cancel()} on your {@link Subscriber}.
+     * <p>
+     * An invocation of this method may be coalesced into any outstanding requests, as requested by
+     *{@link #triggerRequest(long)}, such that only a cancel signal is emitted.
      */
     void signalCancel();
   }


### PR DESCRIPTION
Backport of [JDK-8232367](https://bugs.openjdk.org/browse/JDK-8232367)

Testing
- Local: Compile passed on `MacOS 14.6.1` on Apple M1 Max
  - Not a test or directory containing tests: `java/net/httpclient/reactivestreams-tck/org/reactivestreams/tck/SubscriberWhiteboxVerification.java`
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: We consider SAP nightlies passed on `2024-09-03`
  - Because no test failure is found caused by `SubscriberWhiteboxVerification.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8232367](https://bugs.openjdk.org/browse/JDK-8232367) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232367](https://bugs.openjdk.org/browse/JDK-8232367): Update Reactive Streams to 1.0.3 -- tests only (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2921/head:pull/2921` \
`$ git checkout pull/2921`

Update a local copy of the PR: \
`$ git checkout pull/2921` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2921`

View PR using the GUI difftool: \
`$ git pr show -t 2921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2921.diff">https://git.openjdk.org/jdk11u-dev/pull/2921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2921#issuecomment-2308029119)
</details>
