### PR TITLE
8268364: jmethod clearing should be done during unloading

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -614,6 +614,21 @@ void ClassLoaderData::unload() {
   // after erroneous classes are released.
   classes_do(InstanceKlass::notify_unload_class);
 
+  // Method::clear_jmethod_ids only sets the jmethod_ids to NULL without
+  // releasing the memory for related JNIMethodBlocks and JNIMethodBlockNodes.
+  // This is done intentionally because native code (e.g. JVMTI agent) holding
+  // jmethod_ids may access them after the associated classes and class loader
+  // are unloaded. The Java Native Interface Specification says "method ID
+  // does not prevent the VM from unloading the class from which the ID has
+  // been derived. After the class is unloaded, the method or field ID becomes
+  // invalid". In real world usages, the native code may rely on jmethod_ids
+  // being NULL after class unloading. Hence, it is unsafe to free the memory
+  // from the VM side without knowing when native code is going to stop using
+  // them.
+  if (_jmethod_ids != NULL) {
+    Method::clear_jmethod_ids(this);
+  }
+
   // Clean up global class iterator for compiler
   static_klass_iterator.adjust_saved_class(this);
 }
@@ -748,15 +763,6 @@ ClassLoaderData::~ClassLoaderData() {
   if (m != NULL) {
     _metaspace = NULL;
     delete m;
-  }
-  // Clear all the JNI handles for methods
-  // These aren't deallocated and are going to look like a leak, but that's
-  // needed because we can't really get rid of jmethodIDs because we don't
-  // know when native code is going to stop using them.  The spec says that
-  // they're "invalid" but existing programs likely rely on their being
-  // NULL after class unloading.
-  if (_jmethod_ids != NULL) {
-    Method::clear_jmethod_ids(this);
   }
   // Delete lock
   delete _metaspace_lock;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2191,10 +2191,15 @@ bool Method::is_method_id(jmethodID mid) {
 Method* Method::checked_resolve_jmethod_id(jmethodID mid) {
   if (mid == NULL) return NULL;
   Method* o = resolve_jmethod_id(mid);
-  if (o == NULL || o == JNIMethodBlock::_free_method || !((Metadata*)o)->is_method()) {
+  if (o == NULL || o == JNIMethodBlock::_free_method) {
     return NULL;
   }
-  return o;
+  // Method should otherwise be valid. Assert for testing.
+  assert(is_valid_method(o), "should be valid jmethodid");
+  // If the method's class holder object is unreferenced, but not yet marked as
+  // unloaded, we need to return NULL here too because after a safepoint, its memory
+  // will be reclaimed.
+  return o->method_holder()->is_loader_alive() ? o : NULL;
 };
 
 void Method::set_on_stack(const bool value) {


### PR DESCRIPTION
Backport of [8268364](https://bugs.openjdk.org/browse/JDK-8268364), single hunk conflict resolved by accepting "empty" from the backport commit vs. `clear_jmethod_ids` invocation in the dtor. Backport commit moves the `clear_jmethod_ids` invocation to `unload` method instead.

It fixes crashes when accessing jmethodIDs of a class being unloaded.

Here is the reproducer that crashes JVM in ~1 second without the patch, but works fine with it: [gist](https://gist.github.com/krk/a0800bac5bc5a01709be85637285a965).

This fix also resolves the issue reported at https://github.com/async-profiler/async-profiler/issues/974 for Java 11.

To run the repro:

```
javac Main.java
gcc -shared -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" -fPIC repro.cpp -orepro.so

java -agentpath:"$(pwd)/repro.so" -Xmx100m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+ExplicitGCInvokesConcurrent Main
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8268364](https://bugs.openjdk.org/browse/JDK-8268364) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8268364: jmethod clearing should be done during unloading`

### Issue
 * [JDK-8268364](https://bugs.openjdk.org/browse/JDK-8268364): jmethod clearing should be done during unloading (**Bug** - P4 - Approved)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2935/head:pull/2935` \
`$ git checkout pull/2935`

Update a local copy of the PR: \
`$ git checkout pull/2935` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2935`

View PR using the GUI difftool: \
`$ git pr show -t 2935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2935.diff">https://git.openjdk.org/jdk11u-dev/pull/2935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2935#issuecomment-2358769964)
</details>
