### PR TITLE
8315380: AsyncGetCallTrace crash in frame::safe_for_sender

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
+ * Copyrithg (c) 2025, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +85,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
   // So unextended sp must be within the stack but we need not to check
   // that unextended sp >= sp
 
-  bool unextended_sp_safe = (unextended_sp < thread->stack_base());
+  bool unextended_sp_safe = (unextended_sp < thread->stack_base() && \
+                             sp >= thread->stack_base() - thread->stack_size());
 
   if (!unextended_sp_safe) {
     return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -86,7 +86,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
   // that unextended sp >= sp
 
   bool unextended_sp_safe = (unextended_sp < thread->stack_base() && \
-                             sp >= thread->stack_base() - thread->stack_size());
+                             unextended_sp >= thread->stack_base() - thread->stack_size());
 
   if (!unextended_sp_safe) {
     return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -85,8 +85,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
   // So unextended sp must be within the stack but we need not to check
   // that unextended sp >= sp
 
-  bool unextended_sp_safe = (unextended_sp < thread->stack_base() && \
-                             unextended_sp >= thread->stack_base() - thread->stack_size());
+  bool unextended_sp_safe = (unextended_sp < thread->stack_base() && unextended_sp >= thread->stack_end());
 
   if (!unextended_sp_safe) {
     return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
- * Copyrithg (c) 2025, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This change is fixing the problem in `frame_aarch64.cpp`, function `safe_for_sender`, where we have this code

```
bool unextended_sp_safe = unextended_sp < thread->stack_base();
```

While this captures one possibility of not being safe, it omits the check for `unextended_sp` falling within the stack space.

The proposed change then is

```
bool unextended_sp_safe = (unextended_sp < thread->stack_base() && \
                             sp >= thread->stack_base() - thread->stack_size());
```

This is actually just making sure the behaviour is the same as in JDK 15+ (since [JDK-8238988](https://bugs.openjdk.org/browse/JDK-8238988)) where the `unextended_sp` is checked for being within the stack limits.


The change is not accompanied by a JTReg test because I was not able to craft one triggering the issue reliably.

Existing tests from tier1-tier4 were run on a linux-aarch64 system with no new failures observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8315380](https://bugs.openjdk.org/browse/JDK-8315380) needs maintainer approval

### Issue
 * [JDK-8315380](https://bugs.openjdk.org/browse/JDK-8315380): AsyncGetCallTrace crash in frame::safe_for_sender (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrei Pangin](https://openjdk.org/census#apangin) (@apangin - no project role) Review applies to [d8e1257f](https://git.openjdk.org/jdk11u-dev/pull/3003/files/d8e1257f3eaa32131561fc24e7cae4667086a805)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3003/head:pull/3003` \
`$ git checkout pull/3003`

Update a local copy of the PR: \
`$ git checkout pull/3003` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3003`

View PR using the GUI difftool: \
`$ git pr show -t 3003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3003.diff">https://git.openjdk.org/jdk11u-dev/pull/3003.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3003#issuecomment-2684671800)
</details>
