### PR TITLE
8271456: Avoid looking up standard charsets in "java.desktop" module

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileView.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileView.java
@@ -25,14 +25,19 @@
 
 package com.apple.laf;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.swing.Icon;
 import javax.swing.filechooser.FileView;
 
 import com.apple.laf.AquaUtils.RecyclableSingleton;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @SuppressWarnings("serial") // JDK implementation class
 class AquaFileView extends FileView {
@@ -106,11 +111,7 @@ class AquaFileView extends FileView {
         FileInfo(final File file){
             isDirectory = file.isDirectory();
             absolutePath = file.getAbsolutePath();
-            try {
-                pathBytes = absolutePath.getBytes("UTF-8");
-            } catch (final UnsupportedEncodingException e) {
-                pathBytes = new byte[0];
-            }
+            pathBytes = absolutePath.getBytes(UTF_8);
         }
     }
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDataTransferer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDataTransferer.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +25,27 @@
 
 package sun.lwawt.macosx;
 
-import java.awt.*;
-
-import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.awt.Image;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
-import java.util.*;
-import java.util.regex.*;
-import java.awt.datatransfer.*;
-import java.nio.charset.StandardCharsets;
-import sun.awt.datatransfer.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import sun.awt.datatransfer.DataTransferer;
+import sun.awt.datatransfer.ToolkitThreadBlockedHandler;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class CDataTransferer extends DataTransferer {
     private static final Map<String, Long> predefinedClipboardNameMap;
@@ -133,7 +139,7 @@ public class CDataTransferer extends DataTransferer {
             String charset = Charset.defaultCharset().name();
             if (transferable != null && transferable.isDataFlavorSupported(javaTextEncodingFlavor)) {
                 try {
-                    charset = new String((byte[]) transferable.getTransferData(javaTextEncodingFlavor), StandardCharsets.UTF_8);
+                    charset = new String((byte[]) transferable.getTransferData(javaTextEncodingFlavor), UTF_8);
                 } catch (UnsupportedFlavorException cannotHappen) {
                 }
             }
@@ -160,7 +166,8 @@ public class CDataTransferer extends DataTransferer {
             // class by base method
             format = CF_STRING;
         } else if (format == CF_STRING) {
-            bytes = Normalizer.normalize(new String(bytes, "UTF8"), Form.NFC).getBytes("UTF8");
+            String src = new String(bytes, UTF_8);
+            bytes = Normalizer.normalize(src, Form.NFC).getBytes(UTF_8);
         }
 
         return super.translateBytes(bytes, flavor, format, transferable);

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,15 @@
 
 package com.sun.imageio.plugins.bmp;
 
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
-import org.w3c.dom.Node;
-import com.sun.imageio.plugins.common.I18N;
+import javax.imageio.metadata.IIOMetadataNode;
 
+import com.sun.imageio.plugins.common.I18N;
 import com.sun.imageio.plugins.common.ImageUtil;
+import org.w3c.dom.Node;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class BMPMetadata extends IIOMetadata implements BMPConstants {
     public static final String nativeMetadataFormatName =
@@ -114,11 +110,7 @@ public class BMPMetadata extends IIOMetadata implements BMPConstants {
     }
 
     private String toISO8859(byte[] data) {
-        try {
-            return new String(data, "ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            return "";
-        }
+        return new String(data, ISO_8859_1);
     }
 
     private Node getNativeTree() {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,16 @@
 
 package com.sun.imageio.plugins.gif;
 
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.imageio.ImageTypeSpecifier;
+
 import javax.imageio.metadata.IIOInvalidTreeException;
-import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
+import javax.imageio.metadata.IIOMetadataNode;
+
 import org.w3c.dom.Node;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class GIFImageMetadata extends GIFMetadata {
 
@@ -132,11 +131,7 @@ public class GIFImageMetadata extends GIFMetadata {
     }
 
     private String toISO8859(byte[] data) {
-        try {
-            return new String(data, "ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            return "";
-        }
+        return new String(data, ISO_8859_1);
     }
 
     private Node getNativeTree() {
@@ -384,12 +379,7 @@ public class GIFImageMetadata extends GIFMetadata {
 
         while (commentIter.hasNext()) {
             byte[] comment = commentIter.next();
-            String s = null;
-            try {
-                s = new String(comment, "ISO-8859-1");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException("Encoding ISO-8859-1 unknown!");
-            }
+            String s = new String(comment, ISO_8859_1);
 
             node = new IIOMetadataNode("TextEntry");
             node.setAttribute("value", s);

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFWritableImageMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFWritableImageMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,16 @@
 
 package com.sun.imageio.plugins.gif;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import javax.imageio.ImageTypeSpecifier;
+
 import javax.imageio.metadata.IIOInvalidTreeException;
-import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
+import javax.imageio.metadata.IIOMetadataNode;
+
 import org.w3c.dom.Node;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 class GIFWritableImageMetadata extends GIFImageMetadata {
 
@@ -95,11 +93,7 @@ class GIFWritableImageMetadata extends GIFImageMetadata {
     }
 
     private byte[] fromISO8859(String data) {
-        try {
-            return data.getBytes("ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            return "".getBytes();
-        }
+        return data.getBytes(ISO_8859_1);
     }
 
     protected void mergeNativeTree(Node root) throws IIOInvalidTreeException {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/COMMarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/COMMarkerSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,15 @@
 
 package com.sun.imageio.plugins.jpeg;
 
+import java.io.IOException;
+
+import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.ImageOutputStream;
-import javax.imageio.metadata.IIOInvalidTreeException;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import org.w3c.dom.Node;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  * A Comment marker segment.  Retains an array of bytes representing the
@@ -45,7 +46,6 @@ import org.w3c.dom.Node;
  * byte array, again assuming the default local encoding.
  */
 class COMMarkerSegment extends MarkerSegment {
-    private static final String ENCODING = "ISO-8859-1";
 
     /**
      * Constructs a marker segment from the given buffer, which contains
@@ -96,10 +96,7 @@ class COMMarkerSegment extends MarkerSegment {
      * consulted directly.
      */
     String getComment() {
-        try {
-            return new String (data, ENCODING);
-        } catch (UnsupportedEncodingException e) {}  // Won't happen
-        return null;
+        return new String(data, ISO_8859_1);
     }
 
     /**

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
@@ -25,40 +25,41 @@
 
 package com.sun.imageio.plugins.jpeg;
 
+import java.awt.Graphics;
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.IndexColorModel;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import javax.imageio.IIOException;
 import javax.imageio.IIOImage;
-import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageReader;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.event.IIOReadProgressListener;
 import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
-import javax.imageio.event.IIOReadProgressListener;
 
-import java.awt.Graphics;
-import java.awt.color.ICC_Profile;
-import java.awt.color.ICC_ColorSpace;
-import java.awt.color.ColorSpace;
-import java.awt.image.ColorModel;
-import java.awt.image.SampleModel;
-import java.awt.image.IndexColorModel;
-import java.awt.image.ComponentColorModel;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBuffer;
-import java.awt.image.DataBufferByte;
-import java.awt.image.Raster;
-import java.awt.image.WritableRaster;
-import java.io.IOException;
-import java.io.ByteArrayOutputStream;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Iterator;
-
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.w3c.dom.NamedNodeMap;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * A JFIF (JPEG File Interchange Format) APP0 (Application-Specific)
@@ -1353,7 +1354,7 @@ class JFIFMarkerSegment extends MarkerSegment {
             ios.write(0xff);
             ios.write(JPEG.APP2);
             MarkerSegment.write2bytes(ios, segLength);
-            byte [] id = ID.getBytes("US-ASCII");
+            byte[] id = ID.getBytes(US_ASCII);
             ios.write(id);
             ios.write(0); // Null-terminate the string
             ios.write(chunkNum++);

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,18 +48,22 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+
 import javax.imageio.IIOException;
-import javax.imageio.ImageReader;
 import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
+
 import com.sun.imageio.plugins.common.InputStreamAdapter;
 import com.sun.imageio.plugins.common.ReaderUtil;
 import com.sun.imageio.plugins.common.SubImageInputStream;
-import java.io.ByteArrayOutputStream;
 import sun.awt.image.ByteInterleavedRaster;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class PNGImageDataEnumeration implements Enumeration<InputStream> {
 
@@ -478,9 +483,9 @@ public class PNGImageReader extends ImageReader {
         stream.readFully(b);
 
         if (compressionFlag == 1) { // Decompress the text
-            text = new String(inflate(b), "UTF8");
+            text = new String(inflate(b), UTF_8);
         } else {
-            text = new String(b, "UTF8");
+            text = new String(b, UTF_8);
         }
         metadata.iTXt_text.add(text);
 
@@ -581,7 +586,7 @@ public class PNGImageReader extends ImageReader {
 
         byte[] b = new byte[textLength];
         stream.readFully(b);
-        metadata.tEXt_text.add(new String(b, "ISO-8859-1"));
+        metadata.tEXt_text.add(new String(b, ISO_8859_1));
 
         // Check if the text chunk contains image creation time
         if (keyword.equals(PNGMetadata.tEXt_creationTimeKey)) {
@@ -682,7 +687,7 @@ public class PNGImageReader extends ImageReader {
 
         byte[] b = new byte[textLength];
         stream.readFully(b);
-        metadata.zTXt_text.add(new String(inflate(b), "ISO-8859-1"));
+        metadata.zTXt_text.add(new String(inflate(b), ISO_8859_1));
 
         // Check if the text chunk contains image creation time
         if (keyword.equals(PNGMetadata.tEXt_creationTimeKey)) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,15 +28,16 @@ package com.sun.imageio.plugins.png;
 import java.awt.Rectangle;
 import java.awt.image.IndexColorModel;
 import java.awt.image.Raster;
-import java.awt.image.WritableRaster;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
+
 import javax.imageio.IIOException;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageTypeSpecifier;
@@ -46,6 +47,9 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.spi.ImageWriterSpi;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.ImageOutputStreamImpl;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 final class CRC {
 
@@ -801,15 +805,14 @@ public final class PNGImageWriter extends ImageWriter {
             cs.writeBytes(languageIter.next());
             cs.writeByte(0);
 
-
-            cs.write(translatedKeywordIter.next().getBytes("UTF8"));
+            cs.write(translatedKeywordIter.next().getBytes(UTF_8));
             cs.writeByte(0);
 
             String text = textIter.next();
             if (compressed) {
-                cs.write(deflate(text.getBytes("UTF8")));
+                cs.write(deflate(text.getBytes(UTF_8)));
             } else {
-                cs.write(text.getBytes("UTF8"));
+                cs.write(text.getBytes(UTF_8));
             }
             cs.finish();
         }
@@ -833,7 +836,7 @@ public final class PNGImageWriter extends ImageWriter {
             cs.writeByte(compressionMethod);
 
             String text = textIter.next();
-            cs.write(deflate(text.getBytes("ISO-8859-1")));
+            cs.write(deflate(text.getBytes(ISO_8859_1)));
             cs.finish();
         }
     }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
@@ -22,24 +22,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.imageio.plugins.tiff;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
 import javax.imageio.IIOException;
-import javax.imageio.stream.ImageInputStream;
-import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.plugins.tiff.BaselineTIFFTagSet;
 import javax.imageio.plugins.tiff.TIFFDirectory;
 import javax.imageio.plugins.tiff.TIFFField;
 import javax.imageio.plugins.tiff.TIFFTag;
 import javax.imageio.plugins.tiff.TIFFTagSet;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class TIFFIFD extends TIFFDirectory {
     private static final long MAX_SAMPLES_PER_PIXEL = 0xffff;
@@ -287,8 +290,7 @@ public class TIFFIFD extends TIFFDirectory {
                             if (inString) {
                                 // end of string
                                 String s = new String(bvalues, prevIndex,
-                                        index - prevIndex,
-                                        StandardCharsets.US_ASCII);
+                                        index - prevIndex, US_ASCII);
                                 v.add(s);
                                 inString = false;
                             }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.imageio.plugins.tiff;
 
 import java.awt.Point;
@@ -34,8 +35,8 @@ import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.IndexColorModel;
-import java.awt.image.RenderedImage;
 import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import java.awt.image.WritableRaster;
 import java.io.EOFException;
@@ -44,27 +45,30 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.imageio.IIOException;
 import javax.imageio.IIOImage;
+import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
-import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
-import javax.imageio.spi.ImageWriterSpi;
-import javax.imageio.stream.ImageOutputStream;
-import org.w3c.dom.Node;
-import com.sun.imageio.plugins.common.ImageUtil;
 import javax.imageio.plugins.tiff.BaselineTIFFTagSet;
 import javax.imageio.plugins.tiff.ExifParentTIFFTagSet;
 import javax.imageio.plugins.tiff.ExifTIFFTagSet;
 import javax.imageio.plugins.tiff.TIFFField;
 import javax.imageio.plugins.tiff.TIFFTag;
 import javax.imageio.plugins.tiff.TIFFTagSet;
+import javax.imageio.spi.ImageWriterSpi;
+import javax.imageio.stream.ImageOutputStream;
+
+import com.sun.imageio.plugins.common.ImageUtil;
 import com.sun.imageio.plugins.common.SimpleRenderedImage;
 import com.sun.imageio.plugins.common.SingleTileRenderedImage;
-import java.nio.charset.StandardCharsets;
+import org.w3c.dom.Node;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class TIFFImageWriter extends ImageWriter {
 
@@ -1506,7 +1510,7 @@ public class TIFFImageWriter extends ImageWriter {
                         (exifTags.getTag(ExifTIFFTagSet.TAG_EXIF_VERSION),
                          TIFFTag.TIFF_UNDEFINED,
                          4,
-                         ExifTIFFTagSet.EXIF_VERSION_2_2.getBytes(StandardCharsets.US_ASCII));
+                         ExifTIFFTagSet.EXIF_VERSION_2_2.getBytes(US_ASCII));
                     exifIFD.addTIFFField(f);
                 }
 

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/wbmp/WBMPMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/wbmp/WBMPMetadata.java
@@ -25,19 +25,13 @@
 
 package com.sun.imageio.plugins.wbmp;
 
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
-import org.w3c.dom.Node;
-import com.sun.imageio.plugins.common.I18N;
+import javax.imageio.metadata.IIOMetadataNode;
 
+import com.sun.imageio.plugins.common.I18N;
 import com.sun.imageio.plugins.common.ImageUtil;
+import org.w3c.dom.Node;
 
 public class WBMPMetadata extends IIOMetadata {
 

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java
@@ -22,29 +22,76 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.java.swing.plaf.gtk;
 
-import sun.swing.SwingUtilities2;
-import com.sun.java.swing.plaf.gtk.GTKConstants.ArrowType;
-import com.sun.java.swing.plaf.gtk.GTKConstants.ShadowType;
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Composite;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
+import java.awt.image.FilteredImageSource;
+import java.awt.image.ImageProducer;
+import java.awt.image.RGBImageFilter;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
 
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JInternalFrame;
 import javax.swing.plaf.ColorUIResource;
 import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
-import javax.swing.plaf.synth.*;
+import javax.swing.plaf.synth.ColorType;
+import javax.swing.plaf.synth.SynthConstants;
+import javax.swing.plaf.synth.SynthContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
-import java.awt.*;
-import java.awt.geom.*;
-import java.awt.image.*;
-import java.io.*;
-import java.net.*;
-import java.security.*;
-import java.util.*;
-
-import javax.swing.*;
-
-import javax.xml.parsers.*;
+import com.sun.java.swing.plaf.gtk.GTKConstants.ArrowType;
+import com.sun.java.swing.plaf.gtk.GTKConstants.ShadowType;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-import org.w3c.dom.*;
+import sun.swing.SwingUtilities2;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  */
@@ -535,7 +582,8 @@ class Metacity implements SynthConstants {
                     URL url = new URL(new File(userHome).toURI().toURL(),
                                       ".gconf/apps/metacity/general/%25gconf.xml");
                     // Pending: verify character encoding spec for gconf
-                    Reader reader = new InputStreamReader(url.openStream(), "ISO-8859-1");
+                    Reader reader = new InputStreamReader(url.openStream(),
+                                                          ISO_8859_1);
                     char[] buf = new char[1024];
                     StringBuilder sb = new StringBuilder();
                     int n;

--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -47,6 +47,8 @@ import javax.sound.sampled.AudioFormat.Encoding;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
 /**
  * A DLS Level 1 and Level 2 soundbank reader (from files/url/streams).
  *
@@ -1151,7 +1153,7 @@ public final class DLSSoundbank implements Soundbank {
             return;
         RIFFWriter chunk = writer.writeChunk(name);
         chunk.writeString(value);
-        int len = value.getBytes("ascii").length;
+        int len = value.getBytes(US_ASCII).length;
         chunk.write(0);
         len++;
         if (len % 2 != 0)

--- a/src/java.desktop/share/classes/com/sun/media/sound/RIFFReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/RIFFReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package com.sun.media.sound;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Resource Interchange File Format (RIFF) stream decoder.
@@ -76,14 +78,14 @@ public final class RIFFReader extends InputStream {
         byte[] fourcc = new byte[4];
         fourcc[0] = (byte) b;
         readFully(fourcc, 1, 3);
-        this.fourcc = new String(fourcc, "ascii");
+        this.fourcc = new String(fourcc, US_ASCII);
         ckSize = readUnsignedInt();
         avail = ckSize;
 
         if (getFormat().equals("RIFF") || getFormat().equals("LIST")) {
             byte[] format = new byte[4];
             readFully(format);
-            this.riff_type = new String(format, "ascii");
+            this.riff_type = new String(format, US_ASCII);
         }
     }
 
@@ -227,10 +229,10 @@ public final class RIFFReader extends InputStream {
         readFully(buff);
         for (int i = 0; i < buff.length; i++) {
             if (buff[i] == 0) {
-                return new String(buff, 0, i, "ascii");
+                return new String(buff, 0, i, US_ASCII);
             }
         }
-        return new String(buff, "ascii");
+        return new String(buff, US_ASCII);
     }
 
     // Read 8 bit signed integer from stream

--- a/src/java.desktop/share/classes/com/sun/media/sound/RIFFWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/RIFFWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Resource Interchange File Format (RIFF) stream encoder.
@@ -208,11 +210,11 @@ public final class RIFFWriter extends OutputStream {
             raf.write(0);
 
         if (chunktype == 0)
-            raf.write("RIFF".getBytes("ascii"));
+            raf.write("RIFF".getBytes(US_ASCII));
         else if (chunktype == 1)
-            raf.write("LIST".getBytes("ascii"));
+            raf.write("LIST".getBytes(US_ASCII));
         else
-            raf.write((format + "    ").substring(0, 4).getBytes("ascii"));
+            raf.write((format + "    ").substring(0, 4).getBytes(US_ASCII));
 
         chunksizepointer = raf.getPointer();
         this.chunktype = 2;
@@ -220,8 +222,7 @@ public final class RIFFWriter extends OutputStream {
         this.chunktype = chunktype;
         startpointer = raf.getPointer();
         if (chunktype != 2)
-            raf.write((format + "    ").substring(0, 4).getBytes("ascii"));
-
+            raf.write((format + "    ").substring(0, 4).getBytes(US_ASCII));
     }
 
     public void seek(long pos) throws IOException {

--- a/src/java.desktop/share/classes/com/sun/media/sound/SF2Soundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SF2Soundbank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ import javax.sound.midi.Instrument;
 import javax.sound.midi.Patch;
 import javax.sound.midi.Soundbank;
 import javax.sound.midi.SoundbankResource;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * A SoundFont 2.04 soundbank reader.
@@ -543,7 +545,7 @@ public final class SF2Soundbank implements Soundbank {
             return;
         RIFFWriter chunk = writer.writeChunk(name);
         chunk.writeString(value);
-        int len = value.getBytes("ascii").length;
+        int len = value.getBytes(US_ASCII).length;
         chunk.write(0);
         len++;
         if (len % 2 != 0)

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftTuning.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftTuning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,11 @@
 
 package com.sun.media.sound;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
 import javax.sound.midi.Patch;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * A tuning program container, for use with MIDI Tuning.
@@ -99,11 +100,7 @@ public final class SoftTuning {
                     // http://www.midi.org/about-midi/tuning.shtml
                     //if (!checksumOK2(data))
                     //    break;
-                    try {
-                        name = new String(data, 6, 16, "ascii");
-                    } catch (UnsupportedEncodingException e) {
-                        name = null;
-                    }
+                    name = new String(data, 6, 16, US_ASCII);
                     int r = 22;
                     for (int i = 0; i < 128; i++) {
                         int xx = data[r++] & 0xFF;
@@ -135,11 +132,7 @@ public final class SoftTuning {
                     // http://www.midi.org/about-midi/tuning_extens.shtml
                     if (!checksumOK(data))
                         break;
-                    try {
-                        name = new String(data, 7, 16, "ascii");
-                    } catch (UnsupportedEncodingException e) {
-                        name = null;
-                    }
+                    name = new String(data, 7, 16, US_ASCII);
                     int r = 23;
                     for (int i = 0; i < 128; i++) {
                         int xx = data[r++] & 0xFF;
@@ -156,11 +149,7 @@ public final class SoftTuning {
                     // http://www.midi.org/about-midi/tuning_extens.shtml
                     if (!checksumOK(data))
                         break;
-                    try {
-                        name = new String(data, 7, 16, "ascii");
-                    } catch (UnsupportedEncodingException e) {
-                        name = null;
-                    }
+                    name = new String(data, 7, 16, US_ASCII);
                     int[] octave_tuning = new int[12];
                     for (int i = 0; i < 12; i++)
                         octave_tuning[i] = (data[i + 23] & 0xFF) - 64;
@@ -174,11 +163,7 @@ public final class SoftTuning {
                     // http://www.midi.org/about-midi/tuning_extens.shtml
                     if (!checksumOK(data))
                         break;
-                    try {
-                        name = new String(data, 7, 16, "ascii");
-                    } catch (UnsupportedEncodingException e) {
-                        name = null;
-                    }
+                    name = new String(data, 7, 16, US_ASCII);
                     double[] octave_tuning = new double[12];
                     for (int i = 0; i < 12; i++) {
                         int v = (data[i * 2 + 23] & 0xFF) * 128

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -22,26 +22,82 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text.html;
 
-import sun.awt.AppContext;
-
-import java.awt.*;
-import java.awt.event.*;
-import java.io.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.event.ActionEvent;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.io.Writer;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URL;
-import javax.swing.text.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.TextUI;
-import java.util.*;
-import javax.accessibility.*;
-import java.lang.ref.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Enumeration;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JEditorPane;
+import javax.swing.JViewport;
+import javax.swing.SizeRequirements;
+import javax.swing.SwingUtilities;
+import javax.swing.event.CaretEvent;
+import javax.swing.event.CaretListener;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.plaf.TextUI;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.BoxView;
+import javax.swing.text.ComponentView;
+import javax.swing.text.DefaultHighlighter;
+import javax.swing.text.Document;
+import javax.swing.text.EditorKit;
+import javax.swing.text.Element;
+import javax.swing.text.ElementIterator;
+import javax.swing.text.Highlighter;
+import javax.swing.text.IconView;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.LabelView;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.Position;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.StyledEditorKit;
+import javax.swing.text.TextAction;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
 import javax.swing.text.html.parser.ParserDelegator;
+
+import sun.awt.AppContext;
 import sun.swing.SwingAccessor;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  * The Swing JEditorPane text component supports different kinds
@@ -404,7 +460,7 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
             try {
                 InputStream is = HTMLEditorKit.getResourceAsStream(DEFAULT_CSS);
                 Reader r = new BufferedReader(
-                        new InputStreamReader(is, "ISO-8859-1"));
+                        new InputStreamReader(is, ISO_8859_1));
                 defaultStyles.loadRules(r, null);
                 r.close();
             } catch (Throwable e) {

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/RTFReader.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/RTFReader.java
@@ -22,12 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text.rtf;
 
-import java.lang.*;
-import java.util.*;
-import java.io.*;
 import java.awt.Color;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.StreamTokenizer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -35,7 +39,24 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import javax.swing.text.*;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyleContext;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.TabStop;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
@@ -641,7 +662,7 @@ static char[] readCharset(InputStream strm)
     char[] values = new char[256];
     int i;
     StreamTokenizer in = new StreamTokenizer(new BufferedReader(
-            new InputStreamReader(strm, "ISO-8859-1")));
+            new InputStreamReader(strm, ISO_8859_1)));
 
     in.eolIsSignificant(false);
     in.commentChar('#');

--- a/src/java.desktop/share/classes/sun/awt/FontDescriptor.java
+++ b/src/java.desktop/share/classes/sun/awt/FontDescriptor.java
@@ -22,14 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.awt;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStreamWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
-import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_16BE;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
 
 public class FontDescriptor implements Cloneable {
 
@@ -109,9 +112,8 @@ public class FontDescriptor implements Cloneable {
     public boolean useUnicode() {
         if (useUnicode && unicodeEncoder == null) {
             try {
-                this.unicodeEncoder = isLE?
-                    StandardCharsets.UTF_16LE.newEncoder():
-                    StandardCharsets.UTF_16BE.newEncoder();
+                this.unicodeEncoder = isLE ? UTF_16LE.newEncoder():
+                                             UTF_16BE.newEncoder();
             } catch (IllegalArgumentException x) {}
         }
         return useUnicode;

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -29,77 +29,78 @@ import java.awt.EventQueue;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Toolkit;
-
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.FlavorMap;
 import java.awt.datatransfer.FlavorTable;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ImageObserver;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FilePermission;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Reader;
 import java.io.SequenceInputStream;
 import java.io.StringReader;
-
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.stream.Stream;
 
-import java.util.*;
-
-import sun.datatransfer.DataFlavorUtil;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriter;
+import javax.imageio.spi.ImageWriterSpi;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
 
 import sun.awt.AppContext;
 import sun.awt.ComponentFactory;
 import sun.awt.SunToolkit;
-
-import java.awt.image.BufferedImage;
-import java.awt.image.ImageObserver;
-import java.awt.image.RenderedImage;
-import java.awt.image.WritableRaster;
-import java.awt.image.ColorModel;
-
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.ImageReadParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.ImageTypeSpecifier;
-
-import javax.imageio.spi.ImageWriterSpi;
-
-import javax.imageio.stream.ImageInputStream;
-import javax.imageio.stream.ImageOutputStream;
-
 import sun.awt.image.ImageRepresentation;
 import sun.awt.image.ToolkitImage;
+import sun.datatransfer.DataFlavorUtil;
 
-import java.io.FilePermission;
-import java.util.stream.Stream;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Provides a set of functions to be shared among the DataFlavor class and
@@ -550,7 +551,7 @@ public abstract class DataTransferer {
             try {
                 byte[] charsetNameBytes = (byte[])localeTransferable
                         .getTransferData(javaTextEncodingFlavor);
-                charset = new String(charsetNameBytes, StandardCharsets.UTF_8);
+                charset = new String(charsetNameBytes, UTF_8);
             } catch (UnsupportedFlavorException cannotHappen) {
             }
         } else {

--- a/src/java.desktop/share/classes/sun/font/Type1Font.java
+++ b/src/java.desktop/share/classes/sun/font/Type1Font.java
@@ -25,24 +25,24 @@
 
 package sun.font;
 
-import java.lang.ref.WeakReference;
 import java.awt.FontFormatException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
-import java.nio.BufferUnderflowException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.util.HashMap;
+import java.util.HashSet;
+
 import sun.java2d.Disposer;
 import sun.java2d.DisposerRecord;
-import java.util.HashSet;
-import java.util.HashMap;
-import java.awt.Font;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /*
  * Adobe Technical Note 5040 details the format of PFB files.
@@ -607,11 +607,7 @@ public class Type1Font extends FileFont {
         byte[] nameBytes = new byte[pos2-pos1-1];
         bb.position(pos1);
         bb.get(nameBytes);
-        try {
-            return new String(nameBytes, "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            return new String(nameBytes);
-        }
+        return new String(nameBytes, US_ASCII);
     }
 
     private String getString(ByteBuffer bb) {
@@ -621,11 +617,7 @@ public class Type1Font extends FileFont {
         byte[] nameBytes = new byte[pos2-pos1-1];
         bb.position(pos1);
         bb.get(nameBytes);
-        try {
-            return new String(nameBytes, "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            return new String(nameBytes);
-        }
+        return new String(nameBytes, US_ASCII);
     }
 
 

--- a/src/java.desktop/share/classes/sun/print/PageableDoc.java
+++ b/src/java.desktop/share/classes/sun/print/PageableDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,10 @@
 
 package sun.print;
 
+import java.awt.print.Pageable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-
-import java.awt.print.Pageable;
 
 import javax.print.Doc;
 import javax.print.DocFlavor;
@@ -57,9 +55,7 @@ public class PageableDoc implements Doc {
       return pageable;
    }
 
-   public Reader getReaderForText()
-      throws UnsupportedEncodingException, IOException {
-
+   public Reader getReaderForText() throws IOException {
       return null;
    }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,12 @@ package sun.awt.X11;
  * @since       1.5
  */
 
-import jdk.internal.misc.Unsafe;
 import java.util.HashMap;
+
+import jdk.internal.misc.Unsafe;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class XAtom {
 
@@ -308,12 +312,7 @@ public final class XAtom {
             throw new IllegalStateException("Atom should be initialized");
         }
         checkWindow(window);
-        byte[] bdata = null;
-        try {
-            bdata = str.getBytes("UTF-8");
-        } catch (java.io.UnsupportedEncodingException uee) {
-            uee.printStackTrace();
-        }
+        byte[] bdata = str.getBytes(UTF_8);
         if (bdata != null) {
             setAtomData(window, XA_UTF8_STRING.atom, bdata);
         }
@@ -327,12 +326,7 @@ public final class XAtom {
             throw new IllegalStateException("Atom should be initialized");
         }
         checkWindow(window);
-        byte[] bdata = null;
-        try {
-            bdata = str.getBytes("ISO-8859-1");
-        } catch (java.io.UnsupportedEncodingException uee) {
-            uee.printStackTrace();
-        }
+        byte[] bdata = str.getBytes(ISO_8859_1);
         if (bdata != null) {
             setAtomData(window, XA_STRING, bdata);
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XNETProtocol.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XNETProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,16 @@
  * questions.
  */
 
-
 package sun.awt.X11;
 
 import java.awt.Frame;
+import java.nio.charset.Charset;
 
 import sun.awt.IconInfo;
 import sun.util.logging.PlatformLogger;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 final class XNETProtocol extends XProtocol implements XStateProtocol, XLayerProtocol
 {
@@ -382,22 +385,18 @@ final class XNETProtocol extends XProtocol implements XStateProtocol, XLayerProt
          * mandates UTF8_STRING for _NET_WM_NAME but at least sawfish-1.0
          * still uses STRING.  (mmm, moving targets...).
          */
-        String charSet = "UTF8";
+        Charset charSet = UTF_8;
         byte[] net_wm_name = XA_NET_WM_NAME.getByteArrayProperty(NetWindow, XA_UTF8_STRING.getAtom());
         if (net_wm_name == null) {
             net_wm_name = XA_NET_WM_NAME.getByteArrayProperty(NetWindow, XAtom.XA_STRING);
-            charSet = "ASCII";
+            charSet = US_ASCII;
         }
 
         if (net_wm_name == null) {
             return null;
         }
-        try {
-            net_wm_name_cache = new String(net_wm_name, charSet);
-            return net_wm_name_cache;
-        } catch (java.io.UnsupportedEncodingException uex) {
-            return null;
-        }
+        net_wm_name_cache = new String(net_wm_name, charSet);
+        return net_wm_name_cache;
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -47,7 +47,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.WindowEvent;
 import java.awt.peer.ComponentPeer;
 import java.awt.peer.WindowPeer;
-import java.io.UnsupportedEncodingException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -66,6 +65,8 @@ import sun.awt.X11GraphicsDevice;
 import sun.awt.X11GraphicsEnvironment;
 import sun.java2d.pipe.Region;
 import sun.util.logging.PlatformLogger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class XWindowPeer extends XPanelPeer implements WindowPeer,
                                                 DisplayChangedListener {
@@ -1357,12 +1358,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
         }
         messageBuilder.append('"');
         messageBuilder.append('\0');
-        final byte[] message;
-        try {
-            message = messageBuilder.toString().getBytes("UTF-8");
-        } catch (UnsupportedEncodingException cannotHappen) {
-            return;
-        }
+        final byte[] message = messageBuilder.toString().getBytes(UTF_8);
 
         XClientMessageEvent req = null;
 

--- a/src/java.desktop/unix/classes/sun/awt/XSettings.java
+++ b/src/java.desktop/unix/classes/sun/awt/XSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,10 @@
 package sun.awt;
 
 import java.awt.Color;
-
-import java.io.UnsupportedEncodingException;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Per-screen XSETTINGS.
@@ -198,12 +196,7 @@ public class XSettings {
         {
             needBytes(len);
 
-            String str = null;
-            try {
-                str = new String(data, idx, len, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // XXX: cannot happen, "UTF-8" is always supported
-            }
+            String str = new String(data, idx, len, UTF_8);
 
             idx = (idx + len + 3) & ~0x3;
             return str;

--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -33,23 +33,24 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Scanner;
+
 import sun.awt.FcFontManager;
 import sun.awt.FontConfiguration;
 import sun.awt.FontDescriptor;
 import sun.awt.SunToolkit;
-import sun.font.CompositeFontDescriptor;
 import sun.font.FontManager;
-import sun.font.FontConfigManager.FontConfigInfo;
 import sun.font.FontConfigManager.FcCompFont;
 import sun.font.FontConfigManager.FontConfigFont;
+import sun.font.FontConfigManager.FontConfigInfo;
 import sun.java2d.SunGraphicsEnvironment;
 import sun.util.logging.PlatformLogger;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class FcFontConfiguration extends FontConfiguration {
 
@@ -180,7 +181,7 @@ public class FcFontConfiguration extends FontConfiguration {
         String[] componentFaceNames = cfi[idx].getComponentFaceNames();
         FontDescriptor[] ret = new FontDescriptor[componentFaceNames.length];
         for (int i = 0; i < componentFaceNames.length; i++) {
-            ret[i] = new FontDescriptor(componentFaceNames[i], StandardCharsets.ISO_8859_1.newEncoder(), new int[0]);
+            ret[i] = new FontDescriptor(componentFaceNames[i], ISO_8859_1.newEncoder(), new int[0]);
         }
 
         return ret;

--- a/src/java.desktop/unix/classes/sun/font/NativeFont.java
+++ b/src/java.desktop/unix/classes/sun/font/NativeFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,9 @@ import java.awt.font.FontRenderContext;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.io.UnsupportedEncodingException;
-import java.lang.ref.WeakReference;
 import java.util.Locale;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /*
  * Ideally there would be no native fonts used, and this class would be
@@ -213,23 +213,11 @@ public class NativeFont extends PhysicalFont {
             pos = sb.indexOf("-0-", pos);
         };
         String xlfd = sb.toString();
-        byte[] bytes = null;
-        try {
-            bytes = xlfd.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            bytes = xlfd.getBytes();
-        }
-        return haveBitmapFonts(bytes);
+        return haveBitmapFonts(xlfd.getBytes(UTF_8));
     }
 
     public static boolean fontExists(String xlfd) {
-        byte[] bytes = null;
-        try {
-            bytes = xlfd.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            bytes = xlfd.getBytes();
-        }
-        return fontExists(bytes);
+        return fontExists(xlfd.getBytes(UTF_8));
     }
 
     private static native boolean haveBitmapFonts(byte[] xlfd);
@@ -380,13 +368,7 @@ public class NativeFont extends PhysicalFont {
         }
 
         String xlfd = sb.toString();
-        byte[] bytes = null;
-        try {
-            bytes = xlfd.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            bytes = xlfd.getBytes();
-        }
-        return bytes;
+        return xlfd.getBytes(UTF_8);
     }
 
     public String toString() {

--- a/src/java.desktop/unix/classes/sun/print/AttributeClass.java
+++ b/src/java.desktop/unix/classes/sun/print/AttributeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.print;
 
-import java.util.Objects;
 import java.io.ByteArrayInputStream;
+import java.util.Objects;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class AttributeClass {
     private String myName;
@@ -187,10 +190,7 @@ public class AttributeClass {
 
             byte[] strBytes = new byte[valLength];
             bufStream.read(strBytes, 0, valLength);
-            try {
-                strVal = new String(strBytes, "UTF-8");
-            } catch (java.io.UnsupportedEncodingException uee) {
-            }
+            strVal = new String(strBytes, UTF_8);
         }
         return strVal;
     }
@@ -219,10 +219,7 @@ public class AttributeClass {
                 int valLength = bufStream.read();
                 byte[] bufBytes = new byte[valLength];
                 bufStream.read(bufBytes, 0, valLength);
-                try {
-                    valueArray[i] = new String(bufBytes, "UTF-8");
-                } catch (java.io.UnsupportedEncodingException uee) {
-                }
+                valueArray[i] = new String(bufBytes, UTF_8);
             }
             return valueArray;
         }

--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -27,42 +27,82 @@ package sun.print;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
-import javax.print.attribute.*;
-import javax.print.attribute.standard.*;
-import javax.print.DocFlavor;
-import javax.print.DocPrintJob;
-import javax.print.PrintService;
-import javax.print.ServiceUIFactory;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Date;
-import java.util.Arrays;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import javax.print.event.PrintServiceAttributeListener;
-
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.HttpURLConnection;
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.DataInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintService;
+import javax.print.ServiceUIFactory;
+import javax.print.attribute.Attribute;
+import javax.print.attribute.AttributeSet;
+import javax.print.attribute.AttributeSetUtilities;
+import javax.print.attribute.EnumSyntax;
+import javax.print.attribute.HashAttributeSet;
+import javax.print.attribute.HashPrintServiceAttributeSet;
+import javax.print.attribute.PrintRequestAttribute;
+import javax.print.attribute.PrintServiceAttribute;
+import javax.print.attribute.PrintServiceAttributeSet;
+import javax.print.attribute.Size2DSyntax;
+import javax.print.attribute.standard.Chromaticity;
+import javax.print.attribute.standard.ColorSupported;
+import javax.print.attribute.standard.Copies;
+import javax.print.attribute.standard.CopiesSupported;
+import javax.print.attribute.standard.Destination;
+import javax.print.attribute.standard.DialogOwner;
+import javax.print.attribute.standard.DialogTypeSelection;
+import javax.print.attribute.standard.Fidelity;
+import javax.print.attribute.standard.Finishings;
+import javax.print.attribute.standard.JobName;
+import javax.print.attribute.standard.JobSheets;
+import javax.print.attribute.standard.Media;
+import javax.print.attribute.standard.MediaPrintableArea;
+import javax.print.attribute.standard.MediaSize;
+import javax.print.attribute.standard.MediaSizeName;
+import javax.print.attribute.standard.MediaTray;
+import javax.print.attribute.standard.NumberUp;
+import javax.print.attribute.standard.OrientationRequested;
+import javax.print.attribute.standard.PDLOverrideSupported;
+import javax.print.attribute.standard.PageRanges;
+import javax.print.attribute.standard.PagesPerMinute;
+import javax.print.attribute.standard.PagesPerMinuteColor;
+import javax.print.attribute.standard.PrinterInfo;
+import javax.print.attribute.standard.PrinterIsAcceptingJobs;
+import javax.print.attribute.standard.PrinterLocation;
+import javax.print.attribute.standard.PrinterMakeAndModel;
+import javax.print.attribute.standard.PrinterMessageFromOperator;
+import javax.print.attribute.standard.PrinterMoreInfo;
+import javax.print.attribute.standard.PrinterMoreInfoManufacturer;
+import javax.print.attribute.standard.PrinterName;
+import javax.print.attribute.standard.PrinterResolution;
+import javax.print.attribute.standard.PrinterState;
+import javax.print.attribute.standard.PrinterStateReasons;
+import javax.print.attribute.standard.PrinterURI;
+import javax.print.attribute.standard.QueuedJobCount;
+import javax.print.attribute.standard.RequestingUserName;
+import javax.print.attribute.standard.SheetCollate;
+import javax.print.attribute.standard.Sides;
+import javax.print.event.PrintServiceAttributeListener;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class IPPPrintService implements PrintService, SunPrinterJobService {
 
@@ -324,11 +364,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
         if ((name == null) || (url == null)){
             throw new IllegalArgumentException("null uri or printer name");
         }
-        try {
-            printer = java.net.URLDecoder.decode(name, "UTF-8");
-        } catch (java.io.UnsupportedEncodingException e) {
-            printer = name;
-        }
+        printer = java.net.URLDecoder.decode(name, UTF_8);
         supportedDocFlavors = null;
         supportedCats = null;
         mediaSizeNames = null;
@@ -358,11 +394,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
         if ((name == null) || (uriStr == null)){
             throw new IllegalArgumentException("null uri or printer name");
         }
-        try {
-            printer = java.net.URLDecoder.decode(name, "UTF-8");
-        } catch (java.io.UnsupportedEncodingException e) {
-            printer = name;
-        }
+        printer = java.net.URLDecoder.decode(name, UTF_8);
         supportedDocFlavors = null;
         supportedCats = null;
         mediaSizeNames = null;
@@ -1730,9 +1762,8 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
 
                    InputStream is = urlConnection.getInputStream();
                    if (is != null) {
-                       BufferedReader d =
-                           new BufferedReader(new InputStreamReader(is,
-                                                          Charset.forName("ISO-8859-1")));
+                       BufferedReader d = new BufferedReader(
+                               new InputStreamReader(is, ISO_8859_1));
                        String lineStr;
                        while ((lineStr = d.readLine()) != null) {
                            if (lineStr.startsWith("*cupsFilter:")) {
@@ -1823,13 +1854,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
     public static boolean writeIPPRequest(OutputStream os,
                                            String operCode,
                                            AttributeClass[] attCl) {
-        OutputStreamWriter osw;
-        try {
-            osw = new OutputStreamWriter(os, "UTF-8");
-        } catch (java.io.UnsupportedEncodingException exc) {
-            debug_println(debugPrefix+"writeIPPRequest, UTF-8 not supported? Exception: "+exc);
-            return false;
-        }
+        OutputStreamWriter osw = new OutputStreamWriter(os, UTF_8);
         debug_println(debugPrefix+"writeIPPRequest, op code= "+operCode);
         char[] opCode =  new char[2];
         opCode[0] =  (char)Byte.parseByte(operCode.substring(0,2), 16);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
@@ -25,19 +25,15 @@
 
 package sun.awt.windows;
 
-import java.awt.Image;
 import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.Transparency;
-
 import java.awt.color.ColorSpace;
-
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.FlavorTable;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-
 import java.awt.geom.AffineTransform;
-
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.ComponentColorModel;
@@ -48,18 +44,16 @@ import java.awt.image.DirectColorModel;
 import java.awt.image.ImageObserver;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.io.File;
-
 import java.net.URL;
-
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,13 +63,11 @@ import java.util.SortedMap;
 import sun.awt.Mutex;
 import sun.awt.datatransfer.DataTransferer;
 import sun.awt.datatransfer.ToolkitThreadBlockedHandler;
-
 import sun.awt.image.ImageRepresentation;
 import sun.awt.image.ToolkitImage;
 
-import java.util.ArrayList;
-
-import java.io.ByteArrayOutputStream;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Platform-specific support for the data transfer subsystem.
@@ -249,7 +241,7 @@ final class WDataTransferer extends DataTransferer {
             if (bytes == null || !DataFlavor.javaFileListFlavor.equals(flavor)) {
                 throw new IOException("data translation failed");
             }
-            String st = new String(bytes, 0, bytes.length, "UTF-16LE");
+            String st = new String(bytes, 0, bytes.length, UTF_16LE);
             String[] filenames = st.split("\0");
             if( 0 == filenames.length ){
                 return null;
@@ -275,7 +267,7 @@ final class WDataTransferer extends DataTransferer {
             {
                 try {
                     charset = new String((byte[])localeTransferable.
-                        getTransferData(javaTextEncodingFlavor), "UTF-8");
+                        getTransferData(javaTextEncodingFlavor), UTF_8);
                 } catch (UnsupportedFlavorException cannotHappen) {
                 }
             }
@@ -548,8 +540,6 @@ enum EHTMLReadMode {
  * on encode: static convertToHTMLFormat is responsible for HTML clipboard header creation
  */
 class HTMLCodec extends InputStream {
-    //static section
-    public static final String ENCODING = "UTF-8";
 
     public static final String VERSION = "Version:";
     public static final String START_HTML = "StartHTML:";
@@ -674,13 +664,8 @@ class HTMLCodec extends InputStream {
         //HTML
         header.append(htmlPrefix);
 
-        byte[] headerBytes = null, trailerBytes = null;
-
-        try {
-            headerBytes = header.toString().getBytes(ENCODING);
-            trailerBytes = htmlSuffix.getBytes(ENCODING);
-        } catch (UnsupportedEncodingException cannotHappen) {
-        }
+        byte[] headerBytes = header.toString().getBytes(UTF_8);
+        byte[] trailerBytes = htmlSuffix.getBytes(UTF_8);
 
         byte[] retval = new byte[headerBytes.length + bytes.length +
                 trailerBytes.length];
@@ -789,7 +774,7 @@ class HTMLCodec extends InputStream {
         BufferedReader bufferedReader = new BufferedReader(
                 new InputStreamReader(
                         bufferedStream,
-                        ENCODING
+                        UTF_8
                 ),
                 CHAR_BUFFER_LEN
         );


### PR DESCRIPTION
Backport of [JDK-8271456](https://bugs.openjdk.org/browse/JDK-8271456) from JDK 17, for parity with Oracle 11.0.26.

There were trivial conflicts in copyright years and imports in a few files.

Testing: GitHub CI, `jdk_imageio` test group locally (mac/arm64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271456](https://bugs.openjdk.org/browse/JDK-8271456) needs maintainer approval

### Issue
 * [JDK-8271456](https://bugs.openjdk.org/browse/JDK-8271456): Avoid looking up standard charsets in "java.desktop" module (**Enhancement** - P4 - Approved)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3081/head:pull/3081` \
`$ git checkout pull/3081`

Update a local copy of the PR: \
`$ git checkout pull/3081` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3081`

View PR using the GUI difftool: \
`$ git pr show -t 3081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3081.diff">https://git.openjdk.org/jdk11u-dev/pull/3081.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3081#issuecomment-3233682868)
</details>
