### PR TITLE
8342629: [11u] Properly message out that shenandoah is disabled

### DIFF
--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -378,6 +378,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
     fi
   else
       DISABLED_JVM_FEATURES="$DISABLED_JVM_FEATURES shenandoahgc"
+      AC_MSG_RESULT([no, must be manually enabled --with-jvm-features=shenandoahgc])
   fi
 
   # Only enable ZGC on supported platforms


### PR DESCRIPTION
Unluckily, ShenandoahGC in jdk11 i still disabled by default. In addition, its output is broken:

```
checking for dlopen in -ldl... yes
checking if shenandoah can be built... checking if zgc can be built... no, platform not supported
checking if jvmci module jdk.internal.vm.ci should be built... yes
```

In all other JDKs it is enabled by default, and prints correctly yes/no:
```
checking for dlopen in -ldl... yes
checking if shenandoah can be built... yes
checking if zgc can be built... yes
checking if jvmci module jdk.internal.vm.ci should be built... yes
```


This PR is fixing this. In jdk17 and up , when manually disabled, the "no" is printed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8342629](https://bugs.openjdk.org/browse/JDK-8342629) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342629](https://bugs.openjdk.org/browse/JDK-8342629): [11u] Properly message out that shenandoah is disabled (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2946/head:pull/2946` \
`$ git checkout pull/2946`

Update a local copy of the PR: \
`$ git checkout pull/2946` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2946`

View PR using the GUI difftool: \
`$ git pr show -t 2946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2946.diff">https://git.openjdk.org/jdk11u-dev/pull/2946.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2946#issuecomment-2422905668)
</details>
