### PR TITLE
8286562: GCC 12 reports some compiler warnings

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -570,7 +570,8 @@ else
   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
   # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-       maybe-uninitialized class-memaccess unused-result extra noexcept-type expansion-to-defined
+       maybe-uninitialized class-memaccess unused-result extra use-after-free noexcept-type \
+       expansion-to-defined
   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
        tautological-constant-out-of-range-compare int-to-pointer-cast \
        undef missing-field-initializers deprecated-declarations c++11-narrowing range-loop-analysis

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ protected:
   Array(int length, T init) : _length(length) {
     assert(length >= 0, "illegal length");
     for (int i = 0; i < length; i++) {
-      _data[i] = init;
+      data()[i] = init;
     }
   }
 
@@ -102,12 +102,22 @@ protected:
 
   // standard operations
   int  length() const                 { return _length; }
-  T* data()                           { return _data; }
+
+  T* data() {
+    return reinterpret_cast<T*>(
+      reinterpret_cast<char*>(this) + base_offset_in_bytes());
+  }
+
+  const T* data() const {
+    return reinterpret_cast<const T*>(
+      reinterpret_cast<const char*>(this) + base_offset_in_bytes());
+  }
+
   bool is_empty() const               { return length() == 0; }
 
   int index_of(const T& x) const {
     int i = length();
-    while (i-- > 0 && _data[i] != x) ;
+    while (i-- > 0 && data()[i] != x) ;
 
     return i;
   }
@@ -115,9 +125,9 @@ protected:
   // sort the array.
   bool contains(const T& x) const      { return index_of(x) >= 0; }
 
-  T    at(int i) const                 { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return _data[i]; }
-  void at_put(const int i, const T& x) { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); _data[i] = x; }
-  T*   adr_at(const int i)             { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &_data[i]; }
+  T    at(int i) const                 { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return data()[i]; }
+  void at_put(const int i, const T& x) { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); data()[i] = x; }
+  T*   adr_at(const int i)             { assert(i >= 0 && i< _length, "oob: 0 <= %d < %d", i, _length); return &data()[i]; }
   int  find(const T& x)                { return index_of(x); }
 
   T at_acquire(const int which);

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -199,6 +199,17 @@ const char* type2name_tab[T_CONFLICT+1] = {
   "*narrowklass*",
   "*conflict*"
 };
+const char* type2name(BasicType t) {
+  if (t < ARRAY_SIZE(type2name_tab)) {
+    return type2name_tab[t];
+  } else if (t == T_ILLEGAL) {
+    return "*illegal*";
+  } else {
+    fatal("invalid type %d", t);
+    return "invalid type";
+  }
+}
+
 
 
 BasicType name2type(const char* name) {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -681,9 +681,13 @@ inline BasicType char2type(char c) {
 extern char type2char_tab[T_CONFLICT+1];     // Map a BasicType to a jchar
 inline char type2char(BasicType t) { return (uint)t < T_CONFLICT+1 ? type2char_tab[t] : 0; }
 extern int type2size[T_CONFLICT+1];         // Map BasicType to result stack elements
-extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a jchar
-inline const char* type2name(BasicType t) { return (uint)t < T_CONFLICT+1 ? type2name_tab[t] : NULL; }
+extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a char*
 extern BasicType name2type(const char* name);
+
+inline const char* type2name(BasicType t) {
+  assert((uint)t < T_CONFLICT + 1, "invalid type");
+  return type2name_tab[t];
+}
 
 // Auxiliary math routines
 // least common multiple

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -684,10 +684,7 @@ extern int type2size[T_CONFLICT+1];         // Map BasicType to result stack ele
 extern const char* type2name_tab[T_CONFLICT+1];     // Map a BasicType to a char*
 extern BasicType name2type(const char* name);
 
-inline const char* type2name(BasicType t) {
-  assert((uint)t < T_CONFLICT + 1, "invalid type");
-  return type2name_tab[t];
-}
+const char* type2name(BasicType t);
 
 // Auxiliary math routines
 // least common multiple

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,10 +125,13 @@ ProgramExists(char *name)
 static char *
 Resolve(char *indir, char *cmd)
 {
-    char name[PATH_MAX + 2], *real;
+    char name[PATH_MAX + 1], *real;
+    int snprintf_result;
 
-    if ((JLI_StrLen(indir) + JLI_StrLen(cmd) + 1)  > PATH_MAX) return 0;
-    JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
+    snprintf_result = JLI_Snprintf(name, sizeof(name), "%s%c%s", indir, FILE_SEPARATOR, cmd);
+    if ((snprintf_result < 0) || (snprintf_result >= (int)sizeof(name))) {
+      return NULL;
+    }
     if (!ProgramExists(name)) return 0;
     real = JLI_MemAlloc(PATH_MAX + 2);
     if (!realpath(name, real))

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidDebugInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,20 +153,20 @@ public class TestInvalidDebugInfo extends CodeInstallerTest {
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeInCPURegister() {
         Register reg = getRegister(arch.getPlatformKind(JavaKind.Int), 0);
-        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeInFloatRegister() {
         Register reg = getRegister(arch.getPlatformKind(JavaKind.Float), 0);
-        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{reg.asValue()}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)
     public void testUnexpectedTypeOnStack() {
         ValueKind<?> kind = new TestValueKind(codeCache.getTarget().arch, JavaKind.Int);
         StackSlot value = StackSlot.get(kind, 8, false);
-        test(new JavaValue[]{value}, new JavaKind[]{JavaKind.Illegal}, 1, 0, 0);
+        test(new JavaValue[]{value}, new JavaKind[]{JavaKind.Void}, 1, 0, 0);
     }
 
     @Test(expected = JVMCIError.class)


### PR DESCRIPTION
Backport fixes few warnings in newer gcc (12+), which I have seen some when doing test build for gcc15 (fedora 42) for another [backport](https://github.com/openjdk/jdk11u-dev/pull/3087#issuecomment-3266882552). Warning do not show in current GHA runs because it uses gcc 10. (Btw this change has also been backported to oracle jdk 11.)

Backport is not clear, there were some differences in surrounding context, copyright headers, location of gmk file etc. So part of it had to be done manually.  Changes to jfrTraceIdBits.inline.hpp are not present, because modified function is not present on jdk11.

I also included backport of followup change ([JDK-8293691](https://bugs.openjdk.org/browse/JDK-8293691)), which fixes problem introduced by original backported change.

GHA tests: OK

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8293691](https://bugs.openjdk.org/browse/JDK-8293691) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8286562](https://bugs.openjdk.org/browse/JDK-8286562) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8287491](https://bugs.openjdk.org/browse/JDK-8287491) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8293691: converting a defined BasicType value to a string should not crash the VM`

### Issues
 * [JDK-8286562](https://bugs.openjdk.org/browse/JDK-8286562): GCC 12 reports some compiler warnings (**Bug** - P4 - Approved)
 * [JDK-8293691](https://bugs.openjdk.org/browse/JDK-8293691): converting a defined BasicType value to a string should not crash the VM (**Bug** - P4 - Approved)
 * [JDK-8287491](https://bugs.openjdk.org/browse/JDK-8287491): compiler/jvmci/errors/TestInvalidDebugInfo.java fails new assert:  assert((uint)t &lt; T_CONFLICT + 1) failed: invalid type # (**Bug** - P2 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [a8651e65](https://git.openjdk.org/jdk11u-dev/pull/3091/files/a8651e6575a2c450eb3ef1a20fe8ccec59504e1e)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3091/head:pull/3091` \
`$ git checkout pull/3091`

Update a local copy of the PR: \
`$ git checkout pull/3091` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3091`

View PR using the GUI difftool: \
`$ git pr show -t 3091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3091.diff">https://git.openjdk.org/jdk11u-dev/pull/3091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3091#issuecomment-3275336995)
</details>
