### PR TITLE
8343786: [11u] GHA: Bump macOS and Xcode versions to macos-13 and XCode 14.3.1

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -43,6 +43,8 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   else ifeq ($(call isBuildOs, aix), true)
     ADLC_LDFLAGS := -q64
     ADLC_CFLAGS := -qnortti -qeh -q64 -DAIX
+  else ifeq ($(call isBuildOs, macosx), true)
+    ADLC_CFLAGS := -Wno-deprecated-declarations
   else ifeq ($(call isBuildOs, windows), true)
     ADLC_LDFLAGS := -nologo
     ADLC_CFLAGS := -nologo -EHsc

--- a/make/launcher/Launcher-jdk.pack.gmk
+++ b/make/launcher/Launcher-jdk.pack.gmk
@@ -85,7 +85,7 @@ $(eval $(call SetupJdkExecutable, BUILD_UNPACKEXE, \
     CFLAGS_release := -DPRODUCT, \
     CFLAGS_linux := -fPIC, \
     CFLAGS_solaris := -KPIC, \
-    CFLAGS_macosx := -fPIC, \
+    CFLAGS_macosx := -fPIC -Wno-deprecated-declarations, \
     LDFLAGS := $(LDFLAGS_JDKEXE) $(LDFLAGS_CXX_JDK) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(UNPACKEXE_LIBS) $(LIBCXX), \

--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -208,6 +208,11 @@ ifeq ($(call isTargetOs, linux), true)
   LIBAWT_CFLAGS += $(EXPORT_ALL_SYMBOLS)
 endif
 
+ifeq ($(call isBuildOs, macosx), true)
+  # macos-13 JDK-8343786
+  LIBAWT_CFLAGS += -Wno-deprecated-non-prototype
+endif
+
 # Turn off all warnings for debug_mem.c This is needed because the specific warning
 # about initializing a declared 'extern' cannot be turned off individually. Only
 # applies to debug builds.
@@ -931,7 +936,7 @@ ifeq ($(call isTargetOs, macosx), true)
       libosxapp \
       #
 
-  LIBAWT_LWAWT_CFLAGS := $(X_CFLAGS) $(X_LIBS)
+  LIBAWT_LWAWT_CFLAGS := $(X_CFLAGS) $(X_LIBS)  -Wno-deprecated-non-prototype
 
   LIBAWT_LWAWT_EXFILES := fontpath.c awt_Font.c X11Color.c
   LIBAWT_LWAWT_EXCLUDES := $(TOPDIR)/src/$(MODULE)/unix/native/common/awt/medialib

--- a/make/lib/Lib-java.desktop.gmk
+++ b/make/lib/Lib-java.desktop.gmk
@@ -65,6 +65,7 @@ ifeq ($(call isTargetOs, aix), false)
       OPTIMIZATION := LOW, \
       CFLAGS := $(CFLAGS_JDKLIB) \
           $(LIBJSOUND_CFLAGS), \
+      CFLAGS_macosx := -Wno-deprecated-declarations, \
       CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBJSOUND_CFLAGS), \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \

--- a/make/lib/Lib-jdk.pack.gmk
+++ b/make/lib/Lib-jdk.pack.gmk
@@ -35,6 +35,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBUNPACK, \
     CFLAGS := $(CXXFLAGS_JDKLIB) \
         -DNO_ZLIB -DUNPACK_JNI -DFULL, \
     CFLAGS_release := -DPRODUCT, \
+    CFLAGS_macosx := -Wno-deprecated-declarations, \
     EXTRA_HEADER_DIRS := $(call GetJavaHeaderDir, java.base), \
     DISABLED_WARNINGS_gcc := implicit-fallthrough, \
     LDFLAGS := $(LDFLAGS_JDKLIB) $(LDFLAGS_CXX_JDK) \

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -146,6 +146,11 @@ endif
 
 JVMTI_COMMON_INCLUDES=-I$(TOPDIR)/test/lib/jdk/test/lib/jvmti
 
+ifeq ($(call isBuildOs, macosx), true)
+   NSK_AOD_INCLUDES += -Wno-deprecated-declarations
+   JVMTI_COMMON_INCLUDES += -Wno-deprecated-declarations
+endif
+
 BUILD_HOTSPOT_JTREG_LIBRARIES_CFLAGS_libNoFramePointer := $(NO_FRAMEPOINTER_CFLAGS)
 # Optimization -O3 needed, HIGH == -O3
 BUILD_HOTSPOT_JTREG_LIBRARIES_OPTIMIZATION_libNoFramePointer := HIGH


### PR DESCRIPTION
With [JDK-8340671](https://bugs.openjdk.org/browse/JDK-8340671) the GHA runner was bumped from `macos-11` to `macos-12` with minimum impact.

But the `macos-12` runner image [will be fully retired by December 3rd, 2024](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/), so it's now convenient  to bump to `macos-13`. 

Previous attempts to upgrade to GHA runners to `macos-13`  required a long list of backports that proved difficult to review and risky to backport. These were related to the deprecation of `sprintf` (that is replaced with `snprintf` in more modern OpenJDK versions), and to passing arguments to functions without a prototype in AWT native libraries.

Instead of risking to do these backports an alternate solution may be to add specific compilation flags that transform these errors to warnings. This is done by adding `-Wno-deprecated-declarations` (to bypass `sprintf` deprecation) and `-Wno-deprecated-non-prototype` to bypass passing arguments to a function without a prototype to specific parts of the makefiles for the `macosx` platform only.

For easier review the PR is separated in three commits in two pushes. 

- First push (to verify a proper build on `macos-12` with new compilation flags)
    - The first commit adds `-Wno-deprecated-declaration` to some makefiles (`macosx` only). 
    - And the second one adds `-Wno-deprecated-non-prototype` to the affected AWT libraries (again `macosx` only). 
- A second push (to ensure a proper build on `macos-13`)
  - A third commit that bumps GHA runners to `macos-13` and `xcode 14.3.1` 

Tier-1 tests seem to be failing randomly on `macos-13` with either a timeout or an ArrayIndexOutOfBoundsException t in `serviceability/sa/ClhsdbFindPC.java`.  This is currently under investigation and may be related to [JDK-8260389](https://bugs.openjdk.org/browse/JDK-8260389) or [JDK-8277079](https://bugs.openjdk.org/browse/JDK-8277079). 

Solving this `tier-1` test problem may require a second PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8343786](https://bugs.openjdk.org/browse/JDK-8343786) needs maintainer approval

### Issue
 * [JDK-8343786](https://bugs.openjdk.org/browse/JDK-8343786): [11u] GHA: Bump macOS and Xcode versions to macos-13 and XCode 14.3.1 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2965/head:pull/2965` \
`$ git checkout pull/2965`

Update a local copy of the PR: \
`$ git checkout pull/2965` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2965`

View PR using the GUI difftool: \
`$ git pr show -t 2965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2965.diff">https://git.openjdk.org/jdk11u-dev/pull/2965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2965#issuecomment-2477193058)
</details>
