### PR TITLE
8373690: Unexpected Keystore message using jdk.crypto.disabledAlgorithms

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1780,6 +1780,7 @@ public class KeyStore {
         }
 
         KeyStore keystore = null;
+        String matched = null;
 
         try (DataInputStream dataStream =
             new DataInputStream(
@@ -1806,8 +1807,10 @@ public class KeyStore {
                         if (CryptoAlgorithmConstraints.permits(
                                 "KEYSTORE", type)) {
                             keystore = new KeyStore(impl, (Provider)objs[1], type);
-                            break;
+                        } else {
+                            matched = type;
                         }
+                        break;
                     }
                 } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
                     // ignore
@@ -1836,8 +1839,14 @@ public class KeyStore {
             }
         }
 
-        throw new KeyStoreException("Unrecognized keystore format. "
-                + "Please load it with a specified type");
+        if (matched == null) {
+            throw new KeyStoreException("Unrecognized keystore format. "
+                    + "Please load it with a specified type");
+        } else {
+            throw new KeyStoreException("Keystore format " +
+                    matched +
+                    " disabled by jdk.crypto.disabledAlgorithms property");
+        }
     }
 
     /**

--- a/test/jdk/java/security/KeyStore/DisabledKnownType.java
+++ b/test/jdk/java/security/KeyStore/DisabledKnownType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8373690
+ * @summary verify that the exception message indicates the keystore type
+ *         when the type is disabled instead of being unrecognized
+ * @run main/othervm -Djdk.crypto.disabledAlgorithms=KeyStore.JKS DisabledKnownType
+ */
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+public class DisabledKnownType {
+    public static void main(String[] args) throws Exception {
+        String cacertsPath = System.getProperty("java.home") +
+                "/lib/security/cacerts";
+        try {
+            KeyStore ks = KeyStore.getInstance(new java.io.File(cacertsPath),
+                    "changeit".toCharArray());
+            throw new RuntimeException("Expected KeyStoreException not thrown");
+        } catch (KeyStoreException kse) {
+            if (kse.getMessage().contains("JKS")) {
+                System.out.println("Passed: expected ex thrown: " + kse);
+            } else {
+                // pass it up
+                throw kse;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Backport of [JDK-8373690](https://bugs.openjdk.org/browse/JDK-8373690) - Unexpected Keystore message using jdk.crypto.disabledAlgorithms

## Tests

Test were run on Fedora 44

### Extra tests - PASSING

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/java/security/KeyStore/DisabledKnownType.java
                                                         1     1     0     0
   jtreg:test/jdk/java/security/KeyStore/TestDisabledAlgorithms.java
                                                         1     1     0     0
==============================
TEST SUCCESS
```
- `test/jdk/java/security/KeyStore/DisabledKnownType.java` -> This test is introduced in this backport.
- `test/jdk/java/security/KeyStore/TestDisabledAlgorithms.java` -> This is a test introduced in [JDK-8244336](https://bugs.openjdk.org/browse/JDK-8244336) ( #3213 ) that is originally failing, but is fixed by this backport.

### Tier 1 - PASSING

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/hotspot/jtreg:tier1                     1497  1497     0     0
   jtreg:test/jdk:tier1                               1900  1900     0     0
   jtreg:test/langtools:tier1                         3941  3941     0     0
   jtreg:test/nashorn:tier1                              0     0     0     0
   jtreg:test/jaxp:tier1                                 0     0     0     0
==============================
TEST SUCCESS
```

### gtest - PASSING

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   gtest:all/server                                    507   507     0     0
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] [JDK-8373690](https://bugs.openjdk.org/browse/JDK-8373690) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #3213 must be integrated first

### Issue
 * [JDK-8373690](https://bugs.openjdk.org/browse/JDK-8373690): Unexpected Keystore message using jdk.crypto.disabledAlgorithms (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3216/head:pull/3216` \
`$ git checkout pull/3216`

Update a local copy of the PR: \
`$ git checkout pull/3216` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3216`

View PR using the GUI difftool: \
`$ git pr show -t 3216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3216.diff">https://git.openjdk.org/jdk11u-dev/pull/3216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3216#issuecomment-4602049681)
</details>
