### PR TITLE
8323688: C2: Fix UB of jlong overflow in PhaseIdealLoop::is_counted_loop()

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -739,11 +739,27 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*& loop) {
   //     Since stride > 0 and limit_correction <= stride + 1, we can restate this with no over- or underflow into:
   //         max_int - canonicalized_correction - limit_correction >= limit
   //     Since canonicalized_correction and limit_correction are both constants, we can replace them with a new constant:
-  //         final_correction = canonicalized_correction + limit_correction
+  //         (v) final_correction = canonicalized_correction + limit_correction
+  //
   //     which gives us:
   //
   //     Final predicate condition:
   //         max_int - final_correction >= limit
+  //
+  //     However, we need to be careful that (v) does not over- or underflow.
+  //     We know that:
+  //         canonicalized_correction = stride - 1
+  //     and
+  //         limit_correction <= stride + 1
+  //     and thus
+  //         canonicalized_correction + limit_correction <= 2 * stride
+  //     To prevent an over- or underflow of (v), we must ensure that
+  //         2 * stride <= max_int
+  //     which can safely be checked without over- or underflow with
+  //         (vi) stride != min_int AND abs(stride) <= max_int / 2
+  //
+  //     We could try to further optimize the cases where (vi) does not hold but given that such large strides are
+  //     very uncommon and the loop would only run for a very few iterations anyway, we simply bail out if (vi) fails.
   //
   // (2) Loop Limit Check Predicate for (ii):
   //     Using (ii): init < limit
@@ -775,6 +791,10 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*& loop) {
   //            there is no overflow of the iv phi after the first iteration. In this case, we don't need to check (ii)
   //            again and can skip the predicate.
 
+  // Check (vi) and bail out if the stride is too big.
+  if (stride_con == min_signed_integer(iv_bt) || (ABS(stride_con) > max_signed_integer(iv_bt) / 2)) {
+    return false;
+  }
 
   // Accounting for (LE3) and (LE4) where we use pre-incremented phis in the loop exit check.
   const jlong limit_correction_for_pre_iv_exit_check = (phi_incr != NULL) ? stride_con : 0;


### PR DESCRIPTION
Backport for JDK-8323688 C2: Fix UB of jlong overflow in PhaseIdealLoop::is_counted_loop()
https://bugs.openjdk.org/browse/JDK-8323688

The computation of `final_correction` in `is_counted_loop()` could overflow which is UB. I don't think that any compiler would produce a wrong result. But we should still fix this UB.

This is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8323688](https://bugs.openjdk.org/browse/JDK-8323688) needs maintainer approval

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8323688](https://bugs.openjdk.org/browse/JDK-8323688): C2: Fix UB of jlong overflow in PhaseIdealLoop::is_counted_loop() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2962/head:pull/2962` \
`$ git checkout pull/2962`

Update a local copy of the PR: \
`$ git checkout pull/2962` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2962`

View PR using the GUI difftool: \
`$ git pr show -t 2962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2962.diff">https://git.openjdk.org/jdk11u-dev/pull/2962.diff</a>

</details>
