### PR TITLE
8316193: jdk/jfr/event/oldobject/TestListenerLeak.java java.lang.Exception: Could not find leak

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestListenerLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestListenerLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,15 +74,17 @@ public class TestListenerLeak {
 
     public static void main(String[] args) throws Exception {
         WhiteBox.setWriteAllObjectSamples(true);
-
-        try (Recording r = new Recording()) {
-            r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
-            r.start();
-            listenerLeak();
-            r.stop();
-            List<RecordedEvent> events = Events.fromRecording(r);
-            if (OldObjects.countMatchingEvents(events, Stuff[].class, null, null, -1, "listenerLeak") == 0) {
-                throw new Exception("Could not find leak with " + Stuff[].class);
+        while (true) {
+            try (Recording r = new Recording()) {
+                r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
+                r.start();
+                listenerLeak();
+                r.stop();
+                List<RecordedEvent> events = Events.fromRecording(r);
+                if (OldObjects.countMatchingEvents(events, Stuff[].class, null, null, -1, "listenerLeak") != 0) {
+                    return; // Success
+                }
+                System.out.println("Could not find leak with " + Stuff[].class + ". Retrying.");
             }
         }
     }


### PR DESCRIPTION
Clean backport that makes TestListenerLeak more robust; already backported to 17 and 21. Passes affected test on Linux x64.
MacOS GHA failing due to unrelated deprecated code during compile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316193](https://bugs.openjdk.org/browse/JDK-8316193) needs maintainer approval

### Issue
 * [JDK-8316193](https://bugs.openjdk.org/browse/JDK-8316193): jdk/jfr/event/oldobject/TestListenerLeak.java java.lang.Exception: Could not find leak (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2923/head:pull/2923` \
`$ git checkout pull/2923`

Update a local copy of the PR: \
`$ git checkout pull/2923` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2923`

View PR using the GUI difftool: \
`$ git pr show -t 2923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2923.diff">https://git.openjdk.org/jdk11u-dev/pull/2923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2923#issuecomment-2311093721)