### PR TITLE
8366342: Key generator and key pair generator tests skipping, but showing as passed

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyGenerator/DESParity.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/DESParity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * @run main/othervm DESParity sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.util.Random;
 import javax.crypto.SecretKey;
@@ -46,8 +48,7 @@ public class DESParity extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("SecretKeyFactory", "DES") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         Random random = new Random();
         SecretKeyFactory kf;
@@ -58,7 +59,7 @@ public class DESParity extends PKCS11Test {
             random.nextBytes(b);
             SecretKeySpec spec = new SecretKeySpec(b, "DES");
             SecretKey key = kf.generateSecret(spec);
-            if (DESKeySpec.isParityAdjusted(key.getEncoded(), 0) == false) {
+            if (!DESKeySpec.isParityAdjusted(key.getEncoded(), 0)) {
                 throw new Exception("DES key not parity adjusted");
             }
         }
@@ -69,7 +70,7 @@ public class DESParity extends PKCS11Test {
             random.nextBytes(b);
             SecretKeySpec spec = new SecretKeySpec(b, "DESede");
             SecretKey key = kf.generateSecret(spec);
-            if (DESedeKeySpec.isParityAdjusted(key.getEncoded(), 0) == false) {
+            if (!DESedeKeySpec.isParityAdjusted(key.getEncoded(), 0)) {
                 throw new Exception("DESede key not parity adjusted");
             }
         }

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestChaCha20.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestChaCha20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  * @library /test/lib ..
  * @run main/othervm TestChaCha20
  */
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
@@ -53,8 +55,7 @@ public class TestChaCha20 extends PKCS11Test {
         try {
             kg = KeyGenerator.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO, nsae);
         }
 
         try {

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDH2048.java
+++ b/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDH2048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
  * @run main/othervm TestDH2048 sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -51,8 +53,7 @@ public class TestDH2048 extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyPairGenerator", "DH") == null) {
-            System.out.println("KPG for DH not supported, skipping");
-            return;
+            throw new SkippedException("KPG for DH not supported, skipping");
         }
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);
         kpg.initialize(512);


### PR DESCRIPTION
Hi all,

I will backport JDK-8366342 from JDK 26 to JDK 11 to address an issue where, when specific PKCS#11 DES, ChaCha20 and DH capabilities were unavailable, tests would print a skipping message and return. This caused jtreg to misleadingly mark them as "Passed" because no explicit failure occurred. In other words, when PKCS#11 functionality was unavailable, the tests exited normally and were counted the same as successful tests, even though they did not actually verify any functionality.

This backport is equivalent to the fix applied in JDK 17. 

There are additional, similar PKCS#11 test improvements in newer releases, but we plan to backport those to JDK 11 separately and in due course.

Thank you.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8366342](https://bugs.openjdk.org/browse/JDK-8366342) needs maintainer approval

### Issue
 * [JDK-8366342](https://bugs.openjdk.org/browse/JDK-8366342): Key generator and key pair generator tests skipping, but showing as passed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3224/head:pull/3224` \
`$ git checkout pull/3224`

Update a local copy of the PR: \
`$ git checkout pull/3224` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3224`

View PR using the GUI difftool: \
`$ git pr show -t 3224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3224.diff">https://git.openjdk.org/jdk11u-dev/pull/3224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3224#issuecomment-4645591623)
</details>
