### PR TITLE
8350469: [11u] Test AbsPathsInImage.java fails - JDK-8239429 public clone

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -208,7 +208,7 @@ public class AbsPathsInImage {
             for (byte[] searchPattern : searchPatterns) {
                 boolean found = true;
                 for (int j = 0; j < searchPattern.length; j++) {
-                    if ((i + j > data.length || data[i + j] != searchPattern[j])) {
+                    if ((i + j >= data.length || data[i + j] != searchPattern[j])) {
                         found = false;
                         break;
                     }


### PR DESCRIPTION
Hi all,

We observed test build/AbsPathsInImage.java fails which has been recorded by https://github.com/dragonwell-project/dragonwell11/issues/934, and this backport can fix the test bug which cause the test failure.

The test bug which cause this test failure has been fixed by JDK-8239429. But JDK-8239429 is invisible cause JDK-8239429 can not backported directly. So I create a new issue to fix the test bug in jdk11u-dev.

Clean backport to fix the test bug, change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350469](https://bugs.openjdk.org/browse/JDK-8350469) needs maintainer approval

### Issue
 * [JDK-8350469](https://bugs.openjdk.org/browse/JDK-8350469): [11u] Test AbsPathsInImage.java fails - JDK-8239429 public clone (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2997/head:pull/2997` \
`$ git checkout pull/2997`

Update a local copy of the PR: \
`$ git checkout pull/2997` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2997`

View PR using the GUI difftool: \
`$ git pr show -t 2997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2997.diff">https://git.openjdk.org/jdk11u-dev/pull/2997.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2997#issuecomment-2673240052)
</details>
