### PR TITLE
8343786: [11u] GHA: Bump macOS and Xcode versions to macos-13 and XCode 14.3.1

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -98,7 +98,7 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          --enable-xcode14
+          --disable-warnings-as-errors
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-12
+    runs-on: macos-13
 
     strategy:
       fail-fast: false
@@ -98,6 +98,7 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
+          --enable-xcode14
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '13.4.1'
+      xcode-toolset-version: '14.3.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
@@ -234,7 +234,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '13.4.1'
+      xcode-toolset-version: '14.3.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -298,7 +298,7 @@ jobs:
     with:
       platform: macos-x64
       bootjdk-platform: macos-x64
-      runs-on: macos-12
+      runs-on: macos-13
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           # On macOS we need to install some dependencies for testing
           brew install make
-          sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'


### PR DESCRIPTION
An implementation of [JDK-8343786](https://bugs.openjdk.org/browse/JDK-8343786) that bumps the GHA runners versions to `macos-13` and `XCode 14.3.1`.

This uses the  `--enable-xcode14` configuration flag introduced in https://github.com/openjdk/jdk11u-dev/pull/2966 ([JDK-8344458](https://bugs.openjdk.org/browse/JDK-8344458)) to build and run tier-1 tests on `macos-13` and `XCode 14.3.1`.

Tier-1 tests seem to be failing randomly on macos-13/XCode14  with either a timeout or an ArrayIndexOutOfBoundsException t in serviceability/sa/ClhsdbFindPC.java. This is currently under investigation and may be related to [JDK-8260389](https://bugs.openjdk.org/browse/JDK-8260389) or [JDK-8277079](https://bugs.openjdk.org/browse/JDK-8277079).

The rest of `tier1` tests are expected to pass on this platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343786](https://bugs.openjdk.org/browse/JDK-8343786) needs maintainer approval

### Issue
 * [JDK-8343786](https://bugs.openjdk.org/browse/JDK-8343786): [11u] GHA: Bump macOS and Xcode versions to macos-13 and XCode 14.3.1 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2967/head:pull/2967` \
`$ git checkout pull/2967`

Update a local copy of the PR: \
`$ git checkout pull/2967` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2967`

View PR using the GUI difftool: \
`$ git pr show -t 2967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2967.diff">https://git.openjdk.org/jdk11u-dev/pull/2967.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2967#issuecomment-2484314536)
</details>
