### PR TITLE
8366159: SkippedException is treated as a pass for pkcs11/KeyStore, pkcs11/SecretKeyFactory and pkcs11/SecureRandom

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -260,8 +260,7 @@ public class ClientAuth extends PKCS11Test {
         try {
             javax.crypto.Cipher.getInstance("RSA/ECB/PKCS1Padding", p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
 
         this.provider = p;

--- a/test/jdk/sun/security/pkcs11/SecureRandom/Basic.java
+++ b/test/jdk/sun/security/pkcs11/SecureRandom/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * @run main/othervm Basic sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
@@ -45,9 +47,8 @@ public class Basic extends PKCS11Test {
         try {
             random = SecureRandom.getInstance("PKCS11");
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Provider " + p + " does not support SecureRandom, skipping");
             e.printStackTrace();
-            return;
+            throw new SkippedException("Provider " + p + " does not support SecureRandom, skipping", e);
         }
         byte[] b = new byte[32];
         random.nextBytes(b);

--- a/test/jdk/sun/security/pkcs11/SecureRandom/TestDeserialization.java
+++ b/test/jdk/sun/security/pkcs11/SecureRandom/TestDeserialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  * @modules jdk.crypto.cryptoki
  */
 
+import jtreg.SkippedException;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -43,18 +45,16 @@ public class TestDeserialization extends PKCS11Test {
     public void main(Provider p) throws Exception {
         // Skip this test for providers not found by java.security.Security
         if (Security.getProvider(p.getName()) != p) {
-            System.out.println("Skip test for provider " + p.getName());
-            return;
+            throw new SkippedException("Skip test for provider " + p.getName());
         }
         SecureRandom r;
         try {
             r = SecureRandom.getInstance("PKCS11", p);
             System.out.println("SecureRandom instance " + r);
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Provider " + p +
-                               " does not support SecureRandom, skipping");
             e.printStackTrace();
-            return;
+            throw new SkippedException("Provider " + p +
+                               " does not support SecureRandom, skipping");
         }
         r.setSeed(System.currentTimeMillis());
         byte[] buf = new byte[16];


### PR DESCRIPTION
Hi all,

I will backport JDK-8366159 from JDK 26 to JDK 11. This backport is equivalent to the fix applied in JDK 17. 
This resolves an issue where certain tests in the PKCS#11 test suite were incorrectly treating “skip” conditions (unsupported provider/algorithm, missing configuration, etc.) as normal successful completion instead of signaling them as skipped.

Could someone please review it?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8366159](https://bugs.openjdk.org/browse/JDK-8366159) needs maintainer approval

### Issue
 * [JDK-8366159](https://bugs.openjdk.org/browse/JDK-8366159): SkippedException is treated as a pass for pkcs11/KeyStore, pkcs11/SecretKeyFactory and pkcs11/SecureRandom (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3191/head:pull/3191` \
`$ git checkout pull/3191`

Update a local copy of the PR: \
`$ git checkout pull/3191` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3191`

View PR using the GUI difftool: \
`$ git pr show -t 3191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3191.diff">https://git.openjdk.org/jdk11u-dev/pull/3191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3191#issuecomment-4404730008)
</details>
