### PR TITLE
8357193: [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build

### DIFF
--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -54,6 +54,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \
     OPTIMIZATION := LOW, \
     CFLAGS := $(CFLAGS_JDKLIB) -DJDWP_LOGGING, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     EXTRA_HEADER_DIRS := \
       include \
       libjdwp/export, \


### PR DESCRIPTION
Backport of [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193) to avoid warning `C5287` being treated as an error with Visual Studio 2022/17.14 [1]. This makes it possible to backport [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538) and [JDK-8360042](https://bugs.openjdk.org/browse/JDK-8360042).

The backport is not clean because `make/lib/Lib-jdk.jdwp.agent.gmk` in JDK17 has evolved differently.

Builds with `windows-2019` & MSVC Toolset `14.29`  GHA runner. `tier1` tests are ongoing in GHA.

[1]
```
openjdk\jdk\src\jdk.jdwp.agent\share\native\libjdwp\debugInit.c(184): error C2220: the following warning is treated as an error
\openjdk\jdk\src\jdk.jdwp.agent\share\native\libjdwp\debugInit.c(184): warning C5287: operands are different enum types '<unnamed-enum-JVMTI_VERSION_1>' and '<unnamed-enum-JVMTI_VERSION_MASK_INTERFACE_TYPE>';
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193): [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3053/head:pull/3053` \
`$ git checkout pull/3053`

Update a local copy of the PR: \
`$ git checkout pull/3053` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3053`

View PR using the GUI difftool: \
`$ git pr show -t 3053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3053.diff">https://git.openjdk.org/jdk11u-dev/pull/3053.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3053#issuecomment-2999579673)
</details>
