### PR TITLE
8251548: Remove unnecessary explicit initialization of volatile variables in security-libs code

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -219,7 +219,7 @@ public class KeyStore {
     private KeyStoreSpi keyStoreSpi;
 
     // Has this keystore been initialized (loaded)?
-    private boolean initialized = false;
+    private boolean initialized;
 
     /**
      * A marker interface for {@code KeyStore}
@@ -264,7 +264,7 @@ public class KeyStore {
         private final char[] password;
         private final String protectionAlgorithm;
         private final AlgorithmParameterSpec protectionParameters;
-        private volatile boolean destroyed = false;
+        private volatile boolean destroyed;
 
         /**
          * Creates a password parameter.

--- a/src/java.base/share/classes/java/util/ListResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ListResourceBundle.java
@@ -206,5 +206,5 @@ public abstract class ListResourceBundle extends ResourceBundle {
         lookup = temp;
     }
 
-    private volatile Map<String,Object> lookup = null;
+    private volatile Map<String,Object> lookup;
 }

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -124,7 +124,7 @@ public final class Subject implements java.io.Serializable {
      *
      * @serial
      */
-    private volatile boolean readOnly = false;
+    private volatile boolean readOnly;
 
     private static final int PRINCIPAL_SET = 1;
     private static final int PUB_CREDENTIAL_SET = 2;

--- a/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
@@ -71,7 +71,7 @@ public abstract class AbstractDrbg {
 
     // Common working status
 
-    private boolean instantiated = false;
+    private boolean instantiated;
 
     /**
      * Reseed counter of a DRBG instance. A mechanism should increment it
@@ -80,7 +80,7 @@ public abstract class AbstractDrbg {
      *
      * Volatile, will be used in a double checked locking.
      */
-    protected volatile int reseedCounter = 0;
+    protected volatile int reseedCounter;
 
     // Mech features. If not same as below, must be redefined in constructor.
 

--- a/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
@@ -36,7 +36,7 @@ import sun.security.ssl.SSLCipher.SSLWriteCipher;
  */
 final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
 
-    private DTLSFragmenter fragmenter = null;
+    private DTLSFragmenter fragmenter;
 
     int                 writeEpoch;
 
@@ -44,7 +44,7 @@ final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
     Authenticator       prevWriteAuthenticator;
     SSLWriteCipher      prevWriteCipher;
 
-    private volatile boolean isCloseWaiting = false;
+    private volatile boolean isCloseWaiting;
 
     DTLSOutputRecord(HandshakeHash handshakeHash) {
         super(handshakeHash, SSLWriteCipher.nullDTlsWriteCipher());

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -103,8 +103,8 @@ abstract class HandshakeContext implements ConnectionContext {
     SSLSessionImpl                          resumingSession;
 
     final Queue<Map.Entry<Byte, ByteBuffer>> delegatedActions;
-    volatile boolean                        taskDelegated = false;
-    volatile Exception                      delegatedThrown = null;
+    volatile boolean                        taskDelegated;
+    volatile Exception                      delegatedThrown;
 
     ProtocolVersion                         negotiatedProtocol;
     CipherSuite                             negotiatedCipherSuite;

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
@@ -37,11 +37,11 @@ import sun.security.ssl.SSLCipher.SSLWriteCipher;
  */
 final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
 
-    private HandshakeFragment fragmenter = null;
-    private boolean isTalkingToV2 = false;      // SSLv2Hello
-    private ByteBuffer v2ClientHello = null;    // SSLv2Hello
+    private HandshakeFragment fragmenter;
+    private boolean isTalkingToV2;      // SSLv2Hello
+    private ByteBuffer v2ClientHello;    // SSLv2Hello
 
-    private volatile boolean isCloseWaiting = false;
+    private volatile boolean isCloseWaiting;
 
     SSLEngineOutputRecord(HandshakeHash handshakeHash) {
         super(handshakeHash, SSLWriteCipher.nullTlsWriteCipher());

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -93,8 +93,8 @@ public final class SSLSocketImpl
 
     private String                  peerHost;
     private boolean                 autoClose;
-    private boolean                 isConnected = false;
-    private volatile boolean        tlsIsClosed = false;
+    private boolean                 isConnected;
+    private volatile boolean        tlsIsClosed;
 
     private final ReentrantLock     socketLock = new ReentrantLock();
     private final ReentrantLock     handshakeLock = new ReentrantLock();


### PR DESCRIPTION
Backport of [JDK-8251548](https://bugs.openjdk.org/browse/JDK-8251548) from 17u that removes some unnecessary explicit initialization of variables in the security code. The objective is to make future backports to security code cleaner and easier to review. Low risk.

Clean but for this chunk in `HandshakeContext.java`:

```java
// Session is using stateless resumption
boolean statelessResumption = false;
```

Which doesn't exist in 11 since [JDK-8211018](https://bugs.openjdk.org/browse/JDK-8211018) is missing here.

Security tests continue to pass normally:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk:jdk_security                        1370  1370     0     0   
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] [JDK-8251548](https://bugs.openjdk.org/browse/JDK-8251548) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8251548](https://bugs.openjdk.org/browse/JDK-8251548): Remove unnecessary explicit initialization of volatile variables in security-libs code (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3187/head:pull/3187` \
`$ git checkout pull/3187`

Update a local copy of the PR: \
`$ git checkout pull/3187` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3187`

View PR using the GUI difftool: \
`$ git pr show -t 3187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3187.diff">https://git.openjdk.org/jdk11u-dev/pull/3187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3187#issuecomment-4297465494)
</details>
