### PR TITLE
8366359: Test should throw SkippedException when there is no lpstat

### DIFF
--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,21 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
-import javax.print.attribute.AttributeSet;
-import javax.print.attribute.HashAttributeSet;
-import javax.print.attribute.standard.PrinterName;
+import java.io.IOException;
+
+import jtreg.SkippedException;
 
 /*
  * @test
  * @bug 8032693
  * @key printer
+ * @library /test/lib/
+ * @requires (os.family == "linux")
  * @summary Test that lpstat and JDK agree whether there are printers.
  */
 public class CountPrintServices {
 
   public static void main(String[] args) throws Exception {
-    String os = System.getProperty("os.name").toLowerCase();
-    System.out.println("OS is " + os);
-    if (!os.equals("linux")) {
-        System.out.println("Linux specific test. No need to continue");
-        return;
-    }
     PrintService services[] =
         PrintServiceLookup.lookupPrintServices(null, null);
     if (services.length > 0) {
@@ -51,7 +47,16 @@ public class CountPrintServices {
        return;
     }
     String[] lpcmd = { "lpstat", "-a" };
-    Process proc = Runtime.getRuntime().exec(lpcmd);
+    Process proc;
+    try {
+        proc = Runtime.getRuntime().exec(lpcmd);
+    } catch (IOException e) {
+        if (e.getMessage().contains("No such file or directory")) {
+            throw new SkippedException("Cannot find lpstat");
+        } else {
+            throw e;
+        }
+    }
     proc.waitFor();
     InputStreamReader ir = new InputStreamReader(proc.getInputStream());
     BufferedReader br = new BufferedReader(ir);
@@ -66,4 +71,3 @@ public class CountPrintServices {
     }
  }
 }
-


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f23c1507](https://github.com/openjdk/jdk/commit/f23c150709fbd6d9b84261a7c99b67d7d08334b9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 30 Aug 2025 and was reviewed by Alexey Ivanov and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8366359](https://bugs.openjdk.org/browse/JDK-8366359) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366359](https://bugs.openjdk.org/browse/JDK-8366359): Test should throw SkippedException when there is no lpstat (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3093/head:pull/3093` \
`$ git checkout pull/3093`

Update a local copy of the PR: \
`$ git checkout pull/3093` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3093`

View PR using the GUI difftool: \
`$ git pr show -t 3093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3093.diff">https://git.openjdk.org/jdk11u-dev/pull/3093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3093#issuecomment-3278510633)
</details>
