### PR TITLE
Backport-of: 5f38d1bb94d008c33c1a7af12c81ee0e15371e13

### DIFF
--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -54,6 +54,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \
     OPTIMIZATION := LOW, \
     CFLAGS := $(CFLAGS_JDKLIB) -DJDWP_LOGGING, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     EXTRA_HEADER_DIRS := \
       include \
       libjdwp/export, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5f38d1bb](https://github.com/openjdk/jdk/commit/5f38d1bb94d008c33c1a7af12c81ee0e15371e13) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 21 May 2025 and was reviewed by Serguei Spitsyn.

Thanks!