### PR TITLE
8249836: java/io/IOException/LastErrorString.java should have bug-id as 1st word in @ignore

### DIFF
--- a/test/jdk/java/io/IOException/LastErrorString.java
+++ b/test/jdk/java/io/IOException/LastErrorString.java
@@ -23,7 +23,7 @@
 
 /* @test
    @bug 4167937
-   @ignore Test truncates system files when run as root, see 7042603
+   @ignore 7042603 - Test truncates system files when run as root
    @summary Test code paths that use the JVM_LastErrorString procedure
  */
 


### PR DESCRIPTION
Backport of [JDK-8249836](https://bugs.openjdk.org/browse/JDK-8249836)

Testing
- Local: 
- Pipeline: All passed except `macOS`
  - `macOS`: `/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here` The issue exists in all recent PR in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/pulls) and not caused by Current PR
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8249836](https://bugs.openjdk.org/browse/JDK-8249836) needs maintainer approval

### Issue
 * [JDK-8249836](https://bugs.openjdk.org/browse/JDK-8249836): java/io/IOException/LastErrorString.java should have bug-id as 1st word in @<!---->ignore (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2926/head:pull/2926` \
`$ git checkout pull/2926`

Update a local copy of the PR: \
`$ git checkout pull/2926` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2926`

View PR using the GUI difftool: \
`$ git pr show -t 2926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2926.diff">https://git.openjdk.org/jdk11u-dev/pull/2926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2926#issuecomment-2311495605)