### PR TITLE
8363966: GHA: Switch cross-compiling sysroots to Debian trixie

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -59,23 +59,23 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bookworm
+            debian-version: trixie
 
     steps:
       - name: 'Checkout the JDK source'


### PR DESCRIPTION
This backport switches sysroot for cross-builds in GHA to debian trixie.

[Debian bookworm](https://www.debian.org/releases/oldstable/), which is currently used for sysroot, soon enters LTS (2026-06-11). Then set of supported architectures will be reduced, likely breaking cross-build for some archs in GHA (based on past experience). While list of LTS archs for bookworm [has not yet been determined](https://wiki.debian.org/LTS), based on debian older versions, it will likely be just i386, amd64, armhf and arm64.

Backport is not clean due to context differences and because of missing risc-v. This change only affects testing in GHA.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363966](https://bugs.openjdk.org/browse/JDK-8363966) needs maintainer approval

### Issue
 * [JDK-8363966](https://bugs.openjdk.org/browse/JDK-8363966): GHA: Switch cross-compiling sysroots to Debian trixie (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3196/head:pull/3196` \
`$ git checkout pull/3196`

Update a local copy of the PR: \
`$ git checkout pull/3196` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3196`

View PR using the GUI difftool: \
`$ git pr show -t 3196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3196.diff">https://git.openjdk.org/jdk11u-dev/pull/3196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3196#issuecomment-4432677963)
</details>
