### PR TITLE
8314555: Build with mawk fails on Windows

### DIFF
--- a/make/hotspot/lib/JvmMapfile.gmk
+++ b/make/hotspot/lib/JvmMapfile.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -125,9 +125,26 @@ else ifeq ($(call isTargetOs, aix), true)
 
 else ifeq ($(call isTargetOs, windows), true)
   DUMP_SYMBOLS_CMD := $(DUMPBIN) -symbols *.obj
+
+  # The following lines create a list of vftable symbols to be filtered out of
+  # the mapfile. Removing this line causes the linker to complain about too many
+  # (> 64K) symbols, so the _guess_ is that this line is here to keep down the
+  # number of exported symbols below that limit.
+  #
+  # Some usages of C++ lambdas require the vftable symbol of classes that use
+  # the lambda type as a template parameter. The usage of those classes won't
+  # link if their vftable symbols are removed. That's why there's an exception
+  # for vftable symbols containing the string 'lambda'.
+  #
+  # A very simple example of a lambda usage that fails if the lambda vftable
+  # symbols are missing in the mapfile:
+  #
+  # #include <functional>
+  # std::function<void()> f = [](){}
+
   FILTER_SYMBOLS_AWK_SCRIPT := \
       '{ \
-        if ($$7 ~ /??_7.*@@6B@/ && $$7 !~ /type_info/) print $$7; \
+        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7; \
       }'
 
 else


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2704c802](https://github.com/openjdk/jdk17u/commit/2704c802aa00bd92a4e9b998f62f42a1b84fcb91) from the [openjdk/jdk17u](https://git.openjdk.org/jdk17u) repository.

The commit being backported was authored by Christoph Langer on 9 Mar 2026 and was reviewed by Matthias Baesken.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314555](https://bugs.openjdk.org/browse/JDK-8314555) needs maintainer approval
- [x] [JDK-8275405](https://bugs.openjdk.org/browse/JDK-8275405) needs maintainer approval

### Issues
 * [JDK-8314555](https://bugs.openjdk.org/browse/JDK-8314555): Build with mawk fails on Windows (**Bug** - P4 - Approved)
 * [JDK-8275405](https://bugs.openjdk.org/browse/JDK-8275405): Linking error for classes with lambda template parameters and virtual functions (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3183/head:pull/3183` \
`$ git checkout pull/3183`

Update a local copy of the PR: \
`$ git checkout pull/3183` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3183`

View PR using the GUI difftool: \
`$ git pr show -t 3183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3183.diff">https://git.openjdk.org/jdk11u-dev/pull/3183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3183#issuecomment-4254920129)
</details>
