### PR TITLE
8271566: DSA signature length value is not accurate in P11Signature

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -116,7 +116,7 @@ abstract class P11Key implements Key, Length {
     }
 
     P11Key(String type, Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
+            int keyLength, CK_ATTRIBUTE[] attrs) {
         this.type = type;
         this.token = session.token;
         this.algorithm = algorithm;
@@ -124,15 +124,15 @@ abstract class P11Key implements Key, Length {
         boolean tokenObject = false;
         boolean sensitive = false;
         boolean extractable = true;
-        int n = (attributes == null) ? 0 : attributes.length;
-        for (int i = 0; i < n; i++) {
-            CK_ATTRIBUTE attr = attributes[i];
-            if (attr.type == CKA_TOKEN) {
-                tokenObject = attr.getBoolean();
-            } else if (attr.type == CKA_SENSITIVE) {
-                sensitive = attr.getBoolean();
-            } else if (attr.type == CKA_EXTRACTABLE) {
-                extractable = attr.getBoolean();
+        if (attrs != null) {
+            for (CK_ATTRIBUTE attr : attrs) {
+                if (attr.type == CKA_TOKEN) {
+                    tokenObject = attr.getBoolean();
+                } else if (attr.type == CKA_SENSITIVE) {
+                    sensitive = attr.getBoolean();
+                } else if (attr.type == CKA_EXTRACTABLE) {
+                    extractable = attr.getBoolean();
+                }
             }
         }
         this.tokenObject = tokenObject;
@@ -249,7 +249,7 @@ abstract class P11Key implements Key, Length {
     public String toString() {
         token.ensureValid();
         String s1 = token.provider.getName() + " " + algorithm + " " + type
-                + " key, " + keyLength + " bits";
+                + " key, " + keyLength + " bits ";
         s1 += (tokenObject ? "token" : "session") + " object";
         if (isPublic()) {
             s1 += ")";
@@ -280,19 +280,31 @@ abstract class P11Key implements Key, Length {
         return type == SECRET;
     }
 
-    void fetchAttributes(CK_ATTRIBUTE[] attributes) {
+    CK_ATTRIBUTE[] fetchAttributes(CK_ATTRIBUTE[] attrs) {
+        Objects.requireNonNull(attrs, "attrs must be non-null");
         Session tempSession = null;
         long keyID = this.getKeyID();
         try {
             tempSession = token.getOpSession();
             token.p11.C_GetAttributeValue(tempSession.id(), keyID,
-                        attributes);
+                    attrs);
         } catch (PKCS11Exception e) {
             throw new ProviderException(e);
         } finally {
             this.releaseKeyID();
             token.releaseSession(tempSession);
         }
+        return attrs;
+    }
+
+    // convenience method which returns the attribute values as BigInteger[]
+    BigInteger[] fetchAttributesAsInts(CK_ATTRIBUTE[] attrs) {
+        attrs = fetchAttributes(attrs);
+        BigInteger[] res = new BigInteger[attrs.length];
+        for (int i = 0; i < attrs.length; i++) {
+            res[i] = attrs[i].getBigInteger();
+        }
+        return res;
     }
 
     private final static CK_ATTRIBUTE[] A0 = new CK_ATTRIBUTE[0];
@@ -331,44 +343,43 @@ abstract class P11Key implements Key, Length {
     }
 
     static SecretKey secretKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+            int keyLength, CK_ATTRIBUTE[] attrs) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        return new P11SecretKey(session, keyID, algorithm, keyLength,
-                attributes);
+        return new P11SecretKey(session, keyID, algorithm, keyLength, attrs);
     }
 
-    static SecretKey masterSecretKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes, int major, int minor) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+    static SecretKey masterSecretKey(Session session, long keyID,
+            String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+            int major, int minor) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        return new P11TlsMasterSecretKey(
-                session, keyID, algorithm, keyLength, attributes, major,
-                minor);
+        return new P11TlsMasterSecretKey(session, keyID, algorithm, keyLength,
+                attrs, major, minor);
     }
 
     // we assume that all components of public keys are always accessible
     static PublicKey publicKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
+            int keyLength, CK_ATTRIBUTE[] attrs) {
         switch (algorithm) {
             case "RSA":
                 return new P11RSAPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "DSA":
                 return new P11DSAPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "DH":
                 return new P11DHPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "EC":
                 return new P11ECPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             default:
                 throw new ProviderException
                     ("Unknown public key algorithm " + algorithm);
@@ -376,73 +387,45 @@ abstract class P11Key implements Key, Length {
     }
 
     static PrivateKey privateKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+            int keyLength, CK_ATTRIBUTE[] attrs) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
-            return new P11PrivateKey
-                (session, keyID, algorithm, keyLength, attributes);
-        } else {
-            switch (algorithm) {
-                case "RSA":
-                    // In order to decide if this is RSA CRT key, we first query
-                    // and see if all extra CRT attributes are available.
-                    CK_ATTRIBUTE[] attrs2 = new CK_ATTRIBUTE[] {
-                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PRIME_1),
-                        new CK_ATTRIBUTE(CKA_PRIME_2),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
-                    };
-                    boolean crtKey;
-                    try {
-                        session.token.p11.C_GetAttributeValue
-                            (session.id(), keyID, attrs2);
-                        crtKey = ((attrs2[0].pValue instanceof byte[]) &&
-                                  (attrs2[1].pValue instanceof byte[]) &&
-                                  (attrs2[2].pValue instanceof byte[]) &&
-                                  (attrs2[3].pValue instanceof byte[]) &&
-                                  (attrs2[4].pValue instanceof byte[]) &&
-                                  (attrs2[5].pValue instanceof byte[])) ;
-                    } catch (PKCS11Exception e) {
-                        // ignore, assume not available
-                        crtKey = false;
-                    }
-                    if (crtKey) {
-                        return new P11RSAPrivateKey(session, keyID, algorithm,
-                                keyLength, attributes, attrs2);
-                    } else {
-                        return new P11RSAPrivateNonCRTKey(session, keyID,
-                                algorithm, keyLength, attributes);
-                    }
-                case "DSA":
-                    return new P11DSAPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                case "DH":
-                    return new P11DHPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                case "EC":
-                    return new P11ECPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                default:
-                    throw new ProviderException
-                            ("Unknown private key algorithm " + algorithm);
-            }
+
+        boolean keySensitive = (attrs[0].getBoolean() ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean());
+
+        switch (algorithm) {
+        case "RSA":
+            return P11RSAPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "DSA":
+            return P11DSAPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "DH":
+            return P11DHPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "EC":
+            return P11ECPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        default:
+            throw new ProviderException
+                    ("Unknown private key algorithm " + algorithm);
         }
     }
 
-    // class for sensitive and unextractable private keys
-    private static final class P11PrivateKey extends P11Key
-                                                implements PrivateKey {
+    // base class for all PKCS11 private keys
+    private static abstract class P11PrivateKey extends P11Key implements
+            PrivateKey {
         private static final long serialVersionUID = -2138581185214187615L;
 
+        protected byte[] encoded; // guard by synchronized
+
         P11PrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(PRIVATE, session, keyID, algorithm, keyLength, attrs);
         }
         // XXX temporary encoding for serialization purposes
         public String getFormat() {
@@ -457,11 +440,14 @@ abstract class P11Key implements Key, Length {
 
     private static class P11SecretKey extends P11Key implements SecretKey {
         private static final long serialVersionUID = -7828241727014329084L;
-        private volatile byte[] encoded;
+
+        private volatile byte[] encoded; // guard by double-checked locking
+
         P11SecretKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(SECRET, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(SECRET, session, keyID, algorithm, keyLength, attrs);
         }
+
         public String getFormat() {
             token.ensureValid();
             if (sensitive || !extractable || (isNSS && tokenObject)) {
@@ -470,37 +456,39 @@ abstract class P11Key implements Key, Length {
                 return "RAW";
             }
         }
+
         byte[] getEncodedInternal() {
             token.ensureValid();
             if (getFormat() == null) {
                 return null;
             }
+
             byte[] b = encoded;
             if (b == null) {
                 synchronized (this) {
                     b = encoded;
                     if (b == null) {
-                        Session tempSession = null;
-                        long keyID = this.getKeyID();
-                        try {
-                            tempSession = token.getOpSession();
-                            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+                        b = fetchAttributes(new CK_ATTRIBUTE[] {
                                 new CK_ATTRIBUTE(CKA_VALUE),
-                            };
-                            token.p11.C_GetAttributeValue
-                                    (tempSession.id(), keyID, attributes);
-                            b = attributes[0].getByteArray();
-                        } catch (PKCS11Exception e) {
-                            throw new ProviderException(e);
-                        } finally {
-                            this.releaseKeyID();
-                            token.releaseSession(tempSession);
-                        }
+                        })[0].getByteArray();
                         encoded = b;
                     }
                 }
             }
             return b;
+        }
+    }
+
+    // base class for all PKCS11 public keys
+    private static abstract class P11PublicKey extends P11Key implements
+            PublicKey {
+        private static final long serialVersionUID = 1L;
+
+        protected byte[] encoded; // guard by synchronized
+
+        P11PublicKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(PUBLIC, session, keyID, algorithm, keyLength, attrs);
         }
     }
 
@@ -511,8 +499,8 @@ abstract class P11Key implements Key, Length {
 
         private final int majorVersion, minorVersion;
         P11TlsMasterSecretKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes, int major, int minor) {
-            super(session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs, int major, int minor) {
+            super(session, keyID, algorithm, keyLength, attrs);
             this.majorVersion = major;
             this.minorVersion = minor;
         }
@@ -525,17 +513,92 @@ abstract class P11Key implements Key, Length {
         }
     }
 
+    // impl class for sensitive/unextractable RSA private keys
+    static class P11RSAPrivateKeyInternal extends P11PrivateKey {
+        private static final long serialVersionUID = -2138581185214187615L;
+
+        static P11RSAPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11RSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                CK_ATTRIBUTE[] rsaAttrs = new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_MODULUS),
+                        new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
+                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
+                        new CK_ATTRIBUTE(CKA_PRIME_1),
+                        new CK_ATTRIBUTE(CKA_PRIME_2),
+                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
+                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
+                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
+                };
+                boolean isCRT = true;
+                Session tempSession = null;
+                try {
+                    tempSession = session.token.getOpSession();
+                    session.token.p11.C_GetAttributeValue(tempSession.id(),
+                            keyID, rsaAttrs);
+                    for (CK_ATTRIBUTE attr : rsaAttrs) {
+                        isCRT &= (attr.pValue instanceof byte[]);
+                        if (!isCRT) break;
+                    }
+                } catch (PKCS11Exception e) {
+                    // ignore, assume not available
+                    isCRT = false;
+                } finally {
+                    session.token.releaseSession(tempSession);
+                }
+                BigInteger n = rsaAttrs[0].getBigInteger();
+                BigInteger d = rsaAttrs[1].getBigInteger();
+                if (isCRT) {
+                    return new P11RSAPrivateKey(session, keyID, algorithm,
+                           keyLength, attrs, n, d,
+                           Arrays.copyOfRange(rsaAttrs, 2, rsaAttrs.length));
+                } else {
+                    return new P11RSAPrivateNonCRTKey(session, keyID,
+                           algorithm, keyLength, attrs, n, d);
+                }
+            }
+        }
+
+        protected transient BigInteger n;
+
+        private P11RSAPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (n != null) return;
+
+            n = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_MODULUS)
+            })[0];
+        }
+
+        public BigInteger getModulus() {
+            fetchValues();
+            return n;
+        }
+    }
+
     // RSA CRT private key
-    private static final class P11RSAPrivateKey extends P11Key
-                implements RSAPrivateCrtKey {
+    private static final class P11RSAPrivateKey extends P11RSAPrivateKeyInternal
+            implements RSAPrivateCrtKey {
         private static final long serialVersionUID = 9215872438913515220L;
 
-        private BigInteger n, e, d, p, q, pe, qe, coeff;
-        private byte[] encoded;
-        P11RSAPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attrs, CK_ATTRIBUTE[] crtAttrs) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attrs);
+        private transient BigInteger e, d, p, q, pe, qe, coeff;
 
+        private P11RSAPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs, BigInteger n, BigInteger d,
+                CK_ATTRIBUTE[] crtAttrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+
+            this.n = n;
+            this.d = d;
             for (CK_ATTRIBUTE a : crtAttrs) {
                 if (a.type == CKA_PUBLIC_EXPONENT) {
                     e = a.getBigInteger();
@@ -552,28 +615,15 @@ abstract class P11Key implements Key, Length {
                 }
             }
         }
-        private synchronized void fetchValues() {
-            token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            d = attributes[1].getBigInteger();
-        }
 
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
                     Key newKey = RSAPrivateCrtKeyImpl.newKey
                         (KeyType.RSA, null, n, e, d, p, q, pe, qe, coeff);
@@ -584,15 +634,15 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
+        @Override
         public BigInteger getModulus() {
-            fetchValues();
             return n;
         }
         public BigInteger getPublicExponent() {
             return e;
         }
         public BigInteger getPrivateExponent() {
-            fetchValues();
             return d;
         }
         public BigInteger getPrimeP() {
@@ -613,37 +663,28 @@ abstract class P11Key implements Key, Length {
     }
 
     // RSA non-CRT private key
-    private static final class P11RSAPrivateNonCRTKey extends P11Key
-                implements RSAPrivateKey {
+    private static final class P11RSAPrivateNonCRTKey extends
+            P11RSAPrivateKeyInternal implements RSAPrivateKey {
         private static final long serialVersionUID = 1137764983777411481L;
 
-        private BigInteger n, d;
-        private byte[] encoded;
+        private transient BigInteger d;
+
         P11RSAPrivateNonCRTKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs, BigInteger n,
+                BigInteger d) {
+            super(session, keyID, algorithm, keyLength, attrs);
+            this.n = n;
+            this.d = d;
         }
-        private synchronized void fetchValues() {
-            token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            d = attributes[1].getBigInteger();
-        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
                     // XXX make constructor in SunRsaSign provider public
                     // and call it directly
@@ -657,42 +698,43 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
+        @Override
         public BigInteger getModulus() {
-            fetchValues();
             return n;
         }
         public BigInteger getPrivateExponent() {
-            fetchValues();
             return d;
         }
     }
 
-    private static final class P11RSAPublicKey extends P11Key
+    private static final class P11RSAPublicKey extends P11PublicKey
                                                 implements RSAPublicKey {
         private static final long serialVersionUID = -826726289023854455L;
-        private BigInteger n, e;
-        private byte[] encoded;
+        private transient BigInteger n, e;
+
         P11RSAPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (n != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            e = attributes[1].getBigInteger();
+                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT)
+            });
+            n = res[0];
+            e = res[1];
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -706,6 +748,7 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getModulus() {
             fetchValues();
             return n;
@@ -721,40 +764,37 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DSAPublicKey extends P11Key
+    private static final class P11DSAPublicKey extends P11PublicKey
                                                 implements DSAPublicKey {
         private static final long serialVersionUID = 5989753793316396637L;
 
-        private BigInteger y;
-        private DSAParams params;
-        private byte[] encoded;
+        private transient BigInteger y;
+        private transient DSAParams params;
+
         P11DSAPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (y != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (y != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
                 new CK_ATTRIBUTE(CKA_PRIME),
                 new CK_ATTRIBUTE(CKA_SUBPRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            y = attributes[0].getBigInteger();
-            params = new DSAParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger(),
-                attributes[3].getBigInteger()
-            );
+                new CK_ATTRIBUTE(CKA_BASE)
+            });
+            y = res[0];
+            params = new DSAParameterSpec(res[1], res[2], res[3]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -784,40 +824,76 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DSAPrivateKey extends P11Key
-                                                implements DSAPrivateKey {
+    static class P11DSAPrivateKeyInternal extends P11PrivateKey {
         private static final long serialVersionUID = 3119629997181999389L;
 
-        private BigInteger x;
-        private DSAParams params;
-        private byte[] encoded;
-        P11DSAPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+        protected transient DSAParams params;
+
+        static P11DSAPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11DSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11DSAPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
         }
+
+        private P11DSAPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (x != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_SUBPRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            x = attributes[0].getBigInteger();
-            params = new DSAParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger(),
-                attributes[3].getBigInteger()
-            );
+            if (params != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_SUBPRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            params = new DSAParameterSpec(res[0], res[1], res[2]);
         }
+
+        protected DSAParams getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11DSAPrivateKey extends P11DSAPrivateKeyInternal
+                                        implements DSAPrivateKey {
+        private static final long serialVersionUID = 3119629997181999389L;
+
+        private transient BigInteger x; // params inside P11DSAPrivateKeyInternal
+
+        P11DSAPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (x != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_SUBPRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            x = res[0];
+            params = new DSAParameterSpec(res[1], res[2], res[3]);
+        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -832,48 +908,87 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getX() {
             fetchValues();
             return x;
         }
+
+        @Override
         public DSAParams getParams() {
             fetchValues();
             return params;
         }
     }
 
-    private static final class P11DHPrivateKey extends P11Key
+    static class P11DHPrivateKeyInternal extends P11PrivateKey {
+        private static final long serialVersionUID = 1L;
+
+        protected transient DHParameterSpec params;
+
+        static P11DHPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11DHPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11DHPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
+        }
+
+        private P11DHPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (params != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            params = new DHParameterSpec(res[0], res[1]);
+        }
+
+        public DHParameterSpec getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11DHPrivateKey extends P11DHPrivateKeyInternal
                                                 implements DHPrivateKey {
         private static final long serialVersionUID = -1698576167364928838L;
 
-        private BigInteger x;
-        private DHParameterSpec params;
-        private byte[] encoded;
+        private transient BigInteger x; // params in P11DHPrivateKeyInternal
+
         P11DHPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (x != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            x = attributes[0].getBigInteger();
-            params = new DHParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger()
-            );
+            if (x != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            x = res[0];
+            params = new DHParameterSpec(res[1], res[2]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -900,10 +1015,10 @@ abstract class P11Key implements Key, Length {
             return params;
         }
         public int hashCode() {
+            fetchValues();
             if (!token.isValid()) {
                 return 0;
             }
-            fetchValues();
             return Objects.hash(x, params.getP(), params.getG());
         }
         public boolean equals(Object obj) {
@@ -924,38 +1039,36 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DHPublicKey extends P11Key
+    private static final class P11DHPublicKey extends P11PublicKey
                                                 implements DHPublicKey {
         static final long serialVersionUID = -598383872153843657L;
 
-        private BigInteger y;
-        private DHParameterSpec params;
-        private byte[] encoded;
+        private transient BigInteger y;
+        private transient DHParameterSpec params;
+
         P11DHPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (y != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            y = attributes[0].getBigInteger();
-            params = new DHParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger()
-            );
+            if (y != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            y = res[0];
+            params = new DHParameterSpec(res[1], res[2]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -1011,44 +1124,88 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11ECPrivateKey extends P11Key
-                                                implements ECPrivateKey {
-        private static final long serialVersionUID = -7786054399510515515L;
+    static class P11ECPrivateKeyInternal extends P11PrivateKey {
 
-        private BigInteger s;
-        private ECParameterSpec params;
-        private byte[] encoded;
-        P11ECPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+        private static final long serialVersionUID = 1L;
+
+        protected transient ECParameterSpec params;
+
+        static P11ECPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11ECPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11ECPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
         }
+
+        private P11ECPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (s != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_EC_PARAMS, params),
-            };
-            fetchAttributes(attributes);
-            s = attributes[0].getBigInteger();
+            if (params != null) return;
+
             try {
-                params = P11ECKeyFactory.decodeParameters
-                            (attributes[1].getByteArray());
+                byte[] paramBytes = fetchAttributes(new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_EC_PARAMS)
+                })[0].getByteArray();
+
+                params = P11ECKeyFactory.decodeParameters(paramBytes);
             } catch (Exception e) {
                 throw new RuntimeException("Could not parse key values", e);
             }
         }
+
+        protected ECParameterSpec getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11ECPrivateKey extends P11ECPrivateKeyInternal
+                                                implements ECPrivateKey {
+        private static final long serialVersionUID = -7786054399510515515L;
+
+        private transient BigInteger s; // params in P11ECPrivateKeyInternal
+
+        P11ECPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (s != null) return;
+
+            CK_ATTRIBUTE[] attrs = fetchAttributes(new CK_ATTRIBUTE[] {
+                new CK_ATTRIBUTE(CKA_VALUE),
+                new CK_ATTRIBUTE(CKA_EC_PARAMS),
+            });
+
+            s = attrs[0].getBigInteger();
+            try {
+                params = P11ECKeyFactory.decodeParameters
+                            (attrs[1].getByteArray());
+            } catch (Exception e) {
+                throw new RuntimeException("Could not parse key values", e);
+            }
+        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
-            token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
+                    fetchValues();
                     Key key = ECUtil.generateECPrivateKey(s, params);
                     encoded = key.getEncoded();
                 } catch (InvalidKeySpecException e) {
@@ -1057,42 +1214,43 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getS() {
             fetchValues();
             return s;
         }
+
         public ECParameterSpec getParams() {
             fetchValues();
             return params;
         }
     }
 
-    private static final class P11ECPublicKey extends P11Key
+    private static final class P11ECPublicKey extends P11PublicKey
                                                 implements ECPublicKey {
         private static final long serialVersionUID = -6371481375154806089L;
 
-        private ECPoint w;
-        private ECParameterSpec params;
-        private byte[] encoded;
+        private transient ECPoint w;
+        private transient ECParameterSpec params;
+
         P11ECPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (w != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (w != null) return;
+
+            CK_ATTRIBUTE[] attrs = fetchAttributes(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_EC_POINT),
                 new CK_ATTRIBUTE(CKA_EC_PARAMS),
-            };
-            fetchAttributes(attributes);
+            });
 
             try {
                 params = P11ECKeyFactory.decodeParameters
-                            (attributes[1].getByteArray());
-                byte[] ecKey = attributes[0].getByteArray();
+                            (attrs[1].getByteArray());
+                byte[] ecKey = attrs[0].getByteArray();
 
                 // Check whether the X9.63 encoding of an EC point is wrapped
                 // in an ASN.1 OCTET STRING
@@ -1114,10 +1272,12 @@ abstract class P11Key implements Key, Length {
                 throw new RuntimeException("Could not parse key values", e);
             }
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -1416,3 +1576,4 @@ final class SessionKeyRef extends PhantomReference<P11Key> {
         this.clear();
     }
 }
+

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -108,6 +108,9 @@ final class P11Signature extends SignatureSpi {
     // key instance used, if init*() was called
     private P11Key p11Key;
 
+    // signature length expected or 0 for unknown
+    private int sigLen;
+
     // message digest, if we do the digesting ourselves
     private final MessageDigest md;
 
@@ -292,7 +295,7 @@ final class P11Signature extends SignatureSpi {
         try {
             if (mode == M_SIGN) {
                 if (type == T_UPDATE) {
-                    token.p11.C_SignFinal(session.id(), 0);
+                    token.p11.C_SignFinal(session.id(), sigLen);
                 } else {
                     byte[] digest;
                     if (type == T_DIGEST) {
@@ -303,12 +306,7 @@ final class P11Signature extends SignatureSpi {
                     token.p11.C_Sign(session.id(), digest);
                 }
             } else { // M_VERIFY
-                byte[] signature;
-                if (keyAlgorithm.equals("DSA")) {
-                    signature = new byte[40];
-                } else {
-                    signature = new byte[(p11Key.length() + 7) >> 3];
-                }
+                byte[] signature = new byte[sigLen];
                 if (type == T_UPDATE) {
                     token.p11.C_VerifyFinal(session.id(), signature);
                 } else {
@@ -378,6 +376,15 @@ final class P11Signature extends SignatureSpi {
             bytesProcessed = 0;
             if (md != null) {
                 md.reset();
+            }
+        }
+        sigLen = 0;
+        if ("DSA".equals(p11Key.getAlgorithm())) {
+            if (p11Key instanceof P11Key.P11DSAPrivateKeyInternal) {
+                sigLen = ((P11Key.P11DSAPrivateKeyInternal)p11Key).getParams()
+                        .getQ().bitLength() >> 2;
+            } else if (p11Key instanceof DSAKey) {
+                sigLen = ((DSAKey)p11Key).getParams().getQ().bitLength() >> 2;
             }
         }
         initialized = true;
@@ -631,8 +638,7 @@ final class P11Signature extends SignatureSpi {
         try {
             byte[] signature;
             if (type == T_UPDATE) {
-                int len = keyAlgorithm.equals("DSA") ? 40 : 0;
-                signature = token.p11.C_SignFinal(session.id(), len);
+                signature = token.p11.C_SignFinal(session.id(), sigLen);
             } else {
                 byte[] digest;
                 if (type == T_DIGEST) {
@@ -699,7 +705,7 @@ final class P11Signature extends SignatureSpi {
         try {
             if (!p1363Format) {
                 if (keyAlgorithm.equals("DSA")) {
-                    signature = asn1ToDSA(signature);
+                    signature = asn1ToDSA(signature, sigLen);
                 } else if (keyAlgorithm.equals("EC")) {
                     signature = asn1ToECDSA(signature);
                 }
@@ -809,7 +815,8 @@ final class P11Signature extends SignatureSpi {
         }
     }
 
-    private static byte[] asn1ToDSA(byte[] sig) throws SignatureException {
+    private static byte[] asn1ToDSA(byte[] sig, int sigLen)
+            throws SignatureException {
         try {
             // Enforce strict DER checking for signatures
             DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
@@ -824,8 +831,8 @@ final class P11Signature extends SignatureSpi {
             BigInteger r = values[0].getPositiveBigInteger();
             BigInteger s = values[1].getPositiveBigInteger();
 
-            byte[] br = toByteArray(r, 20);
-            byte[] bs = toByteArray(s, 20);
+            byte[] br = toByteArray(r, sigLen/2);
+            byte[] bs = toByteArray(s, sigLen/2);
             if ((br == null) || (bs == null)) {
                 throw new SignatureException("Out of range value for R or S");
             }
@@ -837,7 +844,7 @@ final class P11Signature extends SignatureSpi {
         }
     }
 
-    private byte[] asn1ToECDSA(byte[] sig) throws SignatureException {
+    private static byte[] asn1ToECDSA(byte[] sig) throws SignatureException {
         try {
             // Enforce strict DER checking for signatures
             DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
@@ -917,3 +924,4 @@ final class P11Signature extends SignatureSpi {
         return null;
     }
 }
+

--- a/test/jdk/sun/security/pkcs11/Signature/LargeDSAKey.java
+++ b/test/jdk/sun/security/pkcs11/Signature/LargeDSAKey.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.AlgorithmParameterGenerator;
+import java.security.AlgorithmParameters;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.spec.DSAGenParameterSpec;
+import java.security.spec.DSAParameterSpec;
+
+/*
+ * @test
+ * @bug 8271566
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @run main/othervm/timeout=30 LargeDSAKey
+ */
+
+public final class LargeDSAKey extends PKCS11Test {
+
+    private static final boolean enableDebug = false;
+
+    private static final String knownText =
+            "Known text known text known text";
+
+    @Override
+    public void main(Provider p) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA", p);
+        AlgorithmParameterGenerator dsaParGen =
+                AlgorithmParameterGenerator.getInstance("DSA");
+        DSAGenParameterSpec dsaParGenSpec =
+                new DSAGenParameterSpec(2048, 256);
+        dsaParGen.init(dsaParGenSpec, new SecureRandom());
+        AlgorithmParameters params = dsaParGen.generateParameters();
+        DSAParameterSpec dsaParams =
+                params.getParameterSpec(DSAParameterSpec.class);
+        kpg.initialize(dsaParams);
+        KeyPair kp = kpg.generateKeyPair();
+        doTestSignature(kp, p);
+    }
+
+    private static void doTestSignature(KeyPair kp, Provider p)
+            throws Exception {
+        byte[] knownTextSig = null;
+        Signature s = Signature.getInstance("SHA1withDSA", p);
+        PrivateKey privKey = kp.getPrivate();
+        PublicKey pubKey = kp.getPublic();
+        if (enableDebug) {
+            System.out.println("Signature algorithm: " + s.getAlgorithm());
+            System.out.println("Signature Provider: " + s.getProvider());
+            System.out.println("Private key for signature: " + privKey);
+            System.out.println("Public key for signature: " + pubKey);
+        }
+        s.initSign(privKey);
+        s.update(knownText.getBytes());
+        knownTextSig = s.sign();
+        s.initVerify(pubKey);
+        s.update(knownText.getBytes());
+        if (s.verify(knownTextSig) == false) {
+            throw new Exception("Could not verify signature");
+        }
+        if (enableDebug) {
+            System.out.println("Signature verified");
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        main(new LargeDSAKey());
+        System.out.println("TEST PASS - OK");
+    }
+
+}


### PR DESCRIPTION
Backport to fix failure we are seeing in some of our tests for jdk11 in FIPS mode (using sunpkcs11 provider):
```
java.security.ProviderException: cancel failed
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Signature.cancelOperation(P11Signature.java:332)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Signature.reset(P11Signature.java:272)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Signature.engineVerify(P11Signature.java:755)
	at java.base/java.security.Signature$Delegate.engineVerify(Signature.java:1416)
	at java.base/java.security.Signature.verify(Signature.java:790)
...
Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_ARGUMENTS_BAD
	at jdk.crypto.cryptoki/sun.security.pkcs11.wrapper.PKCS11.C_VerifyFinal(Native Method)
	at jdk.crypto.cryptoki/sun.security.pkcs11.P11Signature.cancelOperation(P11Signature.java:305)
	... 14 more
```

Backport only affects PKCS11 provider. Not clean because [JDK-8242332](https://bugs.openjdk.org/browse/JDK-8242332) (missing in jdk11), made small changes (in-between) to  `engineSign` and `cancelOperation` methods in `P11Signature` class in regards to DSA, which were then completely overwritten by this change set (so not an actual dependency).

Testing:
Fixes issue higher.
GHA: **OK**
pkcs11 tests (test/jdk/sun/security/pkcs11): **OK**
[ssl-tests](https://github.com/rh-openjdk/ssl-tests) with `TEST_PKCS11_FIPS=1`: **OK**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8271566](https://bugs.openjdk.org/browse/JDK-8271566) needs maintainer approval

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8271566](https://bugs.openjdk.org/browse/JDK-8271566): DSA signature length value is not accurate in P11Signature (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3166/head:pull/3166` \
`$ git checkout pull/3166`

Update a local copy of the PR: \
`$ git checkout pull/3166` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3166`

View PR using the GUI difftool: \
`$ git pr show -t 3166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3166.diff">https://git.openjdk.org/jdk11u-dev/pull/3166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3166#issuecomment-3997735720)
</details>
