### PR TITLE
8231943: ZGC: Enable serviceability/dcmd/gc/RunGCTest

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/RunGCTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/RunGCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,13 +36,12 @@ import jdk.test.lib.dcmd.JMXExecutor;
 /*
  * @test
  * @summary Test of diagnostic command GC.run
- * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -Xlog:gc=debug:RunGC.gclog -XX:-ExplicitGCInvokesConcurrent RunGCTest
+ * @run testng/othervm -Xlog:gc:RunGC.gclog -XX:-ExplicitGCInvokesConcurrent RunGCTest
  */
 public class RunGCTest {
     public void run(CommandExecutor executor) {
@@ -58,7 +57,7 @@ public class RunGCTest {
         }
 
         OutputAnalyzer output = new OutputAnalyzer(gcLog, "");
-        output.shouldContain("Pause Full (Diagnostic Command)");
+        output.shouldContain("(Diagnostic Command)");
     }
 
     @Test


### PR DESCRIPTION
Backporting JDK-8231943: ZGC: Enable serviceability/dcmd/gc/RunGCTest. Adjusting test to be compatible with ZGC by slightly shortening output string check. Also cleaning up test by removing redundant "gc=debug". Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test directly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8231943](https://bugs.openjdk.org/browse/JDK-8231943) needs maintainer approval

### Issue
 * [JDK-8231943](https://bugs.openjdk.org/browse/JDK-8231943): ZGC: Enable serviceability/dcmd/gc/RunGCTest (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3060/head:pull/3060` \
`$ git checkout pull/3060`

Update a local copy of the PR: \
`$ git checkout pull/3060` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3060`

View PR using the GUI difftool: \
`$ git pr show -t 3060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3060.diff">https://git.openjdk.org/jdk11u-dev/pull/3060.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3060#issuecomment-3063180811)
</details>
