### PR TITLE
8342426: [11u] javax/naming/module/RunBasic.java javac compile fails

### DIFF
--- a/test/jdk/javax/naming/module/RunBasic.java
+++ b/test/jdk/javax/naming/module/RunBasic.java
@@ -134,15 +134,7 @@ public class RunBasic {
         opts.add("test/" + clsName);
         opts.add("ldap://" + HOST_NAME + "/dc=ie,dc=oracle,dc=com");
         System.out.println("Running with the '" + desc + "' module...");
-<<<<<<< HEAD
-        runJava("-Dtest.src=" + TEST_SRC, "-p", "mods", "-m", "test/" + clsName,
-                "ldap://" + HOST_NAME + "/dc=ie,dc=oracle,dc=com");
-||||||| 82c330b464
-        runJava("-Dtest.src=" + TEST_SRC, "-p", "mods", "-m", "test/" + clsName,
-                "ldap://localhost/dc=ie,dc=oracle,dc=com");
-=======
         runJava(opts.toArray(String[]::new));
->>>>>>> cee8535a9d3de8558b4b5028d68e397e508bef71
     }
 
     private static void runJava(String... opts) throws Throwable {


### PR DESCRIPTION
Hi all,
The test `test/jdk/javax/naming/module/RunBasic.java` report javac compile fails after `Merge: 1393271305 cee8535a9d`. This PR fix the wrong git context.
The change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342426](https://bugs.openjdk.org/browse/JDK-8342426) needs maintainer approval

### Issue
 * [JDK-8342426](https://bugs.openjdk.org/browse/JDK-8342426): [11u] javax/naming/module/RunBasic.java javac compile fails (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2953/head:pull/2953` \
`$ git checkout pull/2953`

Update a local copy of the PR: \
`$ git checkout pull/2953` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2953`

View PR using the GUI difftool: \
`$ git pr show -t 2953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2953.diff">https://git.openjdk.org/jdk11u-dev/pull/2953.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2953#issuecomment-2417247456)