### PR TITLE
8340671: GHA: Bump macOS and Xcode versions to macos-12 and XCode 13.4.1

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-13
+    runs-on: macos-12
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '14.3.1'
+      xcode-toolset-version: '13.4.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
@@ -234,7 +234,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '14.3.1'
+      xcode-toolset-version: '13.4.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -298,7 +298,7 @@ jobs:
     with:
       platform: macos-x64
       bootjdk-platform: macos-x64
-      runs-on: macos-13
+      runs-on: macos-12
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           # On macOS we need to install some dependencies for testing
           brew install make
-          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'


### PR DESCRIPTION
The macos-11 github runners [were deprecated and removed in June 2024](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/) , making the macos tests to hang in openjdk11u-dev (and other OpenJDK repositories).

[JDK-8335793 GHA: Bump macOS and Xcode versions](https://bugs.openjdk.org/browse/JDK-8335793) upgraded the version https://github.com/openjdk/jdk11u-dev/pull/2835 of mac runners to macos-13. This upgrade in github runners required a long list of changes in openjdk11u-dev that proved difficult to review.

In order to ease the review process this PR downgrades the version of github runners in jdk11u-dev from the current macos-13 to macos-12 and xcode-13.4.1. This will require a single backport of [JDK-8299254 Support dealing with standard assert macro](https://bugs.openjdk.org/browse/JDK-8299254) (a follow-up to this PR), making the review process easier.

Once the github actions are running again in macos-12 an upgrade to macos-13 could be performed, if required, with some more additional PRs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340671](https://bugs.openjdk.org/browse/JDK-8340671) needs maintainer approval

### Issue
 * [JDK-8340671](https://bugs.openjdk.org/browse/JDK-8340671): GHA: Bump macOS and Xcode versions to macos-12 and XCode 13.4.1 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2940/head:pull/2940` \
`$ git checkout pull/2940`

Update a local copy of the PR: \
`$ git checkout pull/2940` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2940`

View PR using the GUI difftool: \
`$ git pr show -t 2940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2940.diff">https://git.openjdk.org/jdk11u-dev/pull/2940.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2940#issuecomment-2372271722)