### PR TITLE
8274453: (sctp) com/sun/nio/sctp/SctpChannel/CloseDescriptors.java test should be resilient to lsof warnings

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -120,7 +120,7 @@ public class CloseDescriptors {
     private static boolean check() throws Exception {
         long myPid = ProcessHandle.current().pid();
         ProcessBuilder pb = new ProcessBuilder(
-                        "lsof", "-U", "-a", "-p", Long.toString(myPid));
+                        "lsof", "-U", "-a", "-w", "-p", Long.toString(myPid));
         pb.redirectErrorStream(true);
         Process p = pb.start();
         p.waitFor();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b1b66965](https://github.com/openjdk/jdk/commit/b1b66965f1ec6eae547cc4f70f8271bd39ded6da) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aleksey Shipilev on 29 Sep 2021 and was reviewed by Daniel Fuchs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274453](https://bugs.openjdk.org/browse/JDK-8274453) needs maintainer approval

### Issue
 * [JDK-8274453](https://bugs.openjdk.org/browse/JDK-8274453): (sctp) com/sun/nio/sctp/SctpChannel/CloseDescriptors.java test should be resilient to lsof warnings (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3047/head:pull/3047` \
`$ git checkout pull/3047`

Update a local copy of the PR: \
`$ git checkout pull/3047` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3047`

View PR using the GUI difftool: \
`$ git pr show -t 3047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3047.diff">https://git.openjdk.org/jdk11u-dev/pull/3047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3047#issuecomment-2969489449)
</details>
