### PR TITLE
Backport 7cff981f5a3aa192e57545c7df069fb48ba69edf

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -249,6 +249,7 @@ class CodeStrings {
 private:
 #ifndef PRODUCT
   CodeString* _strings;
+  CodeString* _strings_last;
 #ifdef ASSERT
   // Becomes true after copy-out, forbids further use.
   bool _defunct; // Zero bit pattern is "valid", see memset call in decode_env::decode_env
@@ -262,6 +263,7 @@ private:
   void set_null_and_invalidate() {
 #ifndef PRODUCT
     _strings = NULL;
+    _strings_last = NULL;
 #ifdef ASSERT
     _defunct = true;
 #endif
@@ -272,6 +274,7 @@ public:
   CodeStrings() {
 #ifndef PRODUCT
     _strings = NULL;
+    _strings_last = NULL;
 #ifdef ASSERT
     _defunct = false;
 #endif


### PR DESCRIPTION
Hi all,
This is prefix backport of [JDK-8231058](https://bugs.openjdk.org/browse/JDK-8231058), after apply this backport will make backport of [JDK-8231058](https://bugs.openjdk.org/browse/JDK-8231058) cleanly.

Additonal testing:

- [ ] linux aarch64 build with release/slowdebug configure
- [ ] linux x86_64 build with release/slowdebug configure
- [ ] jtreg tests(include tier1/2/3 etc.) with release build on linux aarch64
- [ ] jtreg tests(include tier1/2/3 etc.) with release build on linux x86_64