### PR TITLE
8247706: Unintentional use of new Date(year...) with absolute year

### DIFF
--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1067,7 +1067,7 @@ public class DateFormatRegression extends IntlTest {
         TimeZone.setDefault(TimeZone.getTimeZone("PST"));
         SimpleDateFormat fmt = new SimpleDateFormat("yy/MM/dd hh:ss zzz", Locale.JAPAN);
         @SuppressWarnings("deprecation")
-        String result = fmt.format(new Date(1999, 0, 1));
+        String result = fmt.format(new Date(1999 - 1900, 0, 1));
         logln("format()=>" + result);
         if (!result.endsWith("PST")) {
             errln("FAIL: SimpleDataFormat.format() did not retrun PST");

--- a/test/jdk/java/time/tck/java/time/format/TCKLocalizedPrinterParser.java
+++ b/test/jdk/java/time/tck/java/time/format/TCKLocalizedPrinterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class TCKLocalizedPrinterParser {
     @Test(dataProvider="time")
     public void test_time_print(LocalTime time, FormatStyle timeStyle, int timeStyleOld, Locale locale) {
         DateFormat old = DateFormat.getTimeInstance(timeStyleOld, locale);
-        Date oldDate = new Date(1970, 0, 0, time.getHour(), time.getMinute(), time.getSecond());
+        Date oldDate = new Date(1970 - 1900, 0, 0, time.getHour(), time.getMinute(), time.getSecond());
         String text = old.format(oldDate);
 
         DateTimeFormatter f = builder.appendLocalized(null, timeStyle).toFormatter(locale);
@@ -192,7 +192,7 @@ public class TCKLocalizedPrinterParser {
     @Test(dataProvider="time")
     public void test_time_parse(LocalTime time, FormatStyle timeStyle, int timeStyleOld, Locale locale) {
         DateFormat old = DateFormat.getTimeInstance(timeStyleOld, locale);
-        Date oldDate = new Date(1970, 0, 0, time.getHour(), time.getMinute(), time.getSecond());
+        Date oldDate = new Date(1970 - 1900, 0, 0, time.getHour(), time.getMinute(), time.getSecond());
         String text = old.format(oldDate);
 
         DateTimeFormatter f = builder.appendLocalized(null, timeStyle).toFormatter(locale);

--- a/test/jdk/java/util/Calendar/FieldStateTest.java
+++ b/test/jdk/java/util/Calendar/FieldStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ public class FieldStateTest extends IntlTest {
                 + "Then, getTime and set week of year to 43.");
 
         @SuppressWarnings("deprecation")
-        Date d = new Date(2003 - 1990, OCTOBER, 31);
+        Date d = new Date(2003 - 1900, OCTOBER, 31);
         cal.setTime(d);
         cal.set(DAY_OF_WEEK, SUNDAY);
         cal.set(2003, OCTOBER, 31); // 2003/10/31 is Friday.


### PR DESCRIPTION
Backport of [JDK-8247706](https://bugs.openjdk.org/browse/JDK-8247706)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - Passed: `java/text/Format/DateFormat/DateFormatRegression.java`
  - Passed: `java/time/tck/java/time/format/TCKLocalizedPrinterParser.java`
  - Passed: `java/util/Calendar/FieldStateTest.java`
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine: SAP nightlies passed on `2024-09-03`
  - Automated jtreg test: `jtreg_jdk_tier1` Started at `2024-09-03 09:22:44+01:00`
  - java/util/Calendar/FieldStateTest.java: SUCCESSFUL GitHub 📊 - [09:37:01.601 -> 954 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8247706](https://bugs.openjdk.org/browse/JDK-8247706) needs maintainer approval

### Issue
 * [JDK-8247706](https://bugs.openjdk.org/browse/JDK-8247706): Unintentional use of new Date(year...) with absolute year (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2924/head:pull/2924` \
`$ git checkout pull/2924`

Update a local copy of the PR: \
`$ git checkout pull/2924` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2924`

View PR using the GUI difftool: \
`$ git pr show -t 2924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2924.diff">https://git.openjdk.org/jdk11u-dev/pull/2924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2924#issuecomment-2311395833)