### PR TITLE
8366221: [11u] TestPromotionFromSurvivorToTenuredAfterMinorGC.java javac build fails

### DIFF
--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ package gc.survivorAlignment;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @build sun.hotspot.WhiteBox
+ * @build sun.hotspot.WhiteBox SurvivorAlignmentTestMain AlignmentHelper
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions


### PR DESCRIPTION
Hi all,

The test gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java use the class SurvivorAlignmentTestMain and AlignmentHelper which located in the same directory with tested class. I think we should build the depencied class explictly to avoid jtreg report javac compile failure.

This test was removed by https://bugs.openjdk.org/browse/JDK-8255298, So this test only effect jdk11u.

Change has been verified locally, test-fix only, no risk.