### PR TITLE
8312620: WSL Linux build crashes after JDK-8310233

### DIFF
--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -52,6 +52,9 @@ class StaticHugePageSupport {
   // - is the size one gets when using mmap(MAP_HUGETLB) when omitting size specifiers like MAP_HUGE_SHIFT)
   size_t _default_hugepage_size;
 
+  // If true, the kernel support for hugepages is inconsistent
+  bool _inconsistent;
+
 public:
   StaticHugePageSupport();
 
@@ -60,6 +63,8 @@ public:
   os::PageSizes pagesizes() const;
   size_t default_hugepage_size() const;
   void print_on(outputStream* os);
+
+  bool inconsistent() const { return _inconsistent; }
 };
 
 enum THPMode { THPMode_always, THPMode_never, THPMode_madvise };
@@ -98,7 +103,7 @@ public:
   static const THPSupport& thp_info() { return _thp_support; }
 
   static size_t default_static_hugepage_size()  { return _static_hugepage_support.default_hugepage_size(); }
-  static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0; }
+  static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0 && !_static_hugepage_support.inconsistent(); }
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static bool supports_thp()                    { return thp_mode() == THPMode_madvise || thp_mode() == THPMode_always; }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
@@ -29,14 +29,14 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver HugePageDetection
+ * @run driver TestHugePageDetection
  */
 
 import java.util.*;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
-public class HugePageDetection {
+public class TestHugePageDetection {
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
JDK-8312620 is a bug fix that addresses a regression in Linux hugepage detection introduced by JDK-8310233. On WSL1, the kernel reports a non‑zero `Hugepagesize` in `/proc/meminfo` but does not expose `/sys/kernel/mm/hugepages`, which causes the VM to hit an assertion in `StaticHugePageSupport::scan_os()` and crash when static hugepages are enabled (e.g., with `-XX:+UseLargePages`).

The fix was originally implemented in **JDK 22**. Now we are backporting this into **JDK 11**. It is a clean Backport.

This change touches the same code as JDK-8312394(#3172) , which addresses a regression introduced by JDK-8310233. Therefore, JDK-8312394 needs to be integrated before this fix.

## Testing

**System:** Ran on Red Hat Enterprise Linux 9.4 (x86_64).
**jtreg**: A comprehensive `jtreg` run on the entire `hotspot/jtreg` test suite confirmed that **all HotSpot tests passed**. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8312620](https://bugs.openjdk.org/browse/JDK-8312620) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #3172 must be integrated first

### Issue
 * [JDK-8312620](https://bugs.openjdk.org/browse/JDK-8312620): WSL Linux build crashes after JDK-8310233 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3194/head:pull/3194` \
`$ git checkout pull/3194`

Update a local copy of the PR: \
`$ git checkout pull/3194` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3194`

View PR using the GUI difftool: \
`$ git pr show -t 3194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3194.diff">https://git.openjdk.org/jdk11u-dev/pull/3194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3194#issuecomment-4427043334)
</details>
