### PR TITLE
8366125: [11u] Test compiler/loopopts/TestRangeCheckPredicatesControl.java fails OOM

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@
  * @bug 8237859
  * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.
  *
- * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC compiler.loopopts.TestRangeCheckPredicatesControl
- * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
  */
 
 package compiler.loopopts;


### PR DESCRIPTION
Hi all,

On ours linux-x64 machine, `-Xmx256M -XX:+UnlockExperimentalVMOptions -XX:+UseZGC` can not start JVM because of OOM. I think it's not a JVM bug in jdk11u, I think we should increase the max heap size to make test run normally after [JDK-8251949](https://bugs.openjdk.org/browse/JDK-8251949). The `-Xmx256m` was introduced by [JDK-8251949](https://bugs.openjdk.org/browse/JDK-8251949) only for jdk11u. So this PR will only for jdk11u also.

Change has been verified locally, test-fix only, ro risk.