### PR TITLE
8343622: AesDkCrypto.stringToKey should not return null

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/MD4.java
+++ b/src/java.base/share/classes/sun/security/provider/MD4.java
@@ -79,13 +79,8 @@ public final class MD4 extends DigestBase {
         });
     }
 
-    public static MessageDigest getInstance() {
-        try {
-            return MessageDigest.getInstance("MD4", md4Provider);
-        } catch (NoSuchAlgorithmException e) {
-            // should never occur
-            throw new ProviderException(e);
-        }
+    public static MessageDigest getInstance() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD4", md4Provider);
     }
 
     // Standard constructor, creates a new MD4 instance.

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyImpl.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyImpl.java
@@ -95,7 +95,7 @@ class KeyImpl implements SecretKey, Destroyable, Serializable {
             this.keyBytes = key.getBytes();
             this.keyType = key.getEType();
         } catch (KrbException e) {
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException("key creation error", e);
         }
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/AesDkCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/AesDkCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import sun.security.krb5.KrbCryptoException;
 import sun.security.krb5.Confounder;
 import sun.security.krb5.internal.crypto.KeyUsage;
 import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This class provides the implementation of AES Encryption for Kerberos
@@ -104,10 +106,8 @@ public class AesDkCrypto extends DkCrypto {
 
         byte[] saltUtf8 = null;
         try {
-            saltUtf8 = salt.getBytes("UTF-8");
+            saltUtf8 = salt.getBytes(UTF_8);
             return stringToKey(password, saltUtf8, s2kparams);
-        } catch (Exception e) {
-            return null;
         } finally {
             if (saltUtf8 != null) {
                 Arrays.fill(saltUtf8, (byte)0);

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/AesSha2DkCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/AesSha2DkCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ import sun.security.krb5.KrbCryptoException;
 import sun.security.krb5.Confounder;
 import sun.security.krb5.internal.crypto.KeyUsage;
 import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This class provides the implementation of AES Encryption with
@@ -107,10 +109,8 @@ public class AesSha2DkCrypto extends DkCrypto {
 
         byte[] saltUtf8 = null;
         try {
-            saltUtf8 = salt.getBytes("UTF-8");
+            saltUtf8 = salt.getBytes(UTF_8);
             return stringToKey(password, saltUtf8, s2kparams);
-        } catch (Exception e) {
-            return null;
         } finally {
             if (saltUtf8 != null) {
                 Arrays.fill(saltUtf8, (byte)0);

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
@@ -90,8 +90,6 @@ public class ArcFourCrypto extends DkCrypto {
             MessageDigest md = sun.security.provider.MD4.getInstance();
             md.update(passwd);
             digest = md.digest();
-        } catch (Exception e) {
-            return null;
         } finally {
             if (passwd != null) {
                 Arrays.fill(passwd, (byte)0);

--- a/test/jdk/sun/security/krb5/NullStringToKey.java
+++ b/test/jdk/sun/security/krb5/NullStringToKey.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8343622
+ * @summary KerberosKey created with null key bytes
+ * @library /test/lib
+ * @run main/othervm NullStringToKey
+ */
+
+import jdk.test.lib.Utils;
+
+import javax.security.auth.kerberos.KerberosKey;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import java.security.Security;
+import java.util.List;
+
+public class NullStringToKey {
+    public static void main(String[] args) throws Exception {
+
+        Security.removeProvider("SUN");
+        Security.removeProvider("SunJCE");
+
+        var name = new KerberosPrincipal("me@ME.COM");
+        var pass = "password".toCharArray();
+        for (var alg : List.of(
+                "aes128-cts-hmac-sha1-96", "aes256-cts-hmac-sha1-96",
+                "aes128-cts-hmac-sha256-128", "aes256-cts-hmac-sha384-192")) {
+            System.out.println(alg);
+            Utils.runAndCheckException(() -> new KerberosKey(name, pass, alg),
+                    IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport JDK-8343622 for parity with Oracle and fix the NPE issue.

Almost clean backport from JDK17 patch with the following exceptions:
- copyright year in AesDkCrypto.java and AesSha2DkCrypto.java
- JDK11 does not have JDK-8233884 that replaces getBytes(String) to getBytes(Charset).  Without JDK-8233884, salt.getBytes("UTF-8") now throws an uncaught UnsupportedEncodingException. I have replaced salt.getBytes("UTF-8") to salt.getBytes(UTF_8) manually in in AesDkCrypto and AesSha2DkCrypto classes

All sun/security/krb5 JTREG tests passed successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343622](https://bugs.openjdk.org/browse/JDK-8343622) needs maintainer approval

### Issue
 * [JDK-8343622](https://bugs.openjdk.org/browse/JDK-8343622): AesDkCrypto.stringToKey should not return null (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3168/head:pull/3168` \
`$ git checkout pull/3168`

Update a local copy of the PR: \
`$ git checkout pull/3168` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3168`

View PR using the GUI difftool: \
`$ git pr show -t 3168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3168.diff">https://git.openjdk.org/jdk11u-dev/pull/3168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3168#issuecomment-4014845908)
</details>
