### PR TITLE
8342988: GHA: Build JTReg in single step

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,8 @@
 # questions.
 #
 
-name: 'Get JTReg'
-description: 'Download JTReg from cache or source location'
-outputs:
-  path:
-    description: 'Path to the installed JTReg'
-    value: ${{ steps.path-name.outputs.path }}
+name: 'Build JTReg'
+description: 'Build JTReg'
 
 runs:
   using: composite
@@ -39,11 +35,10 @@ runs:
       with:
         var: JTREG_VERSION
 
-    - name: 'Check cache for JTReg'
-      id: get-cached-jtreg
+    - name: 'Check cache for already built JTReg'
+      id: get-cached
       uses: actions/cache@v4
       with:
-        name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed
         key: jtreg-${{ steps.version.outputs.value }}
 
@@ -53,7 +48,7 @@ runs:
         repository: openjdk/jtreg
         ref: jtreg-${{ steps.version.outputs.value }}
         path: jtreg/src
-      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
+      if: (steps.get-cached.outputs.cache-hit != 'true')
 
     - name: 'Build JTReg'
       run: |
@@ -63,11 +58,11 @@ runs:
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src
       shell: bash
-      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
+      if: (steps.get-cached.outputs.cache-hit != 'true')
 
-    - name: 'Export path to where JTReg is installed'
-      id: path-name
-      run: |
-        # Export the path
-        echo 'path=jtreg/installed' >> $GITHUB_OUTPUT
-      shell: bash
+    - name: 'Upload JTReg artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: bundles-jtreg-${{ steps.version.outputs.value }}
+        path: jtreg/installed
+        retention-days: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,19 @@ jobs:
       windows-aarch64: ${{ steps.include.outputs.windows-aarch64 }}
 
     steps:
-        # This function must be inlined in main.yml, or we'd be forced to checkout the repo
+      - name: 'Checkout the scripts'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            make/conf/github-actions.conf
+
+      - name: 'Build JTReg'
+        id: jtreg
+        uses: ./.github/actions/build-jtreg
+
+      # TODO: Now that we are checking out the repo scripts, we can put the following code
+      # into a separate file
       - name: 'Check what jobs to run'
         id: include
         run: |


### PR DESCRIPTION
Backport of [JDK-8349829](https://bugs.openjdk.org/browse/JDK-8349829) from 17u to build jtreg and cache it for subsequent builds. Low risk (only GHA actions affected).

The backport is not clean as [JDK-8338286](https://bugs.openjdk.org/browse/JDK-8338286) has not been backported to JDK-11, on purpose.  Also `JAVA_HOME_11_X64`  is being used now to build `jtreg`.

As expected jtreg is now being built & cached in subsequent builds:

```
2025-02-14T17:08:58.4041646Z Cache hit for: jtreg-7.3.1+1
2025-02-14T17:08:58.6790456Z Received 9265658 of 9265658 (100.0%), 42.7 MBs/sec
2025-02-14T17:08:58.6791682Z Cache Size: ~9 MB (9265658 B)
2025-02-14T17:08:58.6819135Z [command]/usr/bin/tar -xf /home/runner/work/_temp/fe85d627-93f0-40be-9ba4-b41aadc9f6ed/cache.tzst -P -C /home/runner/work/jdk11u-dev/jdk11u-dev --use-compress-program unzstd
2025-02-14T17:08:58.7115863Z Cache restored successfully
2025-02-14T17:08:58.7298813Z Cache restored from key: jtreg-7.3.1+1
```

All tests pass but I detected an intermittent time- out in serviceability agent in macos (possibly because of [JDK-8260389](https://bugs.openjdk.org/browse/JDK-8260389)? despite JDK-8294316 having been already integrated. This is under investigation).

```
2025-02-14T17:48:43.0846500Z --------------------------------------------------
2025-02-14T17:48:46.6648080Z TEST: serviceability/sa/ClhsdbFindPC.java#id0
2025-02-14T17:48:46.6661380Z   build: 0.886 seconds
2025-02-14T17:48:46.6662400Z   compile: 0.886 seconds
2025-02-14T17:48:46.6663300Z   main: 34.198 seconds
2025-02-14T17:48:46.6664240Z TEST RESULT: Passed. Execution successful
2025-02-14T17:48:46.6665470Z --------------------------------------------------
2025-02-14T17:49:24.4350100Z TEST: serviceability/sa/ClhsdbFindPC.java#id2
2025-02-14T17:49:24.4351780Z   build: 0.653 seconds
2025-02-14T17:49:24.4352850Z   compile: 0.653 seconds
2025-02-14T17:49:24.4353430Z   main: 31.826 seconds
2025-02-14T17:49:24.4353820Z TEST RESULT: Passed. Execution successful
2025-02-14T17:49:24.4354390Z --------------------------------------------------
2025-02-14T17:50:36.6580860Z TEST: serviceability/sa/ClhsdbFindPC.java#id1
2025-02-14T17:50:36.6582200Z TEST JDK: /Users/runner/work/jdk11u-dev/jdk11u-dev/bundles/jdk/jdk-11.0.27/fastdebug
...
2025-02-14T17:50:36.6836040Z TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Test ERROR java.io.IOException: App waiting timeout
2025-02-14T17:50:36.6837390Z --------------------------------------------------
2025-02-14T17:51:15.1063160Z TEST: serviceability/sa/ClhsdbFindPC.java#id3
2025-02-14T17:51:15.1461480Z   build: 2.91 seconds
2025-02-14T17:51:15.1520520Z   compile: 2.909 seconds
2025-02-14T17:51:15.1535170Z   main: 102.784 seconds
2025-02-14T17:51:15.1536860Z TEST RESULT: Passed. Execution successful
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8342988](https://bugs.openjdk.org/browse/JDK-8342988) needs maintainer approval

### Issue
 * [JDK-8342988](https://bugs.openjdk.org/browse/JDK-8342988): GHA: Build JTReg in single step (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2996/head:pull/2996` \
`$ git checkout pull/2996`

Update a local copy of the PR: \
`$ git checkout pull/2996` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2996`

View PR using the GUI difftool: \
`$ git pr show -t 2996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2996.diff">https://git.openjdk.org/jdk11u-dev/pull/2996.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2996#issuecomment-2660054031)
</details>
