### PR TITLE
8358538: Update GHA Windows runner to 2025

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         shell: bash
@@ -98,7 +98,7 @@ jobs:
         id: toolchain-check
         run: |
           set +e
-          '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          '/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
             echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT
@@ -111,7 +111,7 @@ jobs:
         run: |
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
-            modify --quiet --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' \
+            modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      msvc-toolset-version: '14.29'
+      msvc-toolset-version: '14.43'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -258,7 +258,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      msvc-toolset-version: '14.29'
+      msvc-toolset-version: '14.43'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'
@@ -308,7 +308,7 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2019
+      runs-on: windows-2022
 
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:


### PR DESCRIPTION
Backport of [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538) to bump the image version of the Windows GHA Runners from the current `windows-2019` (which [is being removed by the end of june](https://github.com/actions/runner-images/issues/12045)) to `windows-2022`.

Note that we're bumping to `windows-2022` and not to `windows-2025` as [in the original commit](https://github.com/openjdk/jdk/commit/b787ff6def08a050b690b60e4a0ceb3aec2b73c8)).

The backport is not clean, because the GHA setup for 11 is different from JDK (and from JDK-17 too). 

With this change we're using `--with-msvc-toolset-version=14.43` (from the current `14.29`) which translates to:

```
* C Compiler:     Version 19.43.34808 (at /c/progra~1/micros~2/2022/enterp~1/vc/tools/msvc/1443~1.348/bin/hostx86/x64/cl.exe)
* C++ Compiler:   Version 19.43.34808 (at /c/progra~1/micros~2/2022/enterp~1/vc/tools/msvc/1443~1.348/bin/hostx86/x64/cl.exe)
```

The build seems to work correctly, but some AOT compiler tests fail on Windows ... 

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/hotspot/jtreg:tier1_compiler             782   728    54     0 <<
 ==============================
 TEST FAILURE
```
... stating that the Microsoft Visual Studio linker cannot be found ... 

```
2025-06-19T06:57:52.2058557Z STDERR:
2025-06-19T06:57:52.2059714Z artifact resolution error: jdk.test.lib.artifacts.ArtifactResolverException: Couldn't automatically resolve dependency for devkit-windows_x64 , revision VS2017-15.5.5+1.0
2025-06-19T06:57:52.2061234Z Please specify the location using jdk.test.lib.artifacts.devkit-windows_x64
2025-06-19T06:57:52.2062000Z  stdout: [Compiling AotInvokeDynamic2AotTest.so...
2025-06-19T06:57:52.2062869Z Exception in thread "main" java.lang.InternalError: Can't locate Microsoft Visual Studio amd64 link.exe
2025-06-19T06:57:52.2063952Z 	at jdk.aot@11.0.29-internal/jdk.tools.jaotc.Linker.<init>(Linker.java:112)
2025-06-19T06:57:52.2064681Z 	at jdk.aot@11.0.29-internal/jdk.tools.jaotc.Main.run(Main.java:160)
2025-06-19T06:57:52.2065355Z 	at jdk.aot@11.0.29-internal/jdk.tools.jaotc.Main.run(Main.java:133)
2025-06-19T06:57:52.2066028Z 	at jdk.aot@11.0.29-internal/jdk.tools.jaotc.Main.main(Main.java:89)
```

... which is possibly related to the modifications to [`Linker.java`](https://github.com/openjdk/jdk11u-dev/blob/501f90c4902e41ff8fd5fdbfb8fd694771496f5b/src/jdk.aot/share/classes/jdk.tools.jaotc/src/jdk/tools/jaotc/Linker.java#L208) that were introduced in [JDK-8231318](https://bugs.openjdk.org/browse/JDK-8231318). This is  JDK11 specific, because the AOT compiler was dropped in [JDK-8264805](https://bugs.openjdk.org/browse/JDK-8264805]) in JDK-17.

The PR is in draft mode while this is being investigated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538) needs maintainer approval

### Issue
 * [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538): Update GHA Windows runner to 2025 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3050/head:pull/3050` \
`$ git checkout pull/3050`

Update a local copy of the PR: \
`$ git checkout pull/3050` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3050`

View PR using the GUI difftool: \
`$ git pr show -t 3050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3050.diff">https://git.openjdk.org/jdk11u-dev/pull/3050.diff</a>

</details>
