### PR TITLE
8365660: test/jdk/sun/security/pkcs11/KeyAgreement/ tests skipped without SkipExceprion

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyAgreement/SupportedDHKeys.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/SupportedDHKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @run main/othervm SupportedDHKeys
  * @run main/othervm SupportedDHKeys sm
  */
+
+import jtreg.SkippedException;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -63,8 +65,7 @@ public class SupportedDHKeys extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyPairGenerator", "DiffieHellman") == null) {
-            System.out.println("No support of DH KeyPairGenerator, skipping");
-            return;
+           throw new SkippedException("No support of DH KeyPairGenerator, skipping");
         }
 
         for (SupportedKeySize keySize : SupportedKeySize.values()) {

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,14 +38,14 @@ import java.security.Provider;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.SecretKey;
+import jtreg.SkippedException;
 
 public class TestDH extends PKCS11Test {
 
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyAgreement", "DH") == null) {
-            System.out.println("DH not supported, skipping");
-            return;
+            throw new SkippedException("DH not supported, skipping");
         }
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);
         kpg.initialize(512);

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestInterop.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
+import jtreg.SkippedException;
 
 public class TestInterop extends PKCS11Test {
 
@@ -80,8 +81,7 @@ public class TestInterop extends PKCS11Test {
     @Override
     public void main(Provider prov) throws Exception {
         if (prov.getService("KeyAgreement", "DH") == null) {
-            System.out.println("DH not supported, skipping");
-            return;
+            throw new SkippedException("DH not supported, skipping");
         }
         try {
             System.out.println("testing generateSecret()");

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestShort.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @run main/othervm TestShort
  * @run main/othervm TestShort sm
  */
+
+import jtreg.SkippedException;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -91,12 +93,10 @@ public class TestShort extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyAgreement", "DH") == null) {
-            System.out.println("DH not supported, skipping");
-            return;
+            throw new SkippedException("DH not supported, skipping");
         }
+
         try {
-            DHPublicKeySpec publicSpec;
-            DHPrivateKeySpec privateSpec;
             KeyFactory kf = KeyFactory.getInstance("DH", provider);
             KeyAgreement ka = KeyAgreement.getInstance("DH", provider);
 
@@ -107,7 +107,7 @@ public class TestShort extends PKCS11Test {
             ka.init(pr1);
             ka.doPhase(pu2, true);
             byte[] n2 = ka.generateSecret();
-            if (Arrays.equals(s2, n2) == false) {
+            if (!Arrays.equals(s2, n2)) {
                 throw new Exception("mismatch 2");
             }
             System.out.println("short ok");
@@ -115,7 +115,7 @@ public class TestShort extends PKCS11Test {
             ka.init(pr1);
             ka.doPhase(pu3, true);
             byte[] n3 = ka.generateSecret();
-            if (Arrays.equals(s3, n3) == false) {
+            if (!Arrays.equals(s3, n3)) {
                 throw new Exception("mismatch 3");
             }
             System.out.println("normal ok");
@@ -124,27 +124,6 @@ public class TestShort extends PKCS11Test {
             ex.printStackTrace();
             throw ex;
         }
-
-/*
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", provider);
-        kpg.initialize(512);
-//        KeyPair kp1 = kpg.generateKeyPair();
-//      System.out.println(kp1.getPublic());
-//      System.out.println(kp1.getPrivate());
-        while (true) {
-            KeyAgreement ka = KeyAgreement.getInstance("DH", provider);
-            ka.init(pr1);
-            KeyPair kp2 = kpg.generateKeyPair();
-            ka.doPhase(kp2.getPublic(), true);
-            byte[] sec = ka.generateSecret();
-            if (sec.length == 64) {
-                System.out.println(kp2.getPrivate());
-                System.out.println(kp2.getPublic());
-                System.out.println(toString(sec));
-                break;
-            }
-        }
-/**/
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/UnsupportedDHKeys.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/UnsupportedDHKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @run main/othervm UnsupportedDHKeys sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.InvalidParameterException;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
@@ -60,8 +62,7 @@ public class UnsupportedDHKeys extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyPairGenerator", "DiffieHellman") == null) {
-            System.out.println("No supported of DH KeyPairGenerator, skipping");
-            return;
+            throw new SkippedException("DH (DiffieHellman) is not supported in KeyPairGenerator, skipping");
         }
 
         for (UnsupportedKeySize keySize : UnsupportedKeySize.values()) {


### PR DESCRIPTION
I will backport JDK-8365660 from JDK 26 to JDK 11. This backport is equivalent to the fix applied in JDK 17.
This resolves an issue where, when specific PKCS#11 DH capabilities were unavailable, tests would print a skipping message and return. 

Could someone please review it?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8365660](https://bugs.openjdk.org/browse/JDK-8365660) needs maintainer approval
- \[x\] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8365660](https://bugs.openjdk.org/browse/JDK-8365660): test/jdk/sun/security/pkcs11/KeyAgreement/ tests skipped without SkipExceprion (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3192/head:pull/3192` \
`$ git checkout pull/3192`

Update a local copy of the PR: \
`$ git checkout pull/3192` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3192`

View PR using the GUI difftool: \
`$ git pr show -t 3192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3192.diff">https://git.openjdk.org/jdk11u-dev/pull/3192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3192#issuecomment-4406075511)
</details>
