### PR TITLE
8339931: Update problem list for WindowUpdateFocusabilityTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -445,7 +445,7 @@ java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all
 java/awt/Debug/DumpOnKey/DumpOnKey.java 8202667 windows-all
-java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
+java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8339929 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all


### PR DESCRIPTION
JDK-8339931 Update problem list for WindowUpdateFocusabilityTest.java

Currently, java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java is problem-listed against [JDK-8202926](https://bugs.openjdk.org/browse/JDK-8202926) which is resolved without a fix. Fixing the proper number of still existing issue.

I backport it for the parity with Oracle 11.0.26.

Clean backport. 
Passed tier 1 tests. 
Passed gtests.

GH Actions are passing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339931](https://bugs.openjdk.org/browse/JDK-8339931) needs maintainer approval
- [x] [JDK-8202926](https://bugs.openjdk.org/browse/JDK-8202926) needs maintainer approval

### Issues
 * [JDK-8339931](https://bugs.openjdk.org/browse/JDK-8339931): Update problem list for WindowUpdateFocusabilityTest.java (**Sub-task** - P4 - Approved)
 * [JDK-8202926](https://bugs.openjdk.org/browse/JDK-8202926): Test java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html fails (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2992/head:pull/2992` \
`$ git checkout pull/2992`

Update a local copy of the PR: \
`$ git checkout pull/2992` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2992`

View PR using the GUI difftool: \
`$ git pr show -t 2992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2992.diff">https://git.openjdk.org/jdk11u-dev/pull/2992.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2992#issuecomment-2656706139)
</details>
