### PR TITLE
8345414: Google CAInterop test failures

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -583,20 +583,20 @@ public class CAInterop {
                     "https://revoked.sfig2.catest.starfieldtech.com");
 
             case "globalsigneccrootcar4":
-                    return new CATestURLs("https://good.gsr4.demo.pki.goog",
-                    "https://revoked.gsr4.demo.pki.goog");
+                    return new CATestURLs("https://good.gsr4.demosite.pki.goog",
+                    "https://revoked.gsr4.demosite.pki.goog");
             case "gtsrootcar1":
-                    return new CATestURLs("https://good.gtsr1.demo.pki.goog",
-                    "https://revoked.gtsr1.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr1.demosite.pki.goog",
+                    "https://revoked.gtsr1.demosite.pki.goog");
             case "gtsrootcar2":
-                    return new CATestURLs("https://good.gtsr2.demo.pki.goog",
-                    "https://revoked.gtsr2.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr2.demosite.pki.goog",
+                    "https://revoked.gtsr2.demosite.pki.goog");
             case "gtsrootecccar3":
-                    return new CATestURLs("https://good.gtsr3.demo.pki.goog",
-                    "https://revoked.gtsr3.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr3.demosite.pki.goog",
+                    "https://revoked.gtsr3.demosite.pki.goog");
             case "gtsrootecccar4":
-                    return new CATestURLs("https://good.gtsr4.demo.pki.goog",
-                    "https://revoked.gtsr4.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr4.demosite.pki.goog",
+                    "https://revoked.gtsr4.demosite.pki.goog");
 
             case "microsoftecc2017":
                     return new CATestURLs("https://acteccroot2017.pki.microsoft.com",


### PR DESCRIPTION
This fixes failing Google cacert tests. The backport does not apply cleanly as 11u does not have [JEP 361: Switch Expressions](https://openjdk.org/jeps/361) and so the test here uses the older format of `switch` statement.

Testing shows that the tests now pass, whereas they failed before:

~~~
--- test.1749863688/tests.log	2025-06-14 02:21:29.917118885 +0100
+++ test.1749864406/tests.log	2025-06-14 02:33:33.360825162 +0100
@@ -21,14 +21,14 @@
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#entrustrootcaec1
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#entrustrootcag4
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigne46
-FAILED: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigneccrootcar4
+Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigneccrootcar4
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsignr46
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsignrootcar6
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#godaddyrootg2ca
-FAILED: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar1
-FAILED: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar2
-FAILED: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar3
-FAILED: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar4
+Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar1
+Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar2
+Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar3
+Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar4
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#letsencryptisrgx1
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#letsencryptisrgx2
 Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#microsoftecc2017
~~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345414](https://bugs.openjdk.org/browse/JDK-8345414) needs maintainer approval

### Issue
 * [JDK-8345414](https://bugs.openjdk.org/browse/JDK-8345414): Google CAInterop test failures (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3048/head:pull/3048` \
`$ git checkout pull/3048`

Update a local copy of the PR: \
`$ git checkout pull/3048` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3048`

View PR using the GUI difftool: \
`$ git pr show -t 3048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3048.diff">https://git.openjdk.org/jdk11u-dev/pull/3048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3048#issuecomment-2972102121)
</details>
