### PR TITLE
8324243: Compilation failures in java.desktop module with gcc 14

### DIFF
--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
@@ -218,7 +218,7 @@ MidiMessage* MIDI_IN_GetMessage(MidiDeviceHandle* handle) {
             return NULL;
         }
     }
-    jdk_message = (MidiMessage*) calloc(sizeof(MidiMessage), 1);
+    jdk_message = (MidiMessage*) calloc(1, sizeof(MidiMessage));
     if (!jdk_message) {
         ERROR0("< ERROR: MIDI_IN_GetMessage(): out of memory\n");
         return NULL;

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
@@ -383,7 +383,7 @@ INT32 openMidiDevice(snd_rawmidi_stream_t direction, INT32 deviceIndex,
 
     TRACE0("> openMidiDevice()\n");
 
-    (*handle) = (MidiDeviceHandle*) calloc(sizeof(MidiDeviceHandle), 1);
+    (*handle) = (MidiDeviceHandle*) calloc(1, sizeof(MidiDeviceHandle));
     if (!(*handle)) {
         ERROR0("ERROR: openDevice: out of memory\n");
         return MIDI_OUT_OF_MEMORY;

--- a/src/java.desktop/share/native/libfontmanager/sunFont.c
+++ b/src/java.desktop/share/native/libfontmanager/sunFont.c
@@ -67,7 +67,7 @@ int isNullScalerContext(void *context) {
  */
 JNIEXPORT jlong JNICALL Java_sun_font_NullFontScaler_getGlyphImage
   (JNIEnv *env, jobject scaler, jlong pContext, jint glyphCode) {
-    void *nullscaler = calloc(sizeof(GlyphInfo), 1);
+    void *nullscaler = calloc(1, sizeof(GlyphInfo));
     return ptr_to_jlong(nullscaler);
 }
 


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [8e5f6ddb](https://github.com/openjdk/jdk/commit/8e5f6ddb68572c0cc8b6e256e423706f6f7cec94) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sam James on 22 Feb 2024 and was reviewed by Julian Waters, Magnus Ihse Bursie, Kim Barrett and Phil Race.

Changes to `make/lib/Awt2dLibraries.gmk` in the original patch were omitted from this backport as it does not apply cleanly and is no longer necessary: the problem it addressed (by suppressing `calloc-transposed-args` warnings in libharbuzz) has since been fixed upstream and was included in jdk11 (by this commit  https://github.com/openjdk/jdk11u-dev/commit/e41de3f1f7fa9fc1e5ede4f561906485a38fa4f1).

The rest of the changes apply cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243) needs maintainer approval

### Issue
 * [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243): Compilation failures in java.desktop module with gcc 14 (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3179/head:pull/3179` \
`$ git checkout pull/3179`

Update a local copy of the PR: \
`$ git checkout pull/3179` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3179`

View PR using the GUI difftool: \
`$ git pr show -t 3179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3179.diff">https://git.openjdk.org/jdk11u-dev/pull/3179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3179#issuecomment-4112759150)
</details>
