### PR TITLE
Backport 51be7db96f3fc32a7ddb24f8af19fb4fc0577aaf

### DIFF
--- a/src/jdk.pack/share/native/common-unpack/constants.h
+++ b/src/jdk.pack/share/native/common-unpack/constants.h
@@ -203,7 +203,7 @@ enum {
     AO_HAVE_FIELD_FLAGS_HI    = 1<<10,
     AO_HAVE_METHOD_FLAGS_HI   = 1<<11,
     AO_HAVE_CODE_FLAGS_HI     = 1<<12,
-    AO_UNUSED_MBZ             = (-1)<<13, // options bits reserved for future use.
+    AO_UNUSED_MBZ             = (int)((~0U)<<13), // options bits reserved for future use.
 
 #define ARCHIVE_BIT_DO(F) \
          F(AO_HAVE_SPECIAL_FORMATS) \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [51be7db9](https://github.com/openjdk/jdk/commit/51be7db96f3fc32a7ddb24f8af19fb4fc0577aaf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kim Barrett on 9 Oct 2018 and was reviewed by Alan Bateman.

Thanks!