### PR TITLE
Backport a0b8865e326a8267499b251aa8c10e8edabc0d3b

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -120,7 +120,7 @@ public class CloseDescriptors {
     private static boolean check() throws Exception {
         long myPid = ProcessHandle.current().pid();
         ProcessBuilder pb = new ProcessBuilder(
-                        "lsof", "-U", "-a", "-p", Long.toString(myPid));
+                        "lsof", "-U", "-a", "-w", "-p", Long.toString(myPid));
         pb.redirectErrorStream(true);
         Process p = pb.start();
         p.waitFor();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b1b66965](https://github.com/openjdk/jdk/commit/b1b66965f1ec6eae547cc4f70f8271bd39ded6da) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aleksey Shipilev on 29 Sep 2021 and was reviewed by Daniel Fuchs.

Thanks!