### PR TITLE
8352302: Test sun/security/tools/jarsigner/TimestampCheck.java is failing

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -865,7 +865,7 @@ public class TimestampCheck {
         }
 
         gencert("tsold", "-ext eku:critical=ts -startdate -40d -validity 500");
-        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 3000");
+        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 5000");
 
         gencert("tsweak", "-ext eku:critical=ts");
         gencert("tsdisabled", "-ext eku:critical=ts");


### PR DESCRIPTION
Clean backport of [JDK-8352561](https://bugs.openjdk.org/browse/JDK-8352561) that solves a problem with `TimestampCheck.java`.

All `test/jdk/sun/security` tests pass now:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/sun/security                         659   659     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8352302](https://bugs.openjdk.org/browse/JDK-8352302) needs maintainer approval

### Issue
 * [JDK-8352302](https://bugs.openjdk.org/browse/JDK-8352302): Test sun/security/tools/jarsigner/TimestampCheck.java is failing (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3017/head:pull/3017` \
`$ git checkout pull/3017`

Update a local copy of the PR: \
`$ git checkout pull/3017` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3017`

View PR using the GUI difftool: \
`$ git pr show -t 3017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3017.diff">https://git.openjdk.org/jdk11u-dev/pull/3017.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3017#issuecomment-2761249535)
</details>
