### PR TITLE
8378180: Compiling OpenJDK with C23 C-Compiler gives warning: initialization discards ‘const’ qualifier from pointer target type

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1010,7 +1010,7 @@ static void
 SetMainModule(const char *s)
 {
     static const char format[] = "-Djdk.module.main=%s";
-    char* slash = JLI_StrChr(s, '/');
+    const char* slash = JLI_StrChr(s, '/');
     size_t s_len, def_len;
     char *def;
 

--- a/src/java.base/share/native/libjli/jli_util.c
+++ b/src/java.base/share/native/libjli/jli_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ JLI_MemFree(void *ptr)
 jboolean
 JLI_HasSuffix(const char *s1, const char *s2)
 {
-    char *p = JLI_StrRChr(s1, '.');
+    const char* p = JLI_StrRChr(s1, '.');
     if (p == NULL || *p == '\0') {
         return JNI_FALSE;
     }

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3842,7 +3842,7 @@ signature_to_fieldtype(context_type *context,
             case JVM_SIGNATURE_CLASS: {
                 char buffer_space[256];
                 char *buffer = buffer_space;
-                char *finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
+                const char* finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
                 int length;
                 if (finish == NULL) {
                     /* Signature must have ';' after the class name.

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ getZoneName(char *str)
 {
     static const char *zidir = "zoneinfo/";
 
-    char *pos = strstr((const char *)str, zidir);
+    char* pos = strstr(str, zidir);
     if (pos == NULL) {
         return NULL;
     }

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,8 +219,7 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByName0
     netif *ifs, *curr;
     jboolean isCopy;
     const char* name_utf;
-    char *colonP;
-    char searchName[IFNAMESIZE];
+    const char *colonP;
     jobject obj = NULL;
 
     if (name != NULL) {
@@ -244,15 +243,11 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByName0
 
     // search the list of interfaces based on name,
     // if it is virtual sub interface search with parent first.
-    strncpy(searchName, name_utf, IFNAMESIZE);
-    searchName[IFNAMESIZE - 1] = '\0';
-    colonP = strchr(searchName, ':');
-    if (colonP != NULL) {
-        *colonP = '\0';
-    }
+    colonP = strchr(name_utf, ':');
+    size_t limit = colonP != NULL ? (size_t)(colonP - name_utf) : strlen(name_utf);
     curr = ifs;
     while (curr != NULL) {
-        if (strcmp(searchName, curr->name) == 0) {
+        if (strlen(curr->name) == limit && memcmp(name_utf, curr->name, limit) == 0) {
             break;
         }
         curr = curr->next;

--- a/src/java.instrument/share/native/libinstrument/JPLISAgent.c
+++ b/src/java.instrument/share/native/libinstrument/JPLISAgent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -769,7 +769,7 @@ getModuleObject(jvmtiEnv*               jvmti,
     jobject moduleObject = NULL;
 
     /* find last slash in the class name */
-    char* last_slash = (cname == NULL) ? NULL : strrchr(cname, '/');
+    const char* last_slash = (cname == NULL) ? NULL : strrchr(cname, '/');
     int len = (last_slash == NULL) ? 0 : (int)(last_slash - cname);
     char* pkg_name_buf = (char*)malloc(len + 1);
 

--- a/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ int filenameStrcmp(const char* s1, const char* s2) {
 }
 
 char* basePath(const char* path) {
-    char* last = strrchr(path, slash);
+    const char* last = strrchr(path, slash);
     if (last == NULL) {
         return (char*)path;
     } else {

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -276,7 +276,7 @@ getPortNumber(const char *s_port) {
 
 static jdwpTransportError
 parseAddress(const char *address, struct sockaddr_in *sa) {
-    char *colon;
+    const char *colon;
     int port;
 
     memset((void *)sa, 0, sizeof(struct sockaddr_in));

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,8 @@ get_time_stamp(char *tbuf, size_t ltbuf)
 static const char *
 file_basename(const char *file)
 {
-    char *p1;
-    char *p2;
+    const char* p1;
+    const char* p2;
 
     if ( file==NULL )
         return "unknown";


### PR DESCRIPTION
This is an unclean backport of of commit [16971af1](https://github.com/openjdk/jdk-17u-dev/commit/16971af10713a9ddd142532845ac58649cf2f970) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository (itslef a backport of [76a44b3e](https://github.com/openjdk/jdk/commit/76a44b3e0341a9c59eaff0bfe8884ad104bda8d5) from [openjdk/jdk](https://git.openjdk.org/jdk)).

The aim for this backport is to address compiler warnings that arise when attempting to build with with more recent version of gcc (16.1+).

The patch does not appy cleanly; the following modifications were necessary:
* Ignore the changes to `src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c` as the file doesn't exists in jdk11
* ~The changes in `src/java.base/unix/native/libnet/NetworkInterface.c` are not applicaple to jdk11 (`*colonP` is assigned a value at line 251, cannot be declared `const`)~ (EDIT: This PR also includes a backport of [JDK-8254871](https://bugs.openjdk.org/browse/JDK-8254871), making the changes to  `src/java.base/unix/native/libnet/NetworkInterface.c` relevant)
* A change not included in the original patch is required to prevent a `discarded-qualifiers` warning in `src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c`

I have verified that with this patch, jdk11u-dev compiles without warning on Fedora 44 with gcc 16.1.1.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8378180](https://bugs.openjdk.org/browse/JDK-8378180) needs maintainer approval
- \[x\] [JDK-8254871](https://bugs.openjdk.org/browse/JDK-8254871) needs maintainer approval

### Issues
 * [JDK-8378180](https://bugs.openjdk.org/browse/JDK-8378180): Compiling OpenJDK with C23 C-Compiler gives warning: initialization discards ‘const’ qualifier from pointer target type (**Enhancement** - P3 - Approved)
 * [JDK-8254871](https://bugs.openjdk.org/browse/JDK-8254871): Remove unnecessary string copy in NetworkInterface.c (**Task** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [5c39c03e](https://git.openjdk.org/jdk11u-dev/pull/3231/files/5c39c03ea89a41eb3721462c05573437dd3ab607)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3231/head:pull/3231` \
`$ git checkout pull/3231`

Update a local copy of the PR: \
`$ git checkout pull/3231` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3231`

View PR using the GUI difftool: \
`$ git pr show -t 3231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3231.diff">https://git.openjdk.org/jdk11u-dev/pull/3231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3231#issuecomment-4811478057)
</details>
