### PR TITLE
8231058: VerifyOops crashes with assert(_offset >= 0) failed: offset for non comment?

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1100,7 +1100,7 @@ CodeString* CodeStrings::find(intptr_t offset) const {
 // Convenience for add_comment.
 CodeString* CodeStrings::find_last(intptr_t offset) const {
   CodeString* a = _strings_last;
-  while (a != NULL && !a->is_comment() && a->offset() > offset) {
+  while (a != NULL && !(a->is_comment() && a->offset() == offset)) {
     a = a->_prev;
   }
   return a;

--- a/test/hotspot/jtreg/runtime/CheckUnhandledOops/TestVerifyOops.java
+++ b/test/hotspot/jtreg/runtime/CheckUnhandledOops/TestVerifyOops.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8231058
+ * @requires vm.debug & (os.arch != "sparc") & (os.arch != "sparcv9")
+ * @run main/othervm -XX:+VerifyOops TestVerifyOops
+ */
+
+public class TestVerifyOops {
+
+    public static void main(String[] args) {
+        System.out.println("Test passed");
+    }
+}


### PR DESCRIPTION
Hi all,
This is clean backport of [JDK-8231058](https://bugs.openjdk.org/browse/JDK-8231058), to fix JVM crash when running with `-XX:+VerifyOops`. The newly added test run failed before this backport, and run passed after apply this backport.

Additonal testing:

- [x]  linux aarch64 build with release/slowdebug configure
- [x]  linux x86_64 build with release/slowdebug configure
- [x]  jtreg tests(include tier1/2/3 etc.) with release build on linux aarch64
- [x]  jtreg tests(include tier1/2/3 etc.) with release build on linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8231058](https://bugs.openjdk.org/browse/JDK-8231058) needs maintainer approval

### Issue
 * [JDK-8231058](https://bugs.openjdk.org/browse/JDK-8231058): VerifyOops crashes with assert(_offset &gt;= 0) failed: offset for non comment? (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2963/head:pull/2963` \
`$ git checkout pull/2963`

Update a local copy of the PR: \
`$ git checkout pull/2963` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2963`

View PR using the GUI difftool: \
`$ git pr show -t 2963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2963.diff">https://git.openjdk.org/jdk11u-dev/pull/2963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2963#issuecomment-2466538089)
</details>
