### PR TITLE
8322920: Some ProcessTools.execute* functions are declared to throw Throwable

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -453,7 +453,7 @@ public final class ProcessTools {
      * @param cmds The command line to execute.
      * @return The output from the process.
      */
-    public static OutputAnalyzer executeProcess(String... cmds) throws Throwable {
+    public static OutputAnalyzer executeProcess(String... cmds) throws Exception {
         return executeProcess(new ProcessBuilder(cmds));
     }
 
@@ -498,8 +498,7 @@ public final class ProcessTools {
      * @param cmds The command line to execute.
      * @return The {@linkplain OutputAnalyzer} instance wrapping the process.
      */
-    public static OutputAnalyzer executeCommand(String... cmds)
-            throws Throwable {
+    public static OutputAnalyzer executeCommand(String... cmds) throws Exception {
         String cmdLine = String.join(" ", cmds);
         System.out.println("Command line: [" + cmdLine + "]");
         OutputAnalyzer analyzer = ProcessTools.executeProcess(cmds);
@@ -516,8 +515,7 @@ public final class ProcessTools {
      * @param pb The ProcessBuilder to execute.
      * @return The {@linkplain OutputAnalyzer} instance wrapping the process.
      */
-    public static OutputAnalyzer executeCommand(ProcessBuilder pb)
-            throws Throwable {
+    public static OutputAnalyzer executeCommand(ProcessBuilder pb) throws Exception {
         String cmdLine = pb.command().stream()
                 .map(x -> (x.contains(" ") || x.contains("$"))
                         ? ("'" + x + "'") : x)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5fd79e96](https://github.com/openjdk/jdk17u-dev/commit/5fd79e961dc370b312e7828a7d1bcc159a0e8635) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Goetz Lindenmaier on 19 Mar 2024 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322920](https://bugs.openjdk.org/browse/JDK-8322920) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322920](https://bugs.openjdk.org/browse/JDK-8322920): Some ProcessTools.execute* functions are declared to throw Throwable (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3025/head:pull/3025` \
`$ git checkout pull/3025`

Update a local copy of the PR: \
`$ git checkout pull/3025` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3025`

View PR using the GUI difftool: \
`$ git pr show -t 3025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3025.diff">https://git.openjdk.org/jdk11u-dev/pull/3025.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3025#issuecomment-2818822943)
</details>
