### PR TITLE
8346887: DrawFocusRect() may cause an assertion failure

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Button.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Button.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,7 +242,7 @@ AwtButton::OwnerDrawItem(UINT /*ctrlId*/, DRAWITEMSTRUCT& drawInfo)
         RECT focusRect;
         VERIFY(::CopyRect(&focusRect, &rect));
         VERIFY(::InflateRect(&focusRect,-inf,-inf));
-        if(::DrawFocusRect(hDC, &focusRect) == 0)
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
             VERIFY(::GetLastError() == 0);
     }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Checkbox.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Checkbox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,13 +290,13 @@ AwtCheckbox::OwnerDrawItem(UINT /*ctrlId*/, DRAWITEMSTRUCT& drawInfo)
     if ((drawInfo.itemState & ODS_FOCUS) &&
         ((drawInfo.itemAction & ODA_FOCUS)||
          (drawInfo.itemAction &ODA_DRAWENTIRE))) {
-        if(::DrawFocusRect(hDC, &focusRect) == 0)
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
             VERIFY(::GetLastError() == 0);
     }
     /*  erase focus rect */
     else if (!(drawInfo.itemState & ODS_FOCUS) &&
              (drawInfo.itemAction & ODA_FOCUS)) {
-        if(::DrawFocusRect(hDC, &focusRect) == 0)
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
             VERIFY(::GetLastError() == 0);
     }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4499,7 +4499,7 @@ void AwtComponent::DrawListItem(JNIEnv *env, DRAWITEMSTRUCT &drawInfo)
     if ((drawInfo.itemState & ODS_FOCUS)  &&
         (drawInfo.itemAction & (ODA_FOCUS | ODA_DRAWENTIRE))) {
       if (!unfocusableChoice){
-          if(::DrawFocusRect(hDC, &rect) == 0)
+          if (!::IsRectEmpty(&rect) && (::DrawFocusRect(hDC, &rect) == 0))
               VERIFY(::GetLastError() == 0);
       }
     }


### PR DESCRIPTION
Backporting JDK-8346887: DrawFocusRect() may cause an assertion failure. Minor change that adds an additional check before running an assertion for windows. Ran GHA Sanity Checks and local Tier 1 and Tier 2 tests. Patch is nearly clean (adjusting comment).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346887](https://bugs.openjdk.org/browse/JDK-8346887) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346887](https://bugs.openjdk.org/browse/JDK-8346887): DrawFocusRect() may cause an assertion failure (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2985/head:pull/2985` \
`$ git checkout pull/2985`

Update a local copy of the PR: \
`$ git checkout pull/2985` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2985`

View PR using the GUI difftool: \
`$ git pr show -t 2985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2985.diff">https://git.openjdk.org/jdk11u-dev/pull/2985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2985#issuecomment-2581729634)
</details>
