### PR TITLE
8214972: Uses of klass_holder() except GC need to apply GC barriers

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -72,7 +72,7 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
   // by the GC but need to be strong roots if reachable from a current compilation.
   // InstanceKlass are created for both weak and strong metadata.  Ensuring this metadata
   // alive covers the cases where there are weak roots without performance cost.
-  oop holder = ik->holder_phantom();
+  oop holder = ik->klass_holder();
   if (ik->is_anonymous()) {
     // Though ciInstanceKlass records class loader oop, it's not enough to keep
     // VM anonymous classes alive (loader == NULL). Klass holder should be used instead.

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -692,6 +692,15 @@ oop ClassLoaderData::holder_phantom() const {
   }
 }
 
+// Let the GC read the holder without keeping it alive.
+oop ClassLoaderData::holder_no_keepalive() const {
+  if (!_holder.is_null()) {  // NULL class_loader
+    return _holder.peek();
+  } else {
+    return NULL;
+  }
+}
+
 // Unloading support
 bool ClassLoaderData::is_alive() const {
   bool alive = keep_alive()         // null class loader and incomplete anonymous klasses.

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -288,12 +288,12 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   void clear_accumulated_modified_oops() { _accumulated_modified_oops = false; }
   bool has_accumulated_modified_oops()   { return _accumulated_modified_oops; }
   oop holder_no_keepalive() const;
+  oop holder_phantom() const;
 
  private:
   void unload();
   bool keep_alive() const       { return _keep_alive > 0; }
 
-  oop holder_phantom() const;
   void classes_do(void f(Klass* const));
   void loaded_classes_do(KlassClosure* klass_closure);
   void classes_do(void f(InstanceKlass*));

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -287,8 +287,9 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   void accumulate_modified_oops()        { if (has_modified_oops()) _accumulated_modified_oops = true; }
   void clear_accumulated_modified_oops() { _accumulated_modified_oops = false; }
   bool has_accumulated_modified_oops()   { return _accumulated_modified_oops; }
- private:
+  oop holder_no_keepalive() const;
 
+ private:
   void unload();
   bool keep_alive() const       { return _keep_alive > 0; }
 

--- a/src/hotspot/share/classfile/classLoaderData.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.inline.hpp
@@ -33,7 +33,7 @@
 
 inline oop ClassLoaderData::class_loader() const {
   assert(!_unloading, "This oop is not available to unloading class loader data");
-  assert(_holder.is_null() || _holder.peek() != NULL , "This class loader data holder must be alive");
+  assert(_holder.is_null() || holder_no_keepalive() != NULL , "This class loader data holder must be alive");
   return _class_loader.resolve();
 }
 

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -165,7 +165,7 @@ void G1FullGCMarker::drain_stack() {
 }
 
 inline void G1FullGCMarker::follow_klass(Klass* k) {
-  oop op = k->klass_holder();
+  oop op = k->class_loader_data()->holder_no_keepalive();
   mark_and_push(&op);
 }
 

--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -93,7 +93,7 @@ inline void ParCompactionManager::MarkAndPushClosure::do_oop(oop* p)       { do_
 inline void ParCompactionManager::MarkAndPushClosure::do_oop(narrowOop* p) { do_oop_work(p); }
 
 inline void ParCompactionManager::follow_klass(Klass* klass) {
-  oop holder = klass->klass_holder();
+  oop holder = klass->class_loader_data()->holder_no_keepalive();
   mark_and_push(&holder);
 }
 

--- a/src/hotspot/share/gc/serial/markSweep.inline.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.inline.hpp
@@ -58,7 +58,7 @@ template <class T> inline void MarkSweep::mark_and_push(T* p) {
 }
 
 inline void MarkSweep::follow_klass(Klass* klass) {
-  oop op = klass->klass_holder();
+  oop op = klass->class_loader_data()->holder_no_keepalive();
   MarkSweep::mark_and_push(&op);
 }
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -49,14 +49,14 @@ JVMCIKlassHandle::JVMCIKlassHandle(Thread* thread, Klass* klass) {
   _thread = thread;
   _klass = klass;
   if (klass != NULL) {
-    _holder = Handle(_thread, klass->holder_phantom());
+    _holder = Handle(_thread, klass->klass_holder());
   }
 }
 
 JVMCIKlassHandle& JVMCIKlassHandle::operator=(Klass* klass) {
   _klass = klass;
   if (klass != NULL) {
-    _holder = Handle(_thread, klass->holder_phantom());
+    _holder = Handle(_thread, klass->klass_holder());
   }
   return *this;
 }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -680,12 +680,6 @@ public:
     }
   }
 
-  // Oop that keeps the metadata for this class from being unloaded
-  // in places where the metadata is stored in other places, like nmethods
-  oop klass_holder() const {
-    return is_anonymous() ? java_mirror() : class_loader();
-  }
-
   bool is_contended() const                {
     return (_misc_flags & _misc_is_contended) != 0;
   }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -393,10 +393,6 @@ void Klass::append_to_sibling_list() {
   debug_only(verify();)
 }
 
-oop Klass::holder_phantom() const {
-  return class_loader_data()->holder_phantom();
-}
-
 void Klass::clean_weak_klass_links(bool unloading_occurred, bool clean_alive_klasses) {
   if (!ClassUnloading || !unloading_occurred) {
     return;

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -506,7 +506,11 @@ protected:
 
   oop class_loader() const;
 
-  virtual oop klass_holder() const      { return class_loader(); }
+  // This loads the klass's holder as a phantom. This is useful when a weak Klass
+  // pointer has been "peeked" and then must be kept alive before it may
+  // be used safely.  All uses of klass_holder need to apply the appropriate barriers,
+  // except during GC.
+  oop klass_holder() const { return class_loader_data()->holder_phantom(); }
 
  protected:
   virtual Klass* array_klass_impl(bool or_null, int rank, TRAPS);
@@ -656,11 +660,6 @@ protected:
   // Iff the class loader (or mirror for anonymous classes) is alive the
   // Klass is considered alive.  Has already been marked as unloading.
   bool is_loader_alive() const { return !class_loader_data()->is_unloading(); }
-
-  // Load the klass's holder as a phantom. This is useful when a weak Klass
-  // pointer has been "peeked" and then must be kept alive before it may
-  // be used safely.
-  oop holder_phantom() const;
 
   static void clean_weak_klass_links(bool unloading_occurred, bool clean_alive_klasses = true);
   static void clean_subklass_tree() {


### PR DESCRIPTION
I've been working on a backport to fix [JDK-8339725](https://bugs.openjdk.org/browse/JDK-8339725). The fix attached to the ticket is not enough to fix the problem on jdk11. 

The missing backport is JDK-8214972, which I apply in this PR. JDK-8210321 is also needed to provide `ClassLoaderData::holder_no_keepalive`.

Tier1 tests completed successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8210321](https://bugs.openjdk.org/browse/JDK-8210321) needs maintainer approval
- [ ] [JDK-8214972](https://bugs.openjdk.org/browse/JDK-8214972) needs maintainer approval

### Issues
 * [JDK-8214972](https://bugs.openjdk.org/browse/JDK-8214972): Uses of klass_holder() except GC need to apply GC barriers (**Bug** - P3 - Rejected)
 * [JDK-8210321](https://bugs.openjdk.org/browse/JDK-8210321): Create NO_KEEPALIVE CLD holder accessor (**Enhancement** - P4 - Rejected)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3059/head:pull/3059` \
`$ git checkout pull/3059`

Update a local copy of the PR: \
`$ git checkout pull/3059` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3059`

View PR using the GUI difftool: \
`$ git pr show -t 3059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3059.diff">https://git.openjdk.org/jdk11u-dev/pull/3059.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3059#issuecomment-3049422528)
</details>
