### PR TITLE
8339803: Acknowledge case insensitive unambiguous keywords in tzdata files

### DIFF
--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
@@ -163,7 +163,8 @@ class TzdbZoneRulesProvider {
                         }
                         continue;
                     }
-                    if (line.startsWith("Zone")) {        // parse Zone line
+                    int token0len = tokens.length > 0 ? tokens[0].length() : line.length();
+                    if (line.regionMatches(true, 0, "Zone", 0, token0len)) {        // parse Zone line
                         String name = tokens[1];
                         if (excludedZones.contains(name)){
                             continue;
@@ -181,13 +182,13 @@ class TzdbZoneRulesProvider {
                         if (zLine.parse(tokens, 2)) {
                             openZone = null;
                         }
-                    } else if (line.startsWith("Rule")) { // parse Rule line
+                    } else if (line.regionMatches(true, 0, "Rule", 0, token0len)) { // parse Rule line
                         String name = tokens[1];
                         if (!rules.containsKey(name)) {
                             rules.put(name, new ArrayList<RuleLine>(10));
                         }
                         rules.get(name).add(new RuleLine().parse(tokens));
-                    } else if (line.startsWith("Link")) { // parse link line
+                    } else if (line.regionMatches(true, 0, "Link", 0, token0len)) { // parse link line
                         if (tokens.length >= 3) {
                             String realId = tokens[1];
                             String aliasId = tokens[2];
@@ -303,7 +304,7 @@ class TzdbZoneRulesProvider {
             month = parseMonth(tokens[off++]);
             if (off < tokens.length) {
                 String dayRule = tokens[off++];
-                if (dayRule.startsWith("last")) {
+                if (dayRule.regionMatches(true, 0, "last", 0, 4)) {
                     dayOfMonth = -1;
                     dayOfWeek = parseDayOfWeek(dayRule.substring(4));
                     adjustForwards = false;
@@ -354,11 +355,12 @@ class TzdbZoneRulesProvider {
         }
 
         int parseYear(String year, int defaultYear) {
-            switch (year.toLowerCase()) {
-            case "min":  return 1900;
-            case "max":  return Year.MAX_VALUE;
-            case "only": return defaultYear;
-            }
+            int len = year.length();
+
+            if (year.regionMatches(true, 0, "minimum", 0, len)) return 1900;
+            if (year.regionMatches(true, 0, "maximum", 0, len)) return Year.MAX_VALUE;
+            if (year.regionMatches(true, 0, "only", 0, len)) return defaultYear;
+
             return Integer.parseInt(year);
         }
 

--- a/test/jdk/sun/util/calendar/zi/RuleRec.java
+++ b/test/jdk/sun/util/calendar/zi/RuleRec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,12 +168,13 @@ class RuleRec {
                 rec.toYear = Integer.parseInt(token);
             } catch (NumberFormatException e) {
                 // it's not integer
-                if ("min".equals(token) || "minimum".equals(token)) {
+                int len = token.length();
+                if (token.regionMatches(true, 0, "minimum", 0, len)) {
                     rec.fromYear = Zoneinfo.getMinYear();
-                } else if ("max".equals(token) || "maximum".equals(token)) {
+                } else if (token.regionMatches(true, 0, "maximum", 0, len)) {
                     rec.toYear = Integer.MAX_VALUE;
                     rec.isLastRule = true;
-                } else if ("only".equals(token)) {
+                } else if (token.regionMatches(true, 0, "only", 0, len)) {
                     rec.toYear = rec.fromYear;
                 } else {
                     Main.panic("invalid year value: "+token);

--- a/test/jdk/sun/util/calendar/zi/Zoneinfo.java
+++ b/test/jdk/sun/util/calendar/zi/Zoneinfo.java
@@ -240,8 +240,9 @@ class Zoneinfo {
                     continue;
                 }
                 String token = tokens.nextToken();
+                int len = token.length();
 
-                if (continued || "Zone".equals(token)) {
+                if (continued || token.regionMatches(true, 0, "Zone", 0, len)){
                     if (zone == null) {
                         if (!tokens.hasMoreTokens()) {
                             panic("syntax error: zone no more token");
@@ -268,7 +269,7 @@ class Zoneinfo {
                         }
                         zone = null;
                     }
-                } else if ("Rule".equals(token)) {
+                } else if (token.regionMatches(true, 0, "Rule", 0, len)) {
                     if (!tokens.hasMoreTokens()) {
                         panic("syntax error: rule no more token");
                     }
@@ -281,7 +282,7 @@ class Zoneinfo {
                     RuleRec rrec = RuleRec.parse(tokens);
                     rrec.setLine(line);
                     rule.add(rrec);
-                } else if ("Link".equals(token)) {
+                } else if (token.regionMatches(true, 0, "Link", 0, len)) {
                     // Link <newname> <oldname>
                     try {
                         String name1 = tokens.nextToken();


### PR DESCRIPTION
Backport of [JDK-8339803](https://bugs.openjdk.org/browse/JDK-8339803) from 17u. Related to tz-2024b timezone update.

Clean backport. Passed tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339803](https://bugs.openjdk.org/browse/JDK-8339803) needs maintainer approval

### Issue
 * [JDK-8339803](https://bugs.openjdk.org/browse/JDK-8339803): Acknowledge case insensitive unambiguous keywords in tzdata files (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2964/head:pull/2964` \
`$ git checkout pull/2964`

Update a local copy of the PR: \
`$ git checkout pull/2964` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2964`

View PR using the GUI difftool: \
`$ git pr show -t 2964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2964.diff">https://git.openjdk.org/jdk11u-dev/pull/2964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2964#issuecomment-2468424436)
</details>
