### PR TITLE
8247362: HeapDumpCompressedTest.java#id0 fails due to "Multiple garbage collectors selected"

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
@@ -36,14 +36,37 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test
- * @summary Test of diagnostic command GC.heap_dump with gzipped output (Serial, Parallel and G1)
+ * @requires vm.gc.Serial
+ * @summary Test of diagnostic command GC.heap_dump with gzipped output (Serial GC)
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UseSerialGC HeapDumpCompressedTest
+ */
+
+/*
+ * @test
+ * @requires vm.gc.Parallel
+ * @summary Test of diagnostic command GC.heap_dump with gzipped output (Parallel GC)
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UseParallelGC HeapDumpCompressedTest
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @summary Test of diagnostic command GC.heap_dump with gzipped output (G1 GC)
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UseG1GC HeapDumpCompressedTest
  */
 


### PR DESCRIPTION
Backporting JDK-8247362: HeapDumpCompressedTest.java#id0 fails due to "Multiple garbage collectors selected". Adjusted test to add @ requires for GCs, fixing failure when run with GC directly. Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test directly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8247362](https://bugs.openjdk.org/browse/JDK-8247362) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247362](https://bugs.openjdk.org/browse/JDK-8247362): HeapDumpCompressedTest.java#id0 fails due to "Multiple garbage collectors selected" (**Bug** - P3 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3061/head:pull/3061` \
`$ git checkout pull/3061`

Update a local copy of the PR: \
`$ git checkout pull/3061` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3061`

View PR using the GUI difftool: \
`$ git pr show -t 3061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3061.diff">https://git.openjdk.org/jdk11u-dev/pull/3061.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3061#issuecomment-3063837479)
</details>
