### PR TITLE
8363965: GHA: Switch cross-compiling sysroots to Debian bookworm

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -59,23 +59,23 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
 
     steps:
       - name: 'Checkout the JDK source'


### PR DESCRIPTION
Fixes GHA cross-compilation. The patch is not clean, because RISC-V GHA configuration is missing. So I reapplied the patch by hand.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965) needs maintainer approval

### Issue
 * [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965): GHA: Switch cross-compiling sysroots to Debian bookworm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3070/head:pull/3070` \
`$ git checkout pull/3070`

Update a local copy of the PR: \
`$ git checkout pull/3070` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3070`

View PR using the GUI difftool: \
`$ git pr show -t 3070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3070.diff">https://git.openjdk.org/jdk11u-dev/pull/3070.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3070#issuecomment-3150082286)
</details>
