### PR TITLE
8381551: DisabledCurve test fails on Windows after disabling SHA1

### DIFF
--- a/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
@@ -23,12 +23,12 @@
 
 /*
  * @test
- * @bug 8246330
+ * @bug 8246330 8381551
  * @library /javax/net/ssl/templates /test/lib
- * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
+ * @run main/othervm -Djdk.tls.namedGroups="secp384r1"
         DisabledCurve DISABLE_NONE PASS
- * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
-        DisabledCurve sect283r1 FAIL
+ * @run main/othervm -Djdk.tls.namedGroups="secp384r1"
+        DisabledCurve secp384r1 FAIL
 */
 import java.security.Security;
 import java.util.Arrays;
@@ -51,20 +51,20 @@ public class DisabledCurve extends SSLSocketTemplate {
     @Override
     protected SSLContext createClientSSLContext() throws Exception {
         return createSSLContext(
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.CA_ECDSA_SECT283R1 },
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.EE_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECP384R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECP384R1 },
                 getClientContextParameters());
     }
 
     @Override
     protected SSLContext createServerSSLContext() throws Exception {
         return createSSLContext(
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.CA_ECDSA_SECT283R1 },
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.EE_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECP384R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECP384R1 },
                 getServerContextParameters());
     }
 
@@ -93,10 +93,13 @@ public class DisabledCurve extends SSLSocketTemplate {
     public static void main(String[] args) throws Exception {
         String expected = args[1];
         String disabledName = ("DISABLE_NONE".equals(args[0]) ? "" : args[0]);
+        boolean disabled = false;
         if (disabledName.equals("")) {
             Security.setProperty("jdk.disabled.namedCurves", "");
+        } else {
+            disabled = true;
+            Security.setProperty("jdk.certpath.disabledAlgorithms", "secp384r1");
         }
-        System.setProperty("jdk.sunec.disableNative", "false");
 
         // Re-enable TLSv1 and TLSv1.1 since test depends on it.
         SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
@@ -106,12 +109,10 @@ public class DisabledCurve extends SSLSocketTemplate {
                 (new DisabledCurve()).run();
                 if (expected.equals("FAIL")) {
                     throw new RuntimeException(
-                            "The test case should not reach here");
+                            "Expected test to fail, but it passed");
                 }
             } catch (SSLException | IllegalStateException ssle) {
-                if ((expected.equals("FAIL"))
-                        && Security.getProperty("jdk.disabled.namedCurves")
-                                .contains(disabledName)) {
+                if (expected.equals("FAIL") && disabled) {
                     System.out.println(
                             "Expected exception was thrown: TEST PASSED");
                 } else {


### PR DESCRIPTION
This patch mimics changes to DisabledCurve.java from commit 0b83fc01.
By replacing `sect283r1` with `secp384r1`, we use SHA384 with ECDSA,
thus avoiding SHA1 with ECDSA altogether.  This patch is required
because a prior commit (13e2a4c) added `ecdsa_sha1` to the list of
disabled algorithms, but that patch didn't make the corresponding change
to DisabledCurve.java.

cc: @jerboaa

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8381551](https://bugs.openjdk.org/browse/JDK-8381551) needs maintainer approval

### Issue
 * [JDK-8381551](https://bugs.openjdk.org/browse/JDK-8381551): DisabledCurve test fails on Windows after disabling SHA1 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3197/head:pull/3197` \
`$ git checkout pull/3197`

Update a local copy of the PR: \
`$ git checkout pull/3197` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3197`

View PR using the GUI difftool: \
`$ git pr show -t 3197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3197.diff">https://git.openjdk.org/jdk11u-dev/pull/3197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3197#issuecomment-4432782379)
</details>
