### PR TITLE
8347740: java/io/File/createTempFile/SpecialTempFile.java failing

### DIFF
--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -41,8 +41,12 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.OSVersion;
 
 public class SpecialTempFile {
+    //
+    // If exceptionExpected == null, then any IOException thrown by
+    // File.createTempFile is ignored.
+    //
     private static void test(String name, String[] prefix, String[] suffix,
-                             boolean exceptionExpected) throws IOException
+                             Boolean exceptionExpected) throws IOException
     {
         if (prefix == null || suffix == null
             || prefix.length != suffix.length)
@@ -69,19 +73,21 @@ public class SpecialTempFile {
                     f = File.createTempFile(prefix[i], suffix[i],
                         tempDir.toFile());
                 } catch (IOException e) {
-                    if (exceptionExpected) {
-                        if (e.getMessage().startsWith(exceptionMsg))
-                            exceptionThrown = true;
-                        else
-                            System.out.println("Wrong error message:" +
-                                               e.getMessage());
-                    } else {
-                        throw e;
+                    if (exceptionExpected != null) {
+                        if (exceptionExpected) {
+                            if (e.getMessage().startsWith(exceptionMsg))
+                                exceptionThrown = true;
+                            else
+                                System.out.println("Wrong error message:" +
+                                                   e.getMessage());
+                        } else {
+                            throw e;
+                        }
+
+                        if (exceptionExpected && (!exceptionThrown || f != null))
+                            throw new RuntimeException("IOException expected");
                     }
                 }
-
-                if (exceptionExpected && (!exceptionThrown || f != null))
-                    throw new RuntimeException("IOException is expected");
             }
         }
     }
@@ -110,9 +116,12 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        boolean exceptionExpected =
-            !(System.getProperty("os.name").endsWith("11") ||
-              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
-        test("ReservedName", resvPre, resvSuf, exceptionExpected);
+
+        System.out.println("OS name:    " + System.getProperty("os.name") + "\n" +
+                           "OS version: " + OSVersion.current());
+
+        // Here the test is for whether File.createTempFile hangs, so whether
+        // an exception is thrown is ignored: expectedException == null
+        test("ReservedName", resvPre, resvSuf, null);
     }
 }


### PR DESCRIPTION
I would like to backport [ 8347740](https://bugs.openjdk.org/browse/JDK-8347740) to jdk11u, which has been backported to  jdk21 and jdk17.  We see it in our CI. It's a test fix, no risk. 

Similar to https://github.com/openjdk/jdk17u-dev/pull/3275, I had to use System.getProperty("os.name") in 11.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347740](https://bugs.openjdk.org/browse/JDK-8347740) needs maintainer approval
- [x] [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714) needs maintainer approval

### Issues
 * [JDK-8347740](https://bugs.openjdk.org/browse/JDK-8347740): java/io/File/createTempFile/SpecialTempFile.java failing (**Bug** - P3 - Approved)
 * [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714): [17u] Backport of 8347740 incomplete (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3193/head:pull/3193` \
`$ git checkout pull/3193`

Update a local copy of the PR: \
`$ git checkout pull/3193` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3193`

View PR using the GUI difftool: \
`$ git pr show -t 3193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3193.diff">https://git.openjdk.org/jdk11u-dev/pull/3193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3193#issuecomment-4407576073)
</details>
