### PR TITLE
Backport JDK-8351933

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -1614,7 +1614,7 @@ public class ForkJoinPool extends AbstractExecutorService {
                          tryTerminate(false, false))
                     break;                        // quiescent shutdown
                 else if (rc <= 0 && pred != 0 && phase == (int)c) {
-                    long nc = (UC_MASK & (c - TC_UNIT)) | (SP_MASK & pred);
+                    long nc = (RC_MASK & c) | (TC_MASK & (c - TC_UNIT)) | (SP_MASK & pred);
                     long d = keepAlive + System.currentTimeMillis();
                     LockSupport.parkUntil(this, d);
                     if (ctl == c &&               // drop on timeout if all idle


### PR DESCRIPTION
This a backport of JDK-8351933 [0] (PR [1]) for 11u. At one of code paths the TC subfield of ctl field is decremented and the result is not masked correctly. The target code is in runWorker() instead of tryTrim()/awaitWork() and the surrounding code is different from the current master, as well as the original mask name. The core change is the same, candidate for CTL.compareAndSet is constructed using '(RC_MASK & c) | (TC_MASK & (c - TC_UNIT))' instead of '(UC_MASK & (c - TC_UNIT))' to correctly preserve the RC subfield.

[0] https://bugs.openjdk.org/browse/JDK-8351933
[1] https://github.com/openjdk/jdk/pull/24034