### PR TITLE
8360816: [11u] Use default value for ProgramFiles(x86) in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
           JDK_IMAGE_DIR=${{ steps.bundles.outputs.jdk-path }}
           SYMBOLS_IMAGE_DIR=${{ steps.bundles.outputs.symbols-path }}
           TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
-          JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
+          JTREG='OPTIONS=-e:ProgramFiles\(x86\)=C:\\Program\ Files\ \(x86\);JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
           && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
         env:
           PATH: ${{ steps.path.outputs.value }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,16 @@ jobs:
             echo "value=$PATH" >> $GITHUB_OUTPUT
           fi
 
+      - name: 'Set JTReg Options'
+        id: jtreg-options
+        run: |
+          if [[ '${{ runner.os }}' == 'Windows' ]]; then
+            # JTReg option for 'ProgramFiles(x86)' environment variable
+            echo 'value=-e:ProgramFiles\(x86\)=C:\\Program\ Files\ \(x86\)' >> $GITHUB_OUTPUT
+          else
+            echo 'value=' >> $GITHUB_OUTPUT
+          fi
+
       - name: 'Run tests'
         id: run-tests
         run: >
@@ -153,7 +163,7 @@ jobs:
           JDK_IMAGE_DIR=${{ steps.bundles.outputs.jdk-path }}
           SYMBOLS_IMAGE_DIR=${{ steps.bundles.outputs.symbols-path }}
           TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
-          JTREG='OPTIONS=-e:ProgramFiles\(x86\)=C:\\Program\ Files\ \(x86\);JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
+          JTREG='OPTIONS=${{ steps.jtreg-options.outputs.value }};JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful'
           && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
         env:
           PATH: ${{ steps.path.outputs.value }}


### PR DESCRIPTION
A fix for [JDK-8360816](https://bugs.openjdk.org/browse/JDK-8360816). 

The `ProgramFiles(x86)` environment variable is not properly propagated to JTReg tests in JDK11, which makes the AOT compiler tests fail on the new `windows-2025` GHA runners, as manifested in the backport of [https://bugs.openjdk.org/browse/JDK-8358538](JDK-8358538).  

Propagating this environment variable to JTRegs may require creating devkits for Windows 2022, but previous attempts were discarded [JDK-8283723](https://bugs.openjdk.org/browse/JDK-8283723). 

This fix prints a warning message when this environment variable is not set, and then uses a default value (`C:\Program Files (x86)`) that makes it possible to run the AOT tests with these new `windows-2025` GHA runners.  If the `ProgramFiles(x86)` env variable is set the fix has no effect, ensuring the previous behaviour. If the proposed default value is incorrect the AOT tests will continue to fail as before.

The PR is on top of  https://github.com/openjdk/jdk11u-dev/pull/3052 to verify the fix works as intended with the new `windows-2025` GHA runners.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360816](https://bugs.openjdk.org/browse/JDK-8360816) needs maintainer approval

### Issue
 * [JDK-8360816](https://bugs.openjdk.org/browse/JDK-8360816): [11u] Use default value for ProgramFiles(x86) in GHA (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3056/head:pull/3056` \
`$ git checkout pull/3056`

Update a local copy of the PR: \
`$ git checkout pull/3056` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3056`

View PR using the GUI difftool: \
`$ git pr show -t 3056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3056.diff">https://git.openjdk.org/jdk11u-dev/pull/3056.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3056#issuecomment-3012496286)
</details>
