### PR TITLE
8367348: Enhance PassFailJFrame to support links in HTML

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -67,6 +67,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.Timer;
+import javax.swing.event.HyperlinkListener;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
@@ -402,6 +403,7 @@ public final class PassFailJFrame {
         frame.add(createInstructionUIPanel(instructions,
                                            testTimeOut,
                                            rows, columns,
+                                           null,
                                            enableScreenCapture,
                                            false, 0),
                   BorderLayout.CENTER);
@@ -420,6 +422,7 @@ public final class PassFailJFrame {
                 createInstructionUIPanel(builder.instructions,
                                          builder.testTimeOut,
                                          builder.rows, builder.columns,
+                                         builder.hyperlinkListener,
                                          builder.screenCapture,
                                          builder.addLogArea,
                                          builder.logAreaRows);
@@ -441,6 +444,7 @@ public final class PassFailJFrame {
     private static JComponent createInstructionUIPanel(String instructions,
                                                        long testTimeOut,
                                                        int rows, int columns,
+                                                       HyperlinkListener hyperlinkListener,
                                                        boolean enableScreenCapture,
                                                        boolean addLogArea,
                                                        int logAreaRows) {
@@ -453,6 +457,9 @@ public final class PassFailJFrame {
         JTextComponent text = instructions.startsWith("<html>")
                               ? configureHTML(instructions, rows, columns)
                               : configurePlainText(instructions, rows, columns);
+        if (hyperlinkListener != null && text instanceof JEditorPane) {
+            ((JEditorPane) text).addHyperlinkListener(hyperlinkListener);
+        }
         text.setEditable(false);
 
         main.add(new JScrollPane(text), BorderLayout.CENTER);
@@ -517,7 +524,7 @@ public final class PassFailJFrame {
         // Reduce the default margins
         styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
         // Make the size of code blocks the same as other text
-        styles.addRule("code { font-size: inherit }");
+        styles.addRule("code { font-size: inherit; background: #DDD; }");
 
         return text;
     }
@@ -1111,6 +1118,7 @@ public final class PassFailJFrame {
         private int rows;
         private int columns;
         private boolean screenCapture;
+        private HyperlinkListener hyperlinkListener;
         private boolean addLogArea;
         private int logAreaRows = 10;
 
@@ -1146,6 +1154,18 @@ public final class PassFailJFrame {
 
         public Builder columns(int columns) {
             this.columns = columns;
+            return this;
+        }
+
+        /**
+         * Sets a {@link HyperlinkListener} for navigating links inside
+         * the instructions pane.
+         *
+         * @param hyperlinkListener the listener
+         * @return this builder
+         */
+        public Builder hyperlinkListener(HyperlinkListener hyperlinkListener) {
+            this.hyperlinkListener = hyperlinkListener;
             return this;
         }
 


### PR DESCRIPTION
Backport of [JDK-8367348](https://bugs.openjdk.org/browse/JDK-8367348) - Enhance PassFailJFrame to support links in HTML. Tests become more interactive if users can click links in the instructions and handle them with their own HyperlinkListener.

This backport is in follow up to the backport of [JDK-8213781](https://bugs.openjdk.org/browse/JDK-8213781) ([this PR](https://github.com/openjdk/jdk11u-dev/pull/3118)).

There are two differences compared to the corresponding [backport to jdk17](https://github.com/openjdk/jdk17u-dev/pull/4106/changes)
- [The change to comment block](https://github.com/openjdk/jdk17u-dev/commit/9e1a6bef2ac7f0c7615d153672a296847f09240a#diff-b1cbfd9042cb693b23dbead14bb6dfec13f738252c978551a983826453586410L101) was omitted because the comment block differ quite a bit between current jdk11 and jdk17 versions, hence it is not clear if and where this change should be integrated.
- [This if](https://github.com/openjdk/jdk17u-dev/commit/9e1a6bef2ac7f0c7615d153672a296847f09240a#diff-b1cbfd9042cb693b23dbead14bb6dfec13f738252c978551a983826453586410R651) uses pattern matching for `instanceof`, which is a feature that is not supported by jdk11, hence I edited this to be jdk11 compatible.
```java
// version in jdk17
if (hyperlinkListener != null && text instanceof JEditorPane ep) {
    ep.addHyperlinkListener(hyperlinkListener);
}

// version in this backport
if (hyperlinkListener != null && text instanceof JEditorPane) {
    ((JEditorPane) text).addHyperlinkListener(hyperlinkListener);
}
```

### Tests

Testing was done on Fedora 43.

#### Tier 1 - PASSES

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/hotspot/jtreg:tier1                     1497  1497     0     0
   jtreg:test/jdk:tier1                               1900  1900     0     0
   jtreg:test/langtools:tier1                         3940  3940     0     0
   jtreg:test/nashorn:tier1                              0     0     0     0
   jtreg:test/jaxp:tier1                                 0     0     0     0
==============================
TEST SUCCESS
```

#### GTest - PASSES

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   gtest:all/server                                    504   504     0     0
==============================
TEST SUCCESS
```

#### GHA - PASSES

`macos-x64 hs/tier1 serviceability` is failing, but this seems to be common over other unrelated PRs too -> not relevant to this backport.

#### Bonus tests - PASSES

I identified following interactive tests that are affected by this backport that seems to be behaving the same way before and after this backport:
- `test/jdk/java/awt/font/TextLayout/ArabicBox.java`
- `test/jdk/java/awt/font/TextLayout/TestJustification.java`
- `test/jdk/java/awt/Frame/ALTTABIconBeingErased/ALTTABIconBeingErased.java`
- `test/jdk/java/awt/Frame/DefaultSizeTest.java`
- `test/jdk/java/awt/Frame/GetBoundsResizeTest.java`
- `test/jdk/java/awt/geom/HitTest/PathHitTest.java`
- `test/jdk/java/awt/Icon/IconChangingTest/IconChangingTest.java`
- `test/jdk/java/awt/Icon/IconShowingTest/IconShowingTest.java`
- `test/jdk/java/awt/Icon/IconTransparencyTest/IconTransparencyTest.java`
- `test/jdk/java/awt/Icon/SetLargeIconTest/SetLargeIconTest.java`
- `test/jdk/java/awt/LightweightComponent/LightweightCliprect.java`
- `test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java`
- `test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java`
- `test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java`
- `test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java`
- `test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java`
- `test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java`
- `test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java`
- `test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java`
- `test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java`
- `test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java`
- `test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java`
- `test/jdk/javax/accessibility/TestJMenuItemShortcutAccessibility.java`
- `test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java`
- `test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java`
- `test/jdk/javax/swing/JFrame/bug4419914.java`
- `test/jdk/javax/swing/JFrame/DefaultCloseOperation.java`
- `test/jdk/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java`
- `test/jdk/javax/swing/JRadioButton/bug4380543.java`
- `test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java`
- `test/jdk/javax/swing/JToolBar/bug4203039.java`
- `test/jdk/javax/swing/MultiMonitor/MultimonVImage.java`
- `test/jdk/javax/swing/ProgressMonitor/ProgressTest.java`
- `test/jdk/javax/swing/text/bug4148489.java`
- `test/jdk/javax/swing/text/html/StyleSheet/bug4803145.java`
- `test/jdk/javax/swing/text/PaintTest.java`
- `test/jdk/sun/awt/PaletteTester.java`

--- 

### Bonus info

This PR may not be the best place to mention this, but since I have no idea where other place to bring this up:

While trying to run the interactive tests mentioned above I find out that few of them are unable to compile, since they make use of `"""` for string block, which is a feature that is not supported by jdk11. The tests that this applies to:
- `GetBoundsResizeTest.java`
- `AddRemoveMenuBarTest_1.java`
- `AddRemoveMenuBarTest_2.java`
- `AddRemoveMenuBarTest_3.java`
- `AddRemoveMenuBarTest_4.java`

Out of curiosity I searched the jdk11 repo and found one more test that also uses `"""`:
- `test/jdk/sun/awt/PaletteTester.java`

Looking into other tests from above that also failed:
- `JComboBoxBorderTest.java` -> seems to be macos specific test that is being executed on Linux too, because it misses corresponding annotation to be run only on mac.
- `TestJustification.java` also seems to be failing on Linux, but in `test/jdk/ProblemList.txt` it is mention only as mac specific.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] [JDK-8367348](https://bugs.openjdk.org/browse/JDK-8367348) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8367348](https://bugs.openjdk.org/browse/JDK-8367348): Enhance PassFailJFrame to support links in HTML (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3147/head:pull/3147` \
`$ git checkout pull/3147`

Update a local copy of the PR: \
`$ git checkout pull/3147` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3147`

View PR using the GUI difftool: \
`$ git pr show -t 3147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3147.diff">https://git.openjdk.org/jdk11u-dev/pull/3147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3147#issuecomment-3870124413)
</details>
