### PR TITLE
8249678: @ignore should be used instead of ProblemList for 8158860, 8163894, 8193479, 8194310

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -98,17 +98,12 @@ compiler/aot/verification/vmflags/TrackedFlagTest.java 8215224 generic-all
 compiler/aot/verification/vmflags/NotTrackedFlagTest.java 8215224 generic-all
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/codecache/stress/OverloadCompileQueueTest.java 8166554 generic-all
-compiler/codegen/Test6896617.java 8193479 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8140405 generic-all
 compiler/gcbarriers/UnsafeIntrinsicsTest.java#z 8315528 linux-x64
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/compilerToVM/GetResolvedJavaTypeTest.java 8158860 generic-all
-compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java 8163894 generic-all
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 compiler/types/correctness/CorrectnessTest.java 8225620 solaris-sparcv9
 compiler/types/correctness/OffTest.java 8225620 solaris-sparcv9
-
-compiler/c2/Test6852078.java 8194310 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 

--- a/test/hotspot/jtreg/compiler/c2/Test6852078.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6852078.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @modules java.corba/com.sun.corba.se.impl.encoding
  *          java.corba/com.sun.jndi.toolkit.corba
  *
+ * @ignore 8194310
  * @run main compiler.c2.Test6852078
  */
 

--- a/test/hotspot/jtreg/compiler/codegen/Test6896617.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test6896617.java
@@ -31,6 +31,7 @@
  *          java.base/sun.nio.cs
  *          java.management
  *
+ * @ignore 8193479
  * @run main/othervm/timeout=1200 -Xbatch -Xmx256m compiler.codegen.Test6896617
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetResolvedJavaTypeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetResolvedJavaTypeTest.java
@@ -27,6 +27,7 @@
  * @requires vm.jvmci
  * @library / /test/lib
  * @library ../common/patches
+ * @ignore 8158860
  * @modules java.base/jdk.internal.misc
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.meta

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java
@@ -27,6 +27,7 @@
  * @requires vm.jvmci
  * @library /test/lib /
  * @library ../common/patches
+ * @ignore 8163894
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.org.objectweb.asm.tree


### PR DESCRIPTION
Backport of [JDK-8249678](https://bugs.openjdk.org/browse/JDK-8249678)

Testing
- Local: 
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8249678](https://bugs.openjdk.org/browse/JDK-8249678) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249678](https://bugs.openjdk.org/browse/JDK-8249678): @<!---->ignore should be used instead of ProblemList for 8158860, 8163894, 8193479, 8194310 (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2925/head:pull/2925` \
`$ git checkout pull/2925`

Update a local copy of the PR: \
`$ git checkout pull/2925` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2925`

View PR using the GUI difftool: \
`$ git pr show -t 2925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2925.diff">https://git.openjdk.org/jdk11u-dev/pull/2925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2925#issuecomment-2311421603)