### PR TITLE
8217527: jmod hash does not work if --hash-module does not include the target module

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -282,19 +282,35 @@ public class JmodTask {
         }
     }
 
-    private boolean hashModules() {
+    private boolean hashModules() throws IOException {
+        String moduleName = null;
+        if (options.jmodFile != null) {
+            try (JmodFile jf = new JmodFile(options.jmodFile)) {
+                try (InputStream in = jf.getInputStream(Section.CLASSES, MODULE_INFO)) {
+                    ModuleInfo.Attributes attrs = ModuleInfo.read(in, null);
+                    moduleName = attrs.descriptor().name();
+                } catch (IOException e) {
+                    throw new CommandException("err.module.descriptor.not.found");
+                }
+            }
+        }
+        Hasher hasher = new Hasher(moduleName, options.moduleFinder);
+
         if (options.dryrun) {
             out.println("Dry run:");
         }
 
-        Hasher hasher = new Hasher(options.moduleFinder);
-        hasher.computeHashes().forEach((mn, hashes) -> {
+        Map<String, ModuleHashes> moduleHashes = hasher.computeHashes();
+        if (moduleHashes.isEmpty()) {
+            throw new CommandException("err.no.moduleToHash", "\"" + options.modulesToHash + "\"");
+        }
+        moduleHashes.forEach((mn, hashes) -> {
             if (options.dryrun) {
                 out.format("%s%n", mn);
                 hashes.names().stream()
-                    .sorted()
-                    .forEach(name -> out.format("  hashes %s %s %s%n",
-                        name, hashes.algorithm(), toHex(hashes.hashFor(name))));
+                      .sorted()
+                      .forEach(name -> out.format("  hashes %s %s %s%n",
+                            name, hashes.algorithm(), toHex(hashes.hashFor(name))));
             } else {
                 try {
                     hasher.updateModuleInfo(mn, hashes);
@@ -846,25 +862,19 @@ public class JmodTask {
         final String moduleName;  // a specific module to record hashes, if set
 
         /**
-         * This constructor is for jmod hash command.
-         *
-         * This Hasher will determine which modules to record hashes, i.e.
-         * the module in a subgraph of modules to be hashed and that
-         * has no outgoing edges.  It will record in each of these modules,
-         * say `M`, with the the hashes of modules that depend upon M
-         * directly or indirectly matching the specified --hash-modules pattern.
-         */
-        Hasher(ModuleFinder finder) {
-            this(null, finder);
-        }
-
-        /**
          * Constructs a Hasher to compute hashes.
          *
          * If a module name `M` is specified, it will compute the hashes of
          * modules that depend upon M directly or indirectly matching the
          * specified --hash-modules pattern and record in the ModuleHashes
          * attribute in M's module-info.class.
+         *
+         * If name is null, this Hasher will determine which modules to
+         * record hashes, i.e. the module in a subgraph of modules to be
+         * hashed and that has no outgoing edges.  It will record in each
+         * of these modules, say `M`, with the hashes of modules that
+         * depend upon M directly or indirectly matching the specified
+         * --hash-modules pattern.
          *
          * @param name    name of the module to record hashes
          * @param finder  module finder for the specified --module-path
@@ -1446,6 +1456,18 @@ public class JmodTask {
                 if (options.moduleFinder == null || options.modulesToHash == null)
                     throw new CommandException("err.modulepath.must.be.specified")
                             .showUsage(true);
+                // It's optional to specify jmod-file.  If not specified, then
+                // it will find all the modules that have no outgoing read edges
+                if (words.size() >= 2) {
+                    Path path = Paths.get(words.get(1));
+                    if (Files.notExists(path))
+                        throw new CommandException("err.jmod.not.found", path);
+
+                    options.jmodFile = path;
+                }
+                if (words.size() > 2)
+                    throw new CommandException("err.unknown.option",
+                            words.subList(2, words.size())).showUsage(true);
             } else {
                 if (words.size() <= 1)
                     throw new CommandException("err.jmod.must.be.specified").showUsage(true);

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/resources/jmod.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/resources/jmod.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,7 @@ err.invalid.dryrun.option=--dry-run can only be used with hash mode
 err.module.descriptor.not.found=Module descriptor not found
 err.missing.export.or.open.packages=Packages that are exported or open in {0} are not present: {1}
 err.module.resolution.fail=Resolution failed: {0}
+err.no.moduleToHash=No hashes recorded: no module matching {0} found to record hashes
 warn.invalid.arg=Invalid classname or pathname not exist: {0}
 warn.no.module.hashes=No hashes recorded: no module specified for hashing depends on {0}
 warn.ignore.entry=ignoring entry {0}, in section {1}

--- a/test/jdk/tools/jmod/JmodNegativeTest.java
+++ b/test/jdk/tools/jmod/JmodNegativeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -504,6 +504,34 @@ public class JmodNegativeTest {
                 .resultChecker(r -> {
                     assertContains(r.output, errMsg);
                 });
+    }
+
+    @Test
+    public void testNoMatchingHashModule() throws IOException {
+        Path lib = Paths.get("hashes");
+        Files.createDirectories(lib);
+        // create jmod file with no module depending on it
+        Path jmod = lib.resolve("foo.jmod");
+        jmod("create",
+             "--class-path", EXPLODED_DIR.resolve("foo").resolve("classes").toString(),
+             jmod.toString());
+
+        // jmod hash command should report no module found to record hashes
+        jmod("hash",
+             "--module-path", lib.toString(),
+             "--hash-modules", ".*",
+             jmod.toString())
+             .resultChecker(r ->
+                     assertContains(r.output, "No hashes recorded: " +
+                             "no module matching \".*\" found to record hashes")
+             );
+        jmod("hash",
+             "--module-path", lib.toString(),
+             "--hash-modules", "foo")
+             .resultChecker(r ->
+                     assertContains(r.output, "No hashes recorded: " +
+                             "no module matching \"foo\" found to record hashes")
+             );
     }
 
     // ---

--- a/test/jdk/tools/jmod/hashes/HashesTest.java
+++ b/test/jdk/tools/jmod/hashes/HashesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8160286 8243666
+ * @bug 8160286 8243666 8217527
  * @summary Test the recording and checking of module hashes
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -450,22 +450,29 @@ public class HashesTest {
      * a ModuleHashes class file attribute.
      */
     private Map<String, ModuleHashes> runJmodHash() {
-        runJmod(List.of("hash",
+        runJmod("hash",
                 "--module-path", lib.toString(),
-                "--hash-modules", ".*"));
-        HashesTest ht = this;
+                "--hash-modules", ".*");
+        return moduleHashes();
+    }
+
+    private Map<String, ModuleHashes> moduleHashes() {
         return ModulePath.of(Runtime.version(), true, lib)
                 .findAll()
                 .stream()
                 .map(ModuleReference::descriptor)
                 .map(ModuleDescriptor::name)
-                .filter(mn -> ht.hashes(mn) != null)
-                .collect(Collectors.toMap(mn -> mn, ht::hashes));
+                .filter(mn -> hashes(mn) != null)
+                .collect(Collectors.toMap(mn -> mn, this::hashes));
     }
 
     private static void runJmod(List<String> args) {
-        int rc = JMOD_TOOL.run(System.out, System.out, args.toArray(new String[args.size()]));
-        System.out.println("jmod " + args.stream().collect(Collectors.joining(" ")));
+        runJmod(args.toArray(new String[args.size()]));
+    }
+
+    private static void runJmod(String... args) {
+        int rc = JMOD_TOOL.run(System.out, System.out, args);
+        System.out.println("jmod " + Arrays.stream(args).collect(Collectors.joining(" ")));
         if (rc != 0) {
             throw new AssertionError("jmod failed: rc = " + rc);
         }


### PR DESCRIPTION
I'd like to backport this fix because currently `jmod hash` command does not work on already created modules and this fixes that issue. This isn't intended behavior; nothing in Oracle documentation states this limitation, and moreover the command itself gives opaque response: there's no error message or non-zero exit, instead the command does nothing and no modules are changed after hashing.

The backport isn't clean because of conflicts in `HashesTest.java`. The conflicts are due to later commits being backported first; as all main `HashesTest.java` patches on jdk17 are now backport to 11, resolution meant simply copying 17's implementation over (some differences remain like `upgradeableModule` method is in different location but otherwise its function is exactly the same). This change was ran on internal Amazon pipelines and passes jtreg tier1-4 + tck tests on the following platforms: linux x64, aarch64, x86, aarch32; macos x64, aarch64; windows x64, x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8217527](https://bugs.openjdk.org/browse/JDK-8217527) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8217527: jmod hash does not work if --hash-module does not include the target module`

### Issue
 * [JDK-8217527](https://bugs.openjdk.org/browse/JDK-8217527): jmod hash does not work if --hash-module does not include the target module (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3039/head:pull/3039` \
`$ git checkout pull/3039`

Update a local copy of the PR: \
`$ git checkout pull/3039` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3039`

View PR using the GUI difftool: \
`$ git pr show -t 3039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3039.diff">https://git.openjdk.org/jdk11u-dev/pull/3039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3039#issuecomment-2922883797)
</details>
