### PR TITLE
Backport 900b3ff7ee933520efe2438fb7c841a4e6a93d17

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -50,6 +50,8 @@
 #include <process.h>
 #pragma warning(pop)
 
+#include <sysinfoapi.h>
+
 typedef unsigned __int32 juint;
 typedef unsigned __int64 julong;
 
@@ -215,10 +217,10 @@ static PdhLookupPerfNameByIndexFunc PdhLookupPerfNameByIndex_i;
  */
 typedef struct {
     HQUERY      query;
-    uint64_t    lastUpdate; // Last time query was updated (ticks)
+    uint64_t    lastUpdate; // Last time query was updated (millis)
 } UpdateQueryS, *UpdateQueryP;
 
-// Min time between query updates (ticks)
+// Min time between query updates (millis)
 static const int MIN_UPDATE_INTERVAL = 500;
 
 /*
@@ -993,7 +995,7 @@ bindPdhFunctionPointers(HMODULE h) {
  */
 static int
 getPerformanceData(UpdateQueryP query, HCOUNTER c, PDH_FMT_COUNTERVALUE* value, DWORD format) {
-    clock_t now = clock();
+    uint64_t now = GetTickCount64();
 
     /*
      * Need to limit how often we update the query


### PR DESCRIPTION
Hi,

It's a clean backport of JDK-8351359.
Changes are related to Windows only.

Testing:
- manual testing code that calls `getProcessCpuLoad()` on windows server 2025, intel cpu
- OpenJDK GHA Sanity Checks