### PR TITLE
8301753: AppendFile/WriteFile has differences between make 3.81 and 4+

### DIFF
--- a/make/common/MakeIO.gmk
+++ b/make/common/MakeIO.gmk
@@ -257,7 +257,7 @@ ifeq ($(HAS_FILE_FUNCTION), true)
 else
   # Use printf to get consistent behavior on all platforms.
   WriteFile = \
-      $(shell $(PRINTF) "%s" $(call ShellQuote, $1) > $2)
+      $(shell $(PRINTF) "%s\n" $(strip $(call ShellQuote, $1)) > $2)
 endif
 
 # Param 1 - Text to write
@@ -268,5 +268,5 @@ ifeq ($(HAS_FILE_FUNCTION), true)
 else
   # Use printf to get consistent behavior on all platforms.
   AppendFile = \
-      $(shell $(PRINTF) "%s" $(call ShellQuote, $1) >> $2)
+      $(shell $(PRINTF) "%s\n" $(strip $(call ShellQuote, $1)) >> $2)
 endif

--- a/test/make/TestMakeBase.gmk
+++ b/test/make/TestMakeBase.gmk
@@ -158,6 +158,62 @@ ifneq ($(READ_WRITE_VALUE), $(READ_WRITE_RESULT))
   $(error Expected: >$(READ_WRITE_VALUE)< - Result: >$(READ_WRITE_RESULT)<)
 endif
 
+TEST_STRING_1 := 1234
+TEST_STRING_2 := 1234$(NEWLINE)
+TEST_STRING_3 := 1234$(NEWLINE)$(NEWLINE)
+
+# Writing a string ending in newline should not add a newline, but if it does
+# not, a newline should be added. We check this by verifying that the size of the
+# file is 5 characters for both test strings.
+TEST_FILE_1 := $(OUTPUT_DIR)/write-file-1
+TEST_FILE_2 := $(OUTPUT_DIR)/write-file-2
+TEST_FILE_3 := $(OUTPUT_DIR)/write-file-3
+
+$(call WriteFile, $(TEST_STRING_1), $(TEST_FILE_1))
+$(call WriteFile, $(TEST_STRING_2), $(TEST_FILE_2))
+$(call WriteFile, $(TEST_STRING_3), $(TEST_FILE_3))
+
+TEST_FILE_1_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_1)))
+TEST_FILE_2_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_2)))
+TEST_FILE_3_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_3)))
+
+ifneq ($(TEST_FILE_1_SIZE), 5)
+  $(error Expected file size 5 for WriteFile 1, got $(TEST_FILE_1_SIZE))
+endif
+ifneq ($(TEST_FILE_2_SIZE), 5)
+  $(error Expected file size 5 for WriteFile 2, got $(TEST_FILE_2_SIZE))
+endif
+ifneq ($(TEST_FILE_3_SIZE), 5)
+  $(error Expected file size 5 for WriteFile 3, got $(TEST_FILE_3_SIZE))
+endif
+
+# Also test append (assumes WriteFile works as expected)
+$(call WriteFile, $(TEST_STRING_1), $(TEST_FILE_1))
+$(call AppendFile, $(TEST_STRING_1), $(TEST_FILE_1))
+$(call AppendFile, $(TEST_STRING_1), $(TEST_FILE_1))
+
+$(call WriteFile, $(TEST_STRING_2), $(TEST_FILE_2))
+$(call AppendFile, $(TEST_STRING_2), $(TEST_FILE_2))
+$(call AppendFile, $(TEST_STRING_2), $(TEST_FILE_2))
+
+$(call WriteFile, $(TEST_STRING_3), $(TEST_FILE_3))
+$(call AppendFile, $(TEST_STRING_3), $(TEST_FILE_3))
+$(call AppendFile, $(TEST_STRING_3), $(TEST_FILE_3))
+
+TEST_FILE_1_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_1)))
+TEST_FILE_2_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_2)))
+TEST_FILE_3_SIZE := $(strip $(shell $(WC) -c < $(TEST_FILE_3)))
+
+ifneq ($(TEST_FILE_1_SIZE), 15)
+  $(error Expected file size 15 for AppendFile 1, got $(TEST_FILE_1_SIZE))
+endif
+ifneq ($(TEST_FILE_2_SIZE), 15)
+  $(error Expected file size 15 for AppendFile 2, got $(TEST_FILE_2_SIZE))
+endif
+ifneq ($(TEST_FILE_3_SIZE), 15)
+  $(error Expected file size 15 for AppendFile 3, got $(TEST_FILE_3_SIZE))
+endif
+
 ################################################################################
 # Test creating dependencies on make variables
 


### PR DESCRIPTION
Clean backport to 11u.
This fixes "make test" build problem occured with make version <4.0 in JDK11.
The new test is passed locally with a manual run with both "GNU Make 3.82" and "GNU Make 4.3".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301753](https://bugs.openjdk.org/browse/JDK-8301753) needs maintainer approval

### Issue
 * [JDK-8301753](https://bugs.openjdk.org/browse/JDK-8301753): AppendFile/WriteFile has differences between make 3.81 and 4+ (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2969/head:pull/2969` \
`$ git checkout pull/2969`

Update a local copy of the PR: \
`$ git checkout pull/2969` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2969`

View PR using the GUI difftool: \
`$ git pr show -t 2969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2969.diff">https://git.openjdk.org/jdk11u-dev/pull/2969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2969#issuecomment-2493087163)
</details>
