### PR TITLE
8328957: Update PKCS11Test.java to not use hardcoded path

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,7 @@ import java.util.Properties;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.lib.Platform;
 import jdk.test.lib.artifacts.Artifact;
@@ -383,19 +381,13 @@ public abstract class PKCS11Test {
 
     static Path getNSSLibPath(String library) throws Exception {
         String osid = getOsId();
-        String nssLibDir = fetchNssLib(osid);
-        if (nssLibDir == null) {
+        Path libraryName = Path.of(System.mapLibraryName(library));
+        Path nssLibPath = fetchNssLib(osid, libraryName);
+        if (nssLibPath == null) {
             throw new SkippedException("Warning: unsupported OS: " + osid
                     + ", please initialize NSS library location, skipping test");
         }
-
-        String libraryName = System.mapLibraryName(library);
-        Path libPath = Paths.get(nssLibDir).resolve(libraryName);
-        if (!Files.exists(libPath)) {
-            throw new SkippedException("NSS library \"" + libraryName + "\" was not found in " + nssLibDir);
-        }
-
-        return libPath;
+        return nssLibPath;
     }
 
     private static String getOsId() {
@@ -834,42 +826,42 @@ public abstract class PKCS11Test {
         return data;
     }
 
-    private static String fetchNssLib(String osId) {
+    private static Path fetchNssLib(String osId, Path libraryName) {
         switch (osId) {
             case "Windows-amd64-64":
-                return fetchNssLib(WINDOWS_X64.class);
+                return fetchNssLib(WINDOWS_X64.class, libraryName);
 
             case "MacOSX-x86_64-64":
-                return fetchNssLib(MACOSX_X64.class);
+                return fetchNssLib(MACOSX_X64.class, libraryName);
 
             case "MacOSX-aarch64-64":
-                return fetchNssLib(MACOSX_AARCH64.class);
+                return fetchNssLib(MACOSX_AARCH64.class, libraryName);
 
             case "Linux-amd64-64":
                 if (Platform.isOracleLinux7()) {
                     throw new SkippedException("Skipping Oracle Linux prior to v8");
                 } else {
-                    return fetchNssLib(LINUX_X64.class);
+                    return fetchNssLib(LINUX_X64.class, libraryName);
                 }
 
             case "Linux-aarch64-64":
                 if (Platform.isOracleLinux7()) {
                     throw new SkippedException("Skipping Oracle Linux prior to v8");
                 } else {
-                    return fetchNssLib(LINUX_AARCH64.class);
+                    return fetchNssLib(LINUX_AARCH64.class, libraryName);
                 }
             default:
                 return null;
         }
     }
 
-    private static String fetchNssLib(Class<?> clazz) {
-        String path = null;
+    private static Path fetchNssLib(Class<?> clazz, Path libraryName) {
+        Path path = null;
         try {
-            path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "nss"
-                    + File.separator + "lib" + File.separator;
-        } catch (ArtifactResolverException e) {
+            Path p = ArtifactResolver.resolve(clazz).entrySet().stream()
+                    .findAny().get().getValue();
+            path = findNSSLibrary(p, libraryName);
+        } catch (ArtifactResolverException | IOException e) {
             Throwable cause = e.getCause();
             if (cause == null) {
                 System.out.println("Cannot resolve artifact, "
@@ -881,6 +873,16 @@ public abstract class PKCS11Test {
         }
         Policy.setPolicy(null); // Clear the policy created by JIB if any
         return path;
+    }
+
+    private static Path findNSSLibrary(Path path, Path libraryName) throws IOException {
+        try(Stream<Path> files = Files.find(path, 10,
+                (tp, attr) -> tp.getFileName().equals(libraryName))) {
+
+            return files.findAny()
+                        .orElseThrow(() -> new SkippedException(
+                        "NSS library \"" + libraryName + "\" was not found in " + path));
+        }
     }
 
     public abstract void main(Provider p) throws Exception;


### PR DESCRIPTION
Hi, I would like to propose an openjdk/jdk@16576b87b7267aaa99c41f77993287e3479577aa backport.

I do this backport for parity with 11.0.26-oracle. The backport is clean.

Also, this allows running _SunPKCS11_ tests more easily, without the need to make symlink workarounds to locate the NSS library inside a `<base>/nss/lib` path.

### Testing

* `jdk:tier1` (see [GitHub Actions run](https://github.com/franferrax/jdk11u-dev/actions/runs/13551011718))
    * The failure in macos-x64 / test (hs/tier1 serviceability) / `serviceability/sa/ClhsdbFindPC.java#id1` is unrelated with PKCS11 test changes
* `test/jdk/sun/security/pkcs11`
    * No regressions found against `jdk11u-dev/master` (currently: 659a4669208645420e151e78ab5fd3ac3808b310)
      ```
      ==============================
      Test summary
      ==============================
         TEST                                              TOTAL  PASS  FAIL ERROR   
      >> jtreg:test/jdk/sun/security/pkcs11                   95    84    10     1 <<
      ==============================
      TEST FAILURE
      ```
    * <details>
      <summary>jtreg <code>summary.txt</code> comparison</summary>
      
      ```diff
      diff --git a/jdk11u-dev/pkcs11_regression/report/text/summary.txt b/jdk11u-dev-backport-8328957/pkcs11_regression/report/text/summary.txt
      index ec3301f..552b9d0 100644
      --- a/jdk11u-dev/pkcs11_regression/report/text/summary.txt
      +++ b/jdk11u-dev-backport-8328957/pkcs11_regression/report/text/summary.txt
      @@ -1,98 +1,98 @@
       sun/security/pkcs11/Cipher/CancelMultipart.java              Passed. Execution successful
       sun/security/pkcs11/Cipher/EncryptionPadding.java            Passed. Execution successful
       sun/security/pkcs11/Cipher/JNICheck.java                     Passed. Execution successful
       sun/security/pkcs11/Cipher/ReinitCipher.java                 Passed. Execution successful
       sun/security/pkcs11/Cipher/Test4512704.java                  Passed. Execution successful
       sun/security/pkcs11/Cipher/TestCICOWithGCM.java              Passed. Execution successful
       sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java        Passed. Execution successful
       sun/security/pkcs11/Cipher/TestChaChaPoly.java               Passed. Execution successful
       sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java            Passed. Execution successful
       sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java        Passed. Execution successful
       sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java     Passed. Execution successful
       sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java         Passed. Execution successful
       sun/security/pkcs11/Cipher/TestKATForGCM.java                Passed. Execution successful
       sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java        Passed. Execution successful
       sun/security/pkcs11/Cipher/TestPaddingOOB.java               Passed. Execution successful
       sun/security/pkcs11/Cipher/TestRSACipher.java                Passed. Execution successful
       sun/security/pkcs11/Cipher/TestRSACipherWrap.java            Passed. Execution successful
       sun/security/pkcs11/Cipher/TestRawRSACipher.java             Passed. Execution successful
       sun/security/pkcs11/Cipher/TestSymmCiphers.java              Passed. Execution successful
       sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java         Passed. Execution successful
       sun/security/pkcs11/Config/ReadConfInUTF16Env.java           Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java   Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/SupportedDHKeys.java        Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/TestDH.java                 Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/TestInterop.java            Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/TestShort.java              Passed. Execution successful
       sun/security/pkcs11/KeyAgreement/UnsupportedDHKeys.java      Passed. Execution successful
       sun/security/pkcs11/KeyGenerator/DESParity.java              Passed. Execution successful
       sun/security/pkcs11/KeyGenerator/TestChaCha20.java           Passed. Execution successful
       sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java       Passed. Execution successful
       sun/security/pkcs11/KeyPairGenerator/TestDH2048.java         Passed. Execution successful
       sun/security/pkcs11/KeyStore/Basic.java                      Failed. Execution failed: `main' threw exception: java.lang.Exception: config failures: 0, test failures: 1
      -sun/security/pkcs11/KeyStore/ClientAuth.java                 Error. Program `jdk11u-dev/build/linux-x86_64-normal-server-slowdebug/images/jdk/bin/java' timed out (timeout set to 960000ms, elapsed time including timeout handling was 962981ms).
      +sun/security/pkcs11/KeyStore/ClientAuth.java                 Error. Program `jdk11u-dev-backport-8328957/build/linux-x86_64-normal-server-slowdebug/images/jdk/bin/java' timed out (timeout set to 960000ms, elapsed time including timeout handling was 961779ms).
       sun/security/pkcs11/KeyStore/SecretKeysBasic.java            Failed. Execution failed: `main' threw exception: java.lang.Exception: config failures: 0, test failures: 1
       sun/security/pkcs11/KeyStore/Solaris.sh                      Passed. Execution successful
       sun/security/pkcs11/Mac/MacKAT.java                          Passed. Execution successful
       sun/security/pkcs11/Mac/MacSameTest.java                     Passed. Execution successful
       sun/security/pkcs11/Mac/ReinitMac.java                       Passed. Execution successful
       sun/security/pkcs11/MessageDigest/ByteBuffers.java           Passed. Execution successful
       sun/security/pkcs11/MessageDigest/DigestKAT.java             Passed. Execution successful
       sun/security/pkcs11/MessageDigest/ReinitDigest.java          Passed. Execution successful
       sun/security/pkcs11/MessageDigest/TestCloning.java           Passed. Execution successful
       sun/security/pkcs11/Provider/Absolute.java                   Passed. Execution successful
       sun/security/pkcs11/Provider/ConfigQuotedString.java         Passed. Execution successful
       sun/security/pkcs11/Provider/ConfigShortPath.java            Passed. Execution successful
       sun/security/pkcs11/Provider/Login.java                      Failed. Execution failed: `main' threw exception: java.lang.Exception: config failures: 0, test failures: 1
       sun/security/pkcs11/Provider/LoginISE.java                   Passed. Execution successful
       sun/security/pkcs11/Provider/MultipleLogins.sh               Failed. Execution failed: exit code 10
       sun/security/pkcs11/SampleTest.java                          Passed. Execution successful
       sun/security/pkcs11/Secmod/AddPrivateKey.java                Failed. Execution failed: `main' threw exception: java.io.IOException: load failed
       sun/security/pkcs11/Secmod/AddTrustedCert.java               Failed. Execution failed: `main' threw exception: java.io.IOException: load failed
       sun/security/pkcs11/Secmod/Crypto.java                       Passed. Execution successful
       sun/security/pkcs11/Secmod/GetPrivateKey.java                Failed. Execution failed: `main' threw exception: java.io.IOException: load failed
       sun/security/pkcs11/Secmod/JksSetPrivateKey.java             Failed. Execution failed: `main' threw exception: java.io.IOException: load failed
       sun/security/pkcs11/Secmod/LoadKeystore.java                 Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Unexpected cause: javax.security.auth.login.LoginException
       sun/security/pkcs11/Secmod/TestNssDbSqlite.java              Passed. Execution successful
       sun/security/pkcs11/Secmod/TrustAnchors.java                 Failed. Execution failed: `main' threw exception: java.security.ProviderException: NSS module not available: trustanchors
       sun/security/pkcs11/SecretKeyFactory/TestGeneral.java        Passed. Execution successful
       sun/security/pkcs11/SecureRandom/Basic.java                  Passed. Execution successful
       sun/security/pkcs11/SecureRandom/TestDeserialization.java    Passed. Execution successful
       sun/security/pkcs11/Serialize/SerializeProvider.java         Passed. Execution successful
       sun/security/pkcs11/Signature/ByteBuffers.java               Passed. Execution successful
       sun/security/pkcs11/Signature/InitAgainPSS.java              Passed. Execution successful
       sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java    Passed. Execution successful
       sun/security/pkcs11/Signature/ReinitSignature.java           Passed. Execution successful
       sun/security/pkcs11/Signature/SigInteropPSS.java             Passed. Execution successful
       sun/security/pkcs11/Signature/SignatureTestPSS.java          Passed. Execution successful
       sun/security/pkcs11/Signature/TestDSA.java                   Passed. Execution successful
       sun/security/pkcs11/Signature/TestDSA2.java                  Passed. Execution successful
       sun/security/pkcs11/Signature/TestDSAKeyLength.java          Failed. Execution failed: `main' threw exception: java.lang.Exception: Test Failed - expected IKE not thrown
       sun/security/pkcs11/Signature/TestRSAKeyLength.java          Passed. Execution successful
       sun/security/pkcs11/ec/ReadCertificates.java                 Passed. Execution successful
       sun/security/pkcs11/ec/ReadPKCS12.java                       Passed. Execution successful
       sun/security/pkcs11/ec/TestCurves.java                       Passed. Execution successful
       sun/security/pkcs11/ec/TestECDH.java                         Passed. Execution successful
       sun/security/pkcs11/ec/TestECDH2.java                        Passed. Execution successful
       sun/security/pkcs11/ec/TestECDSA.java                        Passed. Execution successful
       sun/security/pkcs11/ec/TestECDSA2.java                       Passed. Execution successful
       sun/security/pkcs11/ec/TestECGenSpec.java                    Passed. Execution successful
       sun/security/pkcs11/ec/TestKeyFactory.java                   Failed. Execution failed: `main' threw exception: java.security.spec.InvalidKeySpecException: Could not parse key
       sun/security/pkcs11/fips/ClientJSSEServerJSSE.java           Passed. Execution successful
       sun/security/pkcs11/fips/SunJSSEFIPSInit.java                Passed. Execution successful
       sun/security/pkcs11/fips/SunJSSEKeyExchangeFIPS.java         Passed. Execution successful
       sun/security/pkcs11/fips/TestTLS12.java                      Passed. Execution successful
       sun/security/pkcs11/fips/TrustManagerTest.java               Passed. Execution successful
       sun/security/pkcs11/rsa/KeyWrap.java                         Passed. Execution successful
       sun/security/pkcs11/rsa/TestCACerts.java                     Passed. Execution successful
       sun/security/pkcs11/rsa/TestKeyFactory.java                  Passed. Execution successful
       sun/security/pkcs11/rsa/TestKeyPairGenerator.java            Passed. Execution successful
       sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java  Passed. Execution successful
       sun/security/pkcs11/rsa/TestSignatures.java                  Passed. Execution successful
       sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java         Passed. Execution successful
       sun/security/pkcs11/tls/TestKeyMaterial.java                 Passed. Execution successful
       sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java         Passed. Execution successful
       sun/security/pkcs11/tls/TestLeadingZeroesP11.java            Passed. Execution successful
       sun/security/pkcs11/tls/TestMasterSecret.java                Passed. Execution successful
       sun/security/pkcs11/tls/TestPRF.java                         Passed. Execution successful
       sun/security/pkcs11/tls/TestPremaster.java                   Passed. Execution successful
      ```
      </details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328957](https://bugs.openjdk.org/browse/JDK-8328957) needs maintainer approval

### Issue
 * [JDK-8328957](https://bugs.openjdk.org/browse/JDK-8328957): Update PKCS11Test.java to not use hardcoded path (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3004/head:pull/3004` \
`$ git checkout pull/3004`

Update a local copy of the PR: \
`$ git checkout pull/3004` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3004`

View PR using the GUI difftool: \
`$ git pr show -t 3004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3004.diff">https://git.openjdk.org/jdk11u-dev/pull/3004.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3004#issuecomment-2686208647)
</details>
