### PR TITLE
8318696: Do not use LFS64 symbols on Linux

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -436,7 +436,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
 [
   #### OS DEFINES, these should be independent on toolchain
   if test "x$OPENJDK_TARGET_OS" = xlinux; then
-    CFLAGS_OS_DEF_JVM="-DLINUX"
+    CFLAGS_OS_DEF_JVM="-DLINUX -D_FILE_OFFSET_BITS=64"
     CFLAGS_OS_DEF_JDK="-D_GNU_SOURCE -D_REENTRANT -D_LARGEFILE64_SOURCE"
   elif test "x$OPENJDK_TARGET_OS" = xsolaris; then
     CFLAGS_OS_DEF_JVM="-DSOLARIS"

--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -459,14 +459,14 @@ AttachOperation* AttachListener::dequeue() {
 
 void AttachListener::vm_start() {
   char fn[UNIX_PATH_MAX];
-  struct stat64 st;
+  struct stat st;
   int ret;
 
   int n = snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
            os::get_temp_directory(), os::current_process_id());
   assert(n < (int)UNIX_PATH_MAX, "java_pid file name buffer overflow");
 
-  RESTARTABLE(::stat64(fn, &st), ret);
+  RESTARTABLE(::stat(fn, &st), ret);
   if (ret == 0) {
     ret = ::unlink(fn);
     if (ret == -1) {
@@ -493,8 +493,8 @@ int AttachListener::pd_init() {
 
 bool AttachListener::check_socket_file() {
   int ret;
-  struct stat64 st;
-  ret = stat64(LinuxAttachListener::path(), &st);
+  struct stat st;
+  ret = stat(LinuxAttachListener::path(), &st);
   if (ret == -1) { // need to restart attach listener.
     log_debug(attach)("Socket file %s does not exist - Restart Attach Listener",
                       LinuxAttachListener::path());
@@ -533,14 +533,14 @@ bool AttachListener::is_init_trigger() {
   }
   char fn[PATH_MAX + 1];
   int ret;
-  struct stat64 st;
+  struct stat st;
   sprintf(fn, ".attach_pid%d", os::current_process_id());
-  RESTARTABLE(::stat64(fn, &st), ret);
+  RESTARTABLE(::stat(fn, &st), ret);
   if (ret == -1) {
     log_trace(attach)("Failed to find attach file: %s, trying alternate", fn);
     snprintf(fn, sizeof(fn), "%s/.attach_pid%d",
              os::get_temp_directory(), os::current_process_id());
-    RESTARTABLE(::stat64(fn, &st), ret);
+    RESTARTABLE(::stat(fn, &st), ret);
     if (ret == -1) {
       log_debug(attach)("Failed to find attach file: %s", fn);
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6025,14 +6025,14 @@ int os::open(const char *path, int oflag, int mode) {
   oflag |= O_CLOEXEC;
 #endif
 
-  int fd = ::open64(path, oflag, mode);
+  int fd = ::open(path, oflag, mode);
   if (fd == -1) return -1;
 
   //If the open succeeded, the file might still be a directory
   {
-    struct stat64 buf64;
-    int ret = ::fstat64(fd, &buf64);
-    int st_mode = buf64.st_mode;
+    struct stat buf;
+    int ret = ::fstat(fd, &buf);
+    int st_mode = buf.st_mode;
 
     if (ret != -1) {
       if ((st_mode & S_IFMT) == S_IFDIR) {
@@ -6069,17 +6069,17 @@ int os::open(const char *path, int oflag, int mode) {
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
   oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
-  return ::open64(path, oflags, S_IREAD | S_IWRITE);
+  return ::open(path, oflags, S_IREAD | S_IWRITE);
 }
 
 // return current position of file pointer
 jlong os::current_file_offset(int fd) {
-  return (jlong)::lseek64(fd, (off64_t)0, SEEK_CUR);
+  return (jlong)::lseek(fd, (off_t)0, SEEK_CUR);
 }
 
 // move file pointer to the specified offset
 jlong os::seek_to_file_offset(int fd, jlong offset) {
-  return (jlong)::lseek64(fd, (off64_t)offset, SEEK_SET);
+  return (jlong)::lseek(fd, (off_t)offset, SEEK_SET);
 }
 
 // This code originates from JDK's sysAvailable
@@ -6088,10 +6088,10 @@ jlong os::seek_to_file_offset(int fd, jlong offset) {
 int os::available(int fd, jlong *bytes) {
   jlong cur, end;
   int mode;
-  struct stat64 buf64;
+  struct stat buf;
 
-  if (::fstat64(fd, &buf64) >= 0) {
-    mode = buf64.st_mode;
+  if (::fstat(fd, &buf) >= 0) {
+    mode = buf.st_mode;
     if (S_ISCHR(mode) || S_ISFIFO(mode) || S_ISSOCK(mode)) {
       int n;
       if (::ioctl(fd, FIONREAD, &n) >= 0) {
@@ -6100,11 +6100,11 @@ int os::available(int fd, jlong *bytes) {
       }
     }
   }
-  if ((cur = ::lseek64(fd, 0L, SEEK_CUR)) == -1) {
+  if ((cur = ::lseek(fd, 0L, SEEK_CUR)) == -1) {
     return 0;
-  } else if ((end = ::lseek64(fd, 0L, SEEK_END)) == -1) {
+  } else if ((end = ::lseek(fd, 0L, SEEK_END)) == -1) {
     return 0;
-  } else if (::lseek64(fd, cur, SEEK_SET) == -1) {
+  } else if (::lseek(fd, cur, SEEK_SET) == -1) {
     return 0;
   }
   *bytes = end - cur;

--- a/src/hotspot/os/linux/os_linux.inline.hpp
+++ b/src/hotspot/os/linux/os_linux.inline.hpp
@@ -70,7 +70,7 @@ inline void os::dll_unload(void *lib) {
 inline const int os::default_file_open_flags() { return 0;}
 
 inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek64(fd, offset, whence);
+  return (jlong) ::lseek(fd, offset, whence);
 }
 
 inline int os::fsync(int fd) {
@@ -78,7 +78,7 @@ inline int os::fsync(int fd) {
 }
 
 inline int os::ftruncate(int fd, jlong length) {
-  return ::ftruncate64(fd, length);
+  return ::ftruncate(fd, length);
 }
 
 // macros for restartable system calls


### PR DESCRIPTION
Backport of [JDK-8318696 Do not use LFS64 symbols on Linux](https://bugs.openjdk.org/browse/JDK-8318696). This replaces the usage of LFS64 symbols in Linux with their regular counterparts adding `-D_FILE_OFFSET_BITS=64`.

This is not a clean backport, because in `jdk11`  many of these symbols still live in `os_linux.cpp` and `os_linux_inline.hpp`, that were then refactored/deleted during the years into [the current `os_posix.hpp` and `os_posix.cpp` in `jdk17`](https://github.com/openjdk/jdk17u-dev/commit/2b9228a3c92590e3146ecad468bb2ea68a5a6bb2).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8318696](https://bugs.openjdk.org/browse/JDK-8318696) needs maintainer approval

### Issue
 * [JDK-8318696](https://bugs.openjdk.org/browse/JDK-8318696): Do not use LFS64 symbols on Linux (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2938/head:pull/2938` \
`$ git checkout pull/2938`

Update a local copy of the PR: \
`$ git checkout pull/2938` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2938`

View PR using the GUI difftool: \
`$ git pr show -t 2938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2938.diff">https://git.openjdk.org/jdk11u-dev/pull/2938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2938#issuecomment-2360575022)