### PR TITLE
8257989: Error in gtest os_page_size_for_region_unaligned after 8257588

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -99,7 +99,7 @@ TEST_VM(os, page_size_for_region_unaligned) {
     for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
       const size_t expected = os::page_sizes().next_smaller(s);
       if (expected != 0) {
-        size_t actual = os::page_size_for_region_unaligned(expected - 17, 1);
+        size_t actual = os::page_size_for_region_unaligned(s - 17, 1);
         ASSERT_EQ(actual, expected);
       }
     }


### PR DESCRIPTION
The fix addresses an issue in the `os_page_size_for_region_unaligned` gtest, which was introduced by changes in JDK-8257588. The original test logic had an incorrect comparison, leading to test failures when multiple large page sizes were configured. This enhancement corrects the test logic to accurately verify the `os::page_size_for_region_unaligned` function.

We are backporting this fix from JDK 16 to JDK 11. It is a clean Backport.
## Testing

The `gtest` suite, specifically the `os` tests, including `os.page_size_for_region_unaligned_test_vm`, passed successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8257989](https://bugs.openjdk.org/browse/JDK-8257989) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #3160 must be integrated first

### Issue
 * [JDK-8257989](https://bugs.openjdk.org/browse/JDK-8257989): Error in gtest os_page_size_for_region_unaligned after 8257588 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3195/head:pull/3195` \
`$ git checkout pull/3195`

Update a local copy of the PR: \
`$ git checkout pull/3195` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3195`

View PR using the GUI difftool: \
`$ git pr show -t 3195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3195.diff">https://git.openjdk.org/jdk11u-dev/pull/3195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3195#issuecomment-4427815948)
</details>
