### PR TITLE
8195675: Call to insertText with single character from custom Input Method ignored

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -39,6 +39,9 @@
 // keyboard layout
 static NSString *kbdLayout;
 
+// Constant for keyman layouts
+#define KEYMAN_LAYOUT "keyman"
+
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
 @property (retain) CDragSource *_dragSource;
@@ -281,7 +284,7 @@ static BOOL shouldUsePressAndHold() {
 
 - (void) keyDown: (NSEvent *)event {
     fProcessingKeystroke = YES;
-    fKeyEventsNeeded = YES;
+    fKeyEventsNeeded = ![(NSString *)kbdLayout containsString:@KEYMAN_LAYOUT];
 
     // Allow TSM to look at the event and potentially send back NSTextInputClient messages.
     [self interpretKeyEvents:[NSArray arrayWithObject:event]];
@@ -989,7 +992,7 @@ static jclass jc_CInputMethod = NULL;
 
     if ((utf16Length > 2) ||
         ((utf8Length > 1) && [self isCodePointInUnicodeBlockNeedingIMEvent:codePoint]) ||
-        ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"]))) {
+        [(NSString *)kbdLayout containsString:@KEYMAN_LAYOUT]) {
         aStringIsComplex = YES;
     }
 


### PR DESCRIPTION
@srl295 Could not automatically backport b8f2ec90 to openjdk/jdk11u-dev due to conflicts in the following files:

src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
Please fetch the appropriate branch/commit and manually resolve these conflicts by using the following commands in your personal fork of openjdk/jdk11u-dev. Note: these commands are just some suggestions and you can use other equivalent commands you know.

# Fetch the up-to-date version of the target branch
$ git fetch --no-tags https://git.openjdk.org/jdk11u-dev.git master:master

# Check out the target branch and create your own branch to backport
$ git checkout master
$ git checkout -b backport-srl295-b8f2ec90-master

# Fetch the commit you want to backport
$ git fetch --no-tags https://git.openjdk.org/jdk.git b8f2ec9091f9f7e5f4611991d04dd8aa113b94fd

# Backport the commit
$ git cherry-pick --no-commit b8f2ec9091f9f7e5f4611991d04dd8aa113b94fd
# Resolve conflicts now

# Commit the files you have modified
$ git add files/with/resolved/conflicts
$ git commit -m 'Backport b8f2ec9091f9f7e5f4611991d04dd8aa113b94fd'
Once you have resolved the conflicts as explained above continue with creating a pull request towards the openjdk/jdk11u-dev with the title Backport b8f2ec9091f9f7e5f4611991d04dd8aa113b94fd.

Below you can find a suggestion for the pull request body:

Hi all,

This pull request contains a backport of commit b8f2ec90 from the openjdk/jdk repository.

The commit being backported was authored by Steven Loomis on 28 May 2024 and was reviewed by Phil Race.

PR: https://github.com/openjdk/jdk/pull/17921

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8195675](https://bugs.openjdk.org/browse/JDK-8195675) needs maintainer approval

### Issue
 * [JDK-8195675](https://bugs.openjdk.org/browse/JDK-8195675): Call to insertText with single character from custom Input Method ignored (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2954/head:pull/2954` \
`$ git checkout pull/2954`

Update a local copy of the PR: \
`$ git checkout pull/2954` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2954`

View PR using the GUI difftool: \
`$ git pr show -t 2954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2954.diff">https://git.openjdk.org/jdk11u-dev/pull/2954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2954#issuecomment-2417888007)
</details>
