### PR TITLE
8338058: map_or_reserve_memory_aligned Windows enhance remap assertion

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3185,7 +3185,8 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
 
   }
 
-  assert(aligned_base != NULL, "Did not manage to re-map after %d attempts?", max_attempts);
+  assert(aligned_base != nullptr,
+      "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101) needs maintainer approval
- [x] Commit message must refer to an issue
- [ ] [JDK-8338058](https://bugs.openjdk.org/browse/JDK-8338058) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058`

### Issues
 * [JDK-8338058](https://bugs.openjdk.org/browse/JDK-8338058): map_or_reserve_memory_aligned Windows enhance remap assertion (**Enhancement** - P4 - Requested)
 * [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101): remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058 (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2939/head:pull/2939` \
`$ git checkout pull/2939`

Update a local copy of the PR: \
`$ git checkout pull/2939` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2939`

View PR using the GUI difftool: \
`$ git pr show -t 2939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2939.diff">https://git.openjdk.org/jdk11u-dev/pull/2939.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2939#issuecomment-2367885209)