### PR TITLE
8365098: make/RunTests.gmk generates a wrong path to test artifacts on Alpine

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -913,7 +913,7 @@ UseSpecialTestHandler = \
 # Now process each test to run and setup a proper make rule
 $(foreach test, $(TESTS_TO_RUN), \
   $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
+      $(SED) -E 's/[^0-9A-Za-z]/_/g' | $(TR) -s '_')) \
   $(eval ALL_TEST_IDS += $(TEST_ID)) \
   $(if $(call UseCustomTestHandler, $(test)), \
     $(eval $(call SetupRunCustomTest, $(TEST_ID), \
@@ -964,7 +964,7 @@ run-test: $(TARGETS)
 	    TEST TOTAL PASS FAIL ERROR " "
 	$(foreach test, $(TESTS_TO_RUN), \
 	  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-	      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
+	      $(SED) -E 's/[^0-9A-Za-z]/_/g' | $(TR) -s '_')) \
 	    $(ECHO) >> $(TEST_LAST_IDS) $(TEST_ID) $(NEWLINE) \
 	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '_')) \
 	  $(if $(filter __________________________________________________%, $(NAME_PATTERN)), \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -913,7 +913,7 @@ UseSpecialTestHandler = \
 # Now process each test to run and setup a proper make rule
 $(foreach test, $(TESTS_TO_RUN), \
   $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
   $(eval ALL_TEST_IDS += $(TEST_ID)) \
   $(if $(call UseCustomTestHandler, $(test)), \
     $(eval $(call SetupRunCustomTest, $(TEST_ID), \
@@ -964,9 +964,9 @@ run-test: $(TARGETS)
 	    TEST TOTAL PASS FAIL ERROR " "
 	$(foreach test, $(TESTS_TO_RUN), \
 	  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-	      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+	      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
 	    $(ECHO) >> $(TEST_LAST_IDS) $(TEST_ID) $(NEWLINE) \
-	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '[_*1000]')) \
+	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '_')) \
 	  $(if $(filter __________________________________________________%, $(NAME_PATTERN)), \
 	    $(eval TEST_NAME := ) \
 	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s\n" "  " "$(test)"  $(NEWLINE) \


### PR DESCRIPTION
This is backport of "[JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098) make/RunTests.gmk generates a wrong path to test artifacts on Alpine" as JDK11 tests have the same issue on Alpine - generate a wrong path to test artifacts.

However, there are still vendors which still build jdk11 and below for Solaris, so I added the cross platfrom fix here, using a combination of SED and TR.

So, the backport isn't clean. (Build system fix, test artifacts path processing.)

Tier1 successfully passes.


I'm not sure, if I may request for integration as  a backport, or should I create new JBS bug to cover this (starting from the upstream).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098) needs maintainer approval

### Issue
 * [JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098): make/RunTests.gmk generates a wrong path to test artifacts on Alpine (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3125/head:pull/3125` \
`$ git checkout pull/3125`

Update a local copy of the PR: \
`$ git checkout pull/3125` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3125`

View PR using the GUI difftool: \
`$ git pr show -t 3125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3125.diff">https://git.openjdk.org/jdk11u-dev/pull/3125.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3125#issuecomment-3562218848)
</details>
