### PR TITLE
8340185: Use make -k on GHA to catch more build errors

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ runs:
     - name: 'Build'
       id: build
       run: >
-        make LOG=info ${{ inputs.make-target }}
+        make -k LOG=info ${{ inputs.make-target }}
         || bash ./.github/scripts/gen-build-failure-report.sh "$GITHUB_STEP_SUMMARY"
       shell: bash
 


### PR DESCRIPTION
Improves GHA usability.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340185](https://bugs.openjdk.org/browse/JDK-8340185) needs maintainer approval

### Issue
 * [JDK-8340185](https://bugs.openjdk.org/browse/JDK-8340185): Use make -k on GHA to catch more build errors (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3068/head:pull/3068` \
`$ git checkout pull/3068`

Update a local copy of the PR: \
`$ git checkout pull/3068` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3068`

View PR using the GUI difftool: \
`$ git pr show -t 3068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3068.diff">https://git.openjdk.org/jdk11u-dev/pull/3068.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3068#issuecomment-3145223885)
</details>
