### PR TITLE
8258734: jdk/jfr/event/oldobject/TestClassLoaderLeak.java failed with "RuntimeException: Could not find class leak"

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -57,11 +57,14 @@ public class TestClassLoaderLeak {
             r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
             r.start();
             TestClassLoader testClassLoader = new TestClassLoader();
-            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
+            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 200)) {
                 // Allocate array to trigger sampling code path for interpreter / c1
-                for (int i = 0; i < 20; i++) {
+                for (int i = 0; i < 200; i++) {
                     Object classArray = Array.newInstance(clazz, 20);
-                    Array.set(classArray, i, clazz.newInstance());
+                    // No need to fill whole array
+                    for (int j = 0; j < 5; j++) {
+                        Array.set(classArray, j, clazz.getConstructors()[0].newInstance());
+                    }
                     classObjects.add(classArray);
                 }
             }
@@ -69,6 +72,7 @@ public class TestClassLoaderLeak {
             List<RecordedEvent> events = Events.fromRecording(r);
             Events.hasEvents(events);
             for (RecordedEvent e : events) {
+                System.out.println(e);
                 RecordedObject object = e.getValue("object");
                 RecordedClass rc = object.getValue("type");
                 if (rc.getName().contains("TestClass")) {


### PR DESCRIPTION
Directory "build/jtreg-test" not found: creating
Directory "JTreport" not found: creating
Passed: jdk/jfr/event/oldobject/TestClassLoaderLeak.java
Test results: passed: 1
Report written to /Users/I048686/SAPDevelop/github.com/dev-8258734-17/JTreport/html/report.html
Results written to /Users/I048686/SAPDevelop/github.com/dev-8258734-17/build/jtreg-test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8258734](https://bugs.openjdk.org/browse/JDK-8258734) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258734](https://bugs.openjdk.org/browse/JDK-8258734): jdk/jfr/event/oldobject/TestClassLoaderLeak.java failed with "RuntimeException: Could not find class leak" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2929/head:pull/2929` \
`$ git checkout pull/2929`

Update a local copy of the PR: \
`$ git checkout pull/2929` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2929`

View PR using the GUI difftool: \
`$ git pr show -t 2929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2929.diff">https://git.openjdk.org/jdk11u-dev/pull/2929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2929#issuecomment-2316530779)