### PR TITLE
8343618: Stack smashing in awt_InputMethod.c on Linux s390x

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
@@ -1627,14 +1627,14 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_setCompositionEnabled
     if (NULL != pX11IMData->statusWindow) {
         Window focus = 0;
         int revert_to;
-#if defined(_LP64) && !defined(_LITTLE_ENDIAN)
-        // The Window value which is used for XGetICValues must be 32bit on BigEndian XOrg's xlib
-        unsigned int w = 0;
-#else
         Window w = 0;
-#endif
         XGetInputFocus(awt_display, &focus, &revert_to);
         XGetICValues(pX11IMData->current_ic, XNFocusWindow, &w, NULL);
+#if defined(_LP64) && !defined(_LITTLE_ENDIAN)
+        // On 64bit BigEndian,
+        // Window value may be stored on high 32bit by XGetICValues via XIM
+        if (w > 0xffffffffUL) w = w >> 32;
+#endif
         if (RevertToPointerRoot == revert_to
                 && pX11IMData->ic_active != pX11IMData->ic_passive) {
             if (pX11IMData->current_ic == pX11IMData->ic_active) {
@@ -1683,12 +1683,7 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_isCompositionEnabledN
 {
     X11InputMethodData *pX11IMData = NULL;
     char * ret = NULL;
-#if defined(__linux__) && defined(_LP64) && !defined(_LITTLE_ENDIAN)
-    // XIMPreeditState value which is used for XGetICValues must be 32bit on BigEndian XOrg's xlib
-    unsigned int state = XIMPreeditUnKnown;
-#else
     XIMPreeditState state = XIMPreeditUnKnown;
-#endif
 
     XVaNestedList   pr_atrb;
 
@@ -1704,6 +1699,11 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_isCompositionEnabledN
     ret = XGetICValues(pX11IMData->current_ic, XNPreeditAttributes, pr_atrb, NULL);
     XFree((void *)pr_atrb);
     AWT_UNLOCK();
+#if defined(__linux__) && defined(_LP64) && !defined(_LITTLE_ENDIAN)
+    // On 64bit BigEndian,
+    // XIMPreeditState value may be stored on high 32bit by XGetICValues via XIM
+    if (state > 0xffffffffUL) state = state >> 32;
+#endif
 
     if ((ret != 0)
             && ((strcmp(ret, XNPreeditAttributes) == 0)


### PR DESCRIPTION
Backport fixing stack smashing issue in `awt_InputMethod.c` on s390x. Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343618](https://bugs.openjdk.org/browse/JDK-8343618) needs maintainer approval

### Issue
 * [JDK-8343618](https://bugs.openjdk.org/browse/JDK-8343618): Stack smashing in awt_InputMethod.c on Linux s390x (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3037/head:pull/3037` \
`$ git checkout pull/3037`

Update a local copy of the PR: \
`$ git checkout pull/3037` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3037`

View PR using the GUI difftool: \
`$ git pr show -t 3037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3037.diff">https://git.openjdk.org/jdk11u-dev/pull/3037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3037#issuecomment-2916411275)
</details>
