### PR TITLE
8224087: Compile C code for at least C99 Standard compliance

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -296,6 +296,10 @@
 </tr>
 </tbody>
 </table>
+<p>All compilers are expected to be able to compile to the C99 language standard,
+as some C99 features are used in the source code. Microsoft Visual Studio
+doesn't fully support C99 so in practice shared code is limited to using C99
+features that it does support.</p>
 <h3 id="gcc">gcc</h3>
 <p>The minimum accepted version of gcc is 4.8. Older versions will generate a warning by <code>configure</code> and are unlikely to work.</p>
 <p>The JDK is currently known to be able to compile with at least version 7.4 of gcc.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -313,6 +313,11 @@ issues.
 | Solaris            | Oracle Solaris Studio 12.4 (with compiler version 5.13) |
 | Windows            | Microsoft Visual Studio 2017 update 15.9.16             |
 
+All compilers are expected to be able to compile to the C99 language standard,
+as some C99 features are used in the source code. Microsoft Visual Studio
+doesn't fully support C99 so in practice shared code is limited to using C99
+features that it does support.
+
 ### gcc
 
 The minimum accepted version of gcc is 4.8. Older versions will generate a warning

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -563,7 +563,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS="-errshort=tags"
 
     TOOLCHAIN_CFLAGS_JDK="-mt $TOOLCHAIN_FLAGS"
-    TOOLCHAIN_CFLAGS_JDK_CONLY="-xCC -Xa -W0,-noglobal $TOOLCHAIN_CFLAGS" # C only
+    TOOLCHAIN_CFLAGS_JDK_CONLY="-W0,-noglobal $TOOLCHAIN_CFLAGS" # C only
     TOOLCHAIN_CFLAGS_JDK_CXXONLY="-features=no%except -norunpath -xnolib" # CXX only
     TOOLCHAIN_CFLAGS_JVM="-template=no%extdef -features=no%split_init \
         -library=stlport4 -mt -features=no%except $TOOLCHAIN_FLAGS"
@@ -583,6 +583,30 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-nologo -MD -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:wchar_t-"
   fi
+
+  # CFLAGS C language level for JDK sources (hotspot only uses C++)
+  # Ideally we would have a common level across all toolchains so that all sources
+  # are sure to conform to the same standard. Unfortunately neither our sources nor
+  # our toolchains are in a condition to support that. But what we loosely aim for is
+  # C99 level.
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
+    # This raises the language level for older 4.8 gcc, while lowering it for later
+    # versions. clang and xlclang support the same flag.
+    LANGSTD_CFLAGS="-std=c99"
+  elif test "x$TOOLCHAIN_TYPE" = xsolstudio; then
+    # We can't turn on -std=c99 without breaking compilation of the splashscreen/png
+    # utilities. But we can enable c99 as below (previously achieved by using -Xa).
+    # It is the no_lib that makes the difference.
+    LANGSTD_CFLAGS="-xc99=all,no_lib"
+  elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+    # MSVC doesn't support C99/C11 explicitly, unless you compile as C++:
+    # LANGSTD_CFLAGS="/TP"
+    # but that requires numerous changes to the sources files. So we are limited
+    # to C89/C90 plus whatever extensions Visual Studio has decided to implement.
+    # This is the lowest bar for shared code.
+    LANGSTD_CFLAGS=""
+  fi
+  TOOLCHAIN_CFLAGS_JDK_CONLY="$LANGSTD_CFLAGS $TOOLCHAIN_CFLAGS_JDK_CONLY"
 
   # CFLAGS WARNINGS STUFF
   # Set JVM_CFLAGS warning handling

--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -382,7 +382,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
     OPTIMIZATION := HIGHEST, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LCMS_CFLAGS), \
-    CFLAGS_solaris := -xc99=no_lib, \
     CFLAGS_windows := -DCMS_IS_WINDOWS_, \
     EXTRA_HEADER_DIRS := \
         common/awt/debug \


### PR DESCRIPTION
This backport explicitly sets c99 standard for jdk c sources on compilers, where appropriate. Motivation for this is, [recent gcc switch to c23 as default](https://www.phoronix.com/news/GCC-15-Default-C23), causing errors (jdk sources are not c23 compatible).

Main problem is, that c23 no longer supports non-prototype function declarations (see (3) [here](https://en.cppreference.com/w/c/language/function_declaration.html)). Example errors:
```
/mnt/ramdisk/java-11-openjdk-11.0.28.0.6-1.portable.jdk.el.x86_64.tarxz/src/src/java.base/unix/native/libnet/DefaultProxySelector.c:389:16: error: too many arguments to function 'g_proxy_resolver_lookup'; expected 0, have 4
  389 |     proxies = (*g_proxy_resolver_lookup)(resolver, uri, NULL, &error);
      |               ~^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
```

```
/mnt/ramdisk/java-11-openjdk-11.0.28.0.6-1.portable.jdk.el.x86_64.tarxz/src/test/hotspot/jtreg/runtime/jsig/libTestJNI.c:45:22: error: assignment to 'void (*)(int,  siginfo_t *, void *)' from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
   45 |     act.sa_sigaction = (void (*)())sig_handler;
      |                      ^
```

There are more, if above are fixed. Non prototype function declarations are present even in newest jdk, but newer jdks have c standard set explicitly, so they do not cause errors there.

This should not increase minimum requirements for compiler toolchains needed to build jdk11. [Jdk13](https://github.com/openjdk/jdk13/blob/master/doc/building.md#native-compiler-toolchain-requirements), where this originates from, has same minimal compiler requirements as [jdk11](https://github.com/zzambers/jdk11u-dev/blob/master/doc/building.md#native-compiler-toolchain-requirements). ( gcc 4.8, clang 3.2, Xcode 8, Solaris Studio 12.4)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8224087](https://bugs.openjdk.org/browse/JDK-8224087) needs maintainer approval

### Issue
 * [JDK-8224087](https://bugs.openjdk.org/browse/JDK-8224087): Compile C code for at least C99 Standard compliance (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3087/head:pull/3087` \
`$ git checkout pull/3087`

Update a local copy of the PR: \
`$ git checkout pull/3087` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3087`

View PR using the GUI difftool: \
`$ git pr show -t 3087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3087.diff">https://git.openjdk.org/jdk11u-dev/pull/3087.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3087#issuecomment-3248844884)
</details>
