### PR TITLE
8268463: Windows 32bit build fails in DynamicCodeGenerated\libDynamicCodeGenerated.cpp

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
@@ -46,7 +46,8 @@ void JNICALL DynamicCodeGenerated(jvmtiEnv* jvmti, const char* name, const void*
 
 }
 
-jint Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     vm->GetEnv((void**)&jvmti, JVMTI_VERSION_1_0);
     jvmtiEventCallbacks callbacks;
     memset(&callbacks, 0, sizeof(callbacks));


### PR DESCRIPTION
Small fix for a build error on 32bit Windows, following https://github.com/openjdk/jdk11u-dev/pull/3051.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8268463](https://bugs.openjdk.org/browse/JDK-8268463) needs maintainer approval

### Issue
 * [JDK-8268463](https://bugs.openjdk.org/browse/JDK-8268463): Windows 32bit build fails in DynamicCodeGenerated\libDynamicCodeGenerated.cpp (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3063/head:pull/3063` \
`$ git checkout pull/3063`

Update a local copy of the PR: \
`$ git checkout pull/3063` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3063`

View PR using the GUI difftool: \
`$ git pr show -t 3063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3063.diff">https://git.openjdk.org/jdk11u-dev/pull/3063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3063#issuecomment-3077572921)
</details>
