### PR TITLE
8348328: Update IANA Language Subtag Registry to Version 2025-05-15

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2024-11-19
+File-Date: 2025-05-15
 %%
 Type: language
 Subtag: aa
@@ -5950,6 +5950,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: bql
+Description: Karian
 Description: Bilakura
 Added: 2009-07-29
 %%
@@ -9083,6 +9084,7 @@ Scope: collection
 %%
 Type: language
 Subtag: daz
+Description: Moi-Wadea
 Description: Dao
 Added: 2009-07-29
 %%
@@ -9290,6 +9292,8 @@ Type: language
 Subtag: dek
 Description: Dek
 Added: 2009-07-29
+Deprecated: 2024-12-12
+Preferred-Value: sqm
 %%
 Type: language
 Subtag: del
@@ -14082,6 +14086,12 @@ Added: 2009-07-29
 Macrolanguage: hmn
 %%
 Type: language
+Subtag: hnm
+Description: Hainanese
+Added: 2024-12-12
+Macrolanguage: zh
+%%
+Type: language
 Subtag: hnn
 Description: Hanunoo
 Added: 2009-07-29
@@ -16421,6 +16431,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kci
+Description: Ngyian
 Description: Kamantan
 Added: 2009-07-29
 %%
@@ -21081,6 +21092,12 @@ Description: Laua
 Added: 2009-07-29
 %%
 Type: language
+Subtag: luh
+Description: Leizhou Chinese
+Added: 2024-12-12
+Macrolanguage: zh
+%%
+Type: language
 Subtag: lui
 Description: Luiseno
 Added: 2005-10-16
@@ -22850,6 +22867,8 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: mmi
+Description: Hember Avu
+Description: Amben
 Description: Musar
 Added: 2009-07-29
 %%
@@ -25197,8 +25216,9 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: new
-Description: Newari
 Description: Nepal Bhasa
+Description: Newar
+Description: Newari
 Added: 2005-10-16
 %%
 Type: language
@@ -26641,6 +26661,8 @@ Type: language
 Subtag: nte
 Description: Nathembo
 Added: 2009-07-29
+Deprecated: 2024-12-12
+Preferred-Value: eko
 %%
 Type: language
 Subtag: ntg
@@ -27183,6 +27205,12 @@ Type: language
 Subtag: oac
 Description: Oroch
 Added: 2009-07-29
+%%
+Type: language
+Subtag: oak
+Description: Noakhali
+Description: Noakhailla
+Added: 2025-05-14
 %%
 Type: language
 Subtag: oar
@@ -32145,6 +32173,12 @@ Type: language
 Subtag: sjb
 Description: Sajau Basap
 Added: 2009-07-29
+%%
+Type: language
+Subtag: sjc
+Description: Shaojiang Chinese
+Added: 2024-12-12
+Macrolanguage: zh
 %%
 Type: language
 Subtag: sjd
@@ -41302,6 +41336,11 @@ Description: Aluo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ynb
+Description: Yamben
+Added: 2025-02-06
+%%
+Type: language
 Subtag: ynd
 Description: Yandruwandha
 Added: 2009-07-29
@@ -43616,6 +43655,14 @@ Preferred-Value: hks
 Prefix: sgn
 %%
 Type: extlang
+Subtag: hnm
+Description: Hainanese
+Added: 2024-12-12
+Preferred-Value: hnm
+Prefix: zh
+Macrolanguage: zh
+%%
+Type: extlang
 Subtag: hos
 Description: Ho Chi Minh City Sign Language
 Added: 2009-07-29
@@ -43956,6 +44003,14 @@ Added: 2010-03-11
 Preferred-Value: ltg
 Prefix: lv
 Macrolanguage: lv
+%%
+Type: extlang
+Subtag: luh
+Description: Leizhou Chinese
+Added: 2024-12-12
+Preferred-Value: luh
+Prefix: zh
+Macrolanguage: zh
 %%
 Type: extlang
 Subtag: lvs
@@ -44391,6 +44446,14 @@ Added: 2009-07-29
 Preferred-Value: shu
 Prefix: ar
 Macrolanguage: ar
+%%
+Type: extlang
+Subtag: sjc
+Description: Shaojiang Chinese
+Added: 2024-12-12
+Preferred-Value: sjc
+Prefix: zh
+Macrolanguage: zh
 %%
 Type: extlang
 Subtag: slf
@@ -44844,6 +44907,11 @@ Description: Bangla
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Berf
+Description: Beria Erfe
+Added: 2025-02-06
+%%
+Type: script
 Subtag: Bhks
 Description: Bhaiksuki
 Added: 2015-07-24
@@ -45130,6 +45198,12 @@ Type: script
 Subtag: Hmnp
 Description: Nyiakeng Puachue Hmong
 Added: 2017-08-13
+%%
+Type: script
+Subtag: Hntl
+Description: Han (Traditional variant) with Latin (alias for Hant +
+  Latn)
+Added: 2025-05-14
 %%
 Type: script
 Subtag: Hrkt
@@ -45634,6 +45708,12 @@ Type: script
 Subtag: Saur
 Description: Saurashtra
 Added: 2006-07-21
+%%
+Type: script
+Subtag: Seal
+Description: Seal
+Description: Small Seal
+Added: 2025-05-14
 %%
 Type: script
 Subtag: Sgnw
@@ -47919,6 +47999,12 @@ Comments: Written standard developed by Romanilha in 1853 and used by
   dóu Po, Escolo Gaston Febus, and others
 %%
 Type: variant
+Subtag: hanoi
+Description: The Hà Nội variant of Vietnamese
+Added: 2025-03-10
+Prefix: vi
+%%
+Type: variant
 Subtag: hepburn
 Description: Hepburn romanization
 Added: 2009-10-01
@@ -47947,6 +48033,12 @@ Description: Standard H-system orthographic fallback for spelling
   Esperanto
 Added: 2017-03-14
 Prefix: eo
+%%
+Type: variant
+Subtag: huett
+Description: The Huế (province Thừa Thiên) variant of Vietnamese
+Added: 2025-03-10
+Prefix: vi
 %%
 Type: variant
 Subtag: ijekavsk
@@ -48024,6 +48116,13 @@ Prefix: sa
 Comments: Preferred tag is cls
 %%
 Type: variant
+Subtag: leidentr
+Description: Ancient Egyptian in Leiden Unified Transliteration
+Added: 2025-02-06
+Prefix: egy
+Comments: Recommended by the International Association of Egyptologists
+%%
+Type: variant
 Subtag: lemosin
 Description: Limousin
 Added: 2018-04-22
@@ -48066,6 +48165,19 @@ Added: 2010-10-10
 Prefix: ru
 Comments: Russian orthography as established by the 1917/1918
   orthographic reforms
+%%
+Type: variant
+Subtag: mdcegyp
+Description: Ancient Egyptian hieroglyphs encoded in Manuel de Codage
+Added: 2025-02-06
+Prefix: egy
+%%
+Type: variant
+Subtag: mdctrans
+Description: Ancient Egyptian transliteration encoded in Manuel de
+  Codage
+Added: 2025-02-06
+Prefix: egy
 %%
 Type: variant
 Subtag: metelko
@@ -48253,6 +48365,12 @@ Description: Rumantsch Grischun
 Added: 2010-06-29
 Prefix: rm
 Comments: Supraregional Romansh written standard
+%%
+Type: variant
+Subtag: saigon
+Description: The Sài Gòn variant of Vietnamese
+Added: 2025-03-10
+Prefix: vi
 %%
 Type: variant
 Subtag: scotland

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631 8332424 8334418 8344589
+ *      8327631 8332424 8334418 8344589 8348328
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2024-11-19) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2025-05-15) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */
@@ -45,9 +45,9 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
-        + " en-gb-oed, gti, iba, ilw, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, meg, mtm,"
-        + " ngv, nns, ola, oyb, pat, pcr, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, eko, ema,"
+        + " en-gb-oed, gti, hnm, iba, ilw, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, luh, lvi, meg, mtm,"
+        + " ngv, nns, ola, oyb, pat, pcr, phr, plu, pnd, pub, rib, rnb, rsn, scv, sjc, snz, sqm, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, xia, yos, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
@@ -94,12 +94,16 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("sgn-dsz", 1.0),
             new LanguageRange("ehs", 1.0),
             new LanguageRange("sgn-ehs", 1.0),
+            new LanguageRange("eko", 1.0),
+            new LanguageRange("nte", 1.0),
             new LanguageRange("ema", 1.0),
             new LanguageRange("uok", 1.0),
             new LanguageRange("en-gb-oed", 1.0),
             new LanguageRange("en-gb-oxendict", 1.0),
             new LanguageRange("gti", 1.0),
             new LanguageRange("nyc", 1.0),
+            new LanguageRange("hnm", 1.0),
+            new LanguageRange("zh-hnm", 1.0),
             new LanguageRange("iba", 1.0),
             new LanguageRange("snb", 1.0),
             new LanguageRange("blg", 1.0),
@@ -142,6 +146,8 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("sgn-lsv", 1.0),
             new LanguageRange("lsw", 1.0),
             new LanguageRange("sgn-lsw", 1.0),
+            new LanguageRange("luh", 1.0),
+            new LanguageRange("zh-luh", 1.0),
             new LanguageRange("lvi", 1.0),
             new LanguageRange("meg", 1.0),
             new LanguageRange("cir", 1.0),
@@ -176,8 +182,12 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("sgn-rsn", 1.0),
             new LanguageRange("scv", 1.0),
             new LanguageRange("zir", 1.0),
+            new LanguageRange("sjc", 1.0),
+            new LanguageRange("zh-sjc", 1.0),
             new LanguageRange("snz", 1.0),
             new LanguageRange("asd", 1.0),
+            new LanguageRange("sqm", 1.0),
+            new LanguageRange("dek", 1.0),
             new LanguageRange("sqx", 1.0),
             new LanguageRange("sgn-sqx", 1.0),
             new LanguageRange("suj", 1.0),
@@ -264,12 +274,18 @@ public class LanguageSubtagRegistryTest {
 
             System.err.println("  Expected size=" + expectedSize);
             for (LanguageRange lr : expected) {
+                if (!got.contains(lr)) {
+                    System.err.print("Error - Actual does not contain:");
+                }
                 System.err.println("    range=" + lr.getRange()
                         + ", weight=" + lr.getWeight());
             }
 
             System.err.println("  Actual size=" + actualSize);
             for (LanguageRange lr : got) {
+                if (!expected.contains(lr)) {
+                    System.err.print("Error - Expected does not contain:");
+                }
                 System.err.println("    range=" + lr.getRange()
                         + ", weight=" + lr.getWeight());
             }


### PR DESCRIPTION
Backport of JDK-8348328 - Update IANA Language Subtag Registry to Version 2025-05-15

The IANA Functions Operator has updated the language subtag registry to "2025-05-15".

Clean backport.
Passed tier1 tests.
Passed gtests.

GH Actions are passing, Windows failures are unrelated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8348328](https://bugs.openjdk.org/browse/JDK-8348328) needs maintainer approval

### Issue
 * [JDK-8348328](https://bugs.openjdk.org/browse/JDK-8348328): Update IANA Language Subtag Registry to Version 2025-05-15 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3043/head:pull/3043` \
`$ git checkout pull/3043`

Update a local copy of the PR: \
`$ git checkout pull/3043` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3043`

View PR using the GUI difftool: \
`$ git pr show -t 3043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3043.diff">https://git.openjdk.org/jdk11u-dev/pull/3043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3043#issuecomment-2945054117)
</details>
