### PR TITLE
8354469: Keytool exposes the password in plain text when command is piped using | grep

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -26,7 +26,9 @@
 package java.io;
 
 import java.util.*;
+import java.lang.annotation.Native;
 import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicReference;
 import jdk.internal.misc.JavaIOAccess;
 import jdk.internal.misc.SharedSecrets;
 import sun.nio.cs.StreamDecoder;
@@ -308,6 +310,51 @@ public final class Console implements Flushable
     *          or {@code null} if an end of stream has been reached.
     */
     public char[] readPassword(String fmt, Object ... args) {
+        return readPassword0(false, fmt, args);
+    }
+
+    // These two methods are intended for sun.security.util.Password, so tools like keytool can
+    // use Console even when standard output is redirected. The Password class should first
+    // check if `System.console()` returns a Console instance and use it if available. Otherwise,
+    // it should call this method to obtain a Console. This ensures only one Console
+    // instance exists in the Java runtime.
+    private static final AtomicReference<Optional<Console>> INSTANCE = new AtomicReference<>();
+    private static Optional<Console> passwordConsole() {
+         Optional<Console> result = INSTANCE.get();
+         if (result != null) {
+             return result;
+         }
+
+         synchronized (Console.class) {
+             result = INSTANCE.get();
+             if (result != null) {
+                 return result;
+             }
+
+            // If there's already a proper console, throw an exception
+            if (System.console() != null) {
+                throw new IllegalStateException("Can't create a dedicated password " +
+                    "console since a real console already exists");
+            }
+
+            // If stdin is NOT redirected, return an Optional containing a Console
+            // instance, otherwise an empty Optional.
+            result = isStdinTty() ?
+                Optional.of(
+                    new Console()) :
+                Optional.empty();
+
+            INSTANCE.set(result);
+            return result;
+        }
+    }
+
+    // Dedicated entry for sun.security.util.Password when stdout is redirected.
+    private char[] readPasswordNoNewLine() {
+        return readPassword0(true, "");
+    }
+
+    private char[] readPassword0(boolean noNewLine, String fmt, Object ... args) {
         char[] passwd = null;
         synchronized (writeLock) {
             synchronized(readLock) {
@@ -347,7 +394,9 @@ public final class Console implements Flushable
                         throw ioe;
                     }
                 }
-                pw.println();
+                if (!noNewLine) {
+                    pw.println();
+                }
             }
         }
         return passwd;
@@ -411,6 +460,12 @@ public final class Console implements Flushable
     private boolean restoreEcho;
     private boolean shutdownHookInstalled;
     private static native String encoding();
+    @Native private static final int TTY_STDIN_MASK = 0x00000001;
+    @Native private static final int TTY_STDOUT_MASK = 0x00000002;
+    @Native private static final int TTY_STDERR_MASK = 0x00000004;
+    // ttyStatus() returns bit patterns above, a bit is set if the corresponding file
+    // descriptor is a character device
+    private static final int ttyStatus = ttyStatus();
     /*
      * Sets the console echo status to {@code on} and returns the previous
      * console on/off status.
@@ -575,7 +630,7 @@ public final class Console implements Flushable
     static {
         SharedSecrets.setJavaIOAccess(new JavaIOAccess() {
             public Console console() {
-                if (istty()) {
+                if (isStdinTty() && isStdoutTty()) {
                     if (cons == null)
                         cons = new Console();
                     return cons;
@@ -588,10 +643,15 @@ public final class Console implements Flushable
                 // cons already exists when this method is called
                 return cons.cs;
             }
+            public Optional<Console> passwordConsole() {
+                return Console.passwordConsole();
+            }
+            public char[] readPasswordNoNewLine(Console c) {
+                return c.readPasswordNoNewLine();
+            }
         });
     }
     private static Console cons;
-    private static native boolean istty();
     private Console() {
         readLock = new Object();
         writeLock = new Object();
@@ -615,4 +675,14 @@ public final class Console implements Flushable
                      cs));
         rcb = new char[1024];
     }
+    private static boolean isStdinTty() {
+        return (ttyStatus & TTY_STDIN_MASK) != 0;
+    }
+    private static boolean isStdoutTty() {
+        return (ttyStatus & TTY_STDOUT_MASK) != 0;
+    }
+    private static boolean isStderrTty() {
+        return (ttyStatus & TTY_STDERR_MASK) != 0;
+    }
+    private static native int ttyStatus();
 }

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -382,7 +382,9 @@ public final class Console implements Flushable
                             ioe.addSuppressed(x);
                     }
                     if (ioe != null) {
-                        Arrays.fill(passwd, ' ');
+                        if (passwd != null) {
+                            Arrays.fill(passwd, ' ');
+                        }
                         try {
                             if (reader instanceof LineReader) {
                                 LineReader lr = (LineReader)reader;

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -640,10 +640,10 @@ public final class Console implements Flushable
                 return null;
             }
 
-            public Charset charset() {
+            public Charset charset(Console c) {
                 // This method is called in sun.security.util.Password,
                 // cons already exists when this method is called
-                return cons.cs;
+                return c.cs;
             }
             public Optional<Console> passwordConsole() {
                 return Console.passwordConsole();

--- a/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 
 public interface JavaIOAccess {
     public Console console();
-    public Charset charset();
+    public Charset charset(Console c);
     public Optional<Console> passwordConsole();
     public char[] readPasswordNoNewLine(Console c);
 }

--- a/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,11 @@ package jdk.internal.misc;
 
 import java.io.Console;
 import java.nio.charset.Charset;
+import java.util.Optional;
 
 public interface JavaIOAccess {
     public Console console();
     public Charset charset();
+    public Optional<Console> passwordConsole();
+    public char[] readPasswordNoNewLine(Console c);
 }

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -152,11 +152,12 @@ public class Password {
             Charset charset;
             if (c1 != null) {
                 c2 = null;
-                charset = c1.charset();
+                charset = SharedSecrets.getJavaIOAccess().charset(c1);
             } else {
                 c2 = SharedSecrets.getJavaIOAccess().passwordConsole()
                         .orElse(null);
-                charset = (c2 != null) ? c2.charset() : null;
+                charset = (c2 != null)
+                    ? SharedSecrets.getJavaIOAccess().charset(c2) : null;
             }
             enc = charset == null ? null : charset.newEncoder()
                     .onMalformedInput(CodingErrorAction.REPLACE)

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import jdk.internal.misc.SharedSecrets;
 
 /**
  * A utility class for reading passwords
- *
  */
 public class Password {
     /** Reads user password from given input stream. */
@@ -50,29 +49,36 @@ public class Password {
 
         char[] consoleEntered = null;
         byte[] consoleBytes = null;
+        char[] buf = null;
 
         try {
             // Use the new java.io.Console class
-            Console con = null;
-            if (!isEchoOn && in == System.in && ((con = System.console()) != null)) {
-                consoleEntered = con.readPassword();
-                // readPassword returns "" if you just print ENTER,
-                // to be compatible with old Password class, change to null
-                if (consoleEntered != null && consoleEntered.length == 0) {
-                    return null;
+            if (!isEchoOn) {
+                if (in == System.in
+                        && ConsoleHolder.consoleIsAvailable()) {
+                    consoleEntered = ConsoleHolder.readPassword();
+                    // readPassword might return null. Stop now.
+                    if (consoleEntered == null) {
+                        return null;
+                    }
+                    consoleBytes = ConsoleHolder.convertToBytes(consoleEntered);
+                    in = new ByteArrayInputStream(consoleBytes);
+                } else if (System.in.available() == 0) {
+                    // This may be running in an IDE Run Window or in JShell,
+                    // which acts like an interactive console and echoes the
+                    // entered password. In this case, print a warning that
+                    // the password might be echoed. If available() is not zero,
+                    // it's more likely the input comes from a pipe, such as
+                    // "echo password |" or "cat password_file |" where input
+                    // will be silently consumed without echoing to the screen.
+                    System.err.print(ResourcesMgr.getString
+                            ("warning.input.may.be.visible.on.screen"));
                 }
-                consoleBytes = convertToBytes(consoleEntered);
-                in = new ByteArrayInputStream(consoleBytes);
             }
 
             // Rest of the lines still necessary for KeyStoreLoginModule
             // and when there is no console.
-
-            char[] lineBuffer;
-            char[] buf;
-            int i;
-
-            buf = lineBuffer = new char[128];
+            buf = new char[128];
 
             int room = buf.length;
             int offset = 0;
@@ -100,11 +106,11 @@ public class Password {
                     /* fall through */
                   default:
                     if (--room < 0) {
+                        char[] oldBuf = buf;
                         buf = new char[offset + 128];
                         room = buf.length - offset - 1;
-                        System.arraycopy(lineBuffer, 0, buf, 0, offset);
-                        Arrays.fill(lineBuffer, ' ');
-                        lineBuffer = buf;
+                        System.arraycopy(oldBuf, 0, buf, 0, offset);
+                        Arrays.fill(oldBuf, ' ');
                     }
                     buf[offset++] = (char) c;
                     break;
@@ -117,8 +123,6 @@ public class Password {
 
             char[] ret = new char[offset];
             System.arraycopy(buf, 0, ret, 0, offset);
-            Arrays.fill(buf, ' ');
-
             return ret;
         } finally {
             if (consoleEntered != null) {
@@ -127,35 +131,74 @@ public class Password {
             if (consoleBytes != null) {
                 Arrays.fill(consoleBytes, (byte)0);
             }
+            if (buf != null) {
+                Arrays.fill(buf, ' ');
+            }
         }
     }
 
-    /**
-     * Change a password read from Console.readPassword() into
-     * its original bytes.
-     *
-     * @param pass a char[]
-     * @return its byte[] format, similar to new String(pass).getBytes()
-     */
-    private static byte[] convertToBytes(char[] pass) {
-        if (enc == null) {
-            synchronized (Password.class) {
-                enc = SharedSecrets.getJavaIOAccess()
-                        .charset()
-                        .newEncoder()
-                        .onMalformedInput(CodingErrorAction.REPLACE)
-                        .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    // Everything on Console is inside this class.
+    private static class ConsoleHolder {
+
+        // primary console; may be null
+        private static final Console c1;
+        // secondary console (when stdout is redirected); may be null
+        private static final Console c2;
+        // encoder for c1 or c2
+        private static final CharsetEncoder enc;
+
+        static {
+            c1 = System.console();
+            Charset charset;
+            if (c1 != null) {
+                c2 = null;
+                charset = c1.charset();
+            } else {
+                c2 = SharedSecrets.getJavaIOAccess().passwordConsole()
+                        .orElse(null);
+                charset = (c2 != null) ? c2.charset() : null;
+            }
+            enc = charset == null ? null : charset.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        }
+
+        public static boolean consoleIsAvailable() {
+            return c1 != null || c2 != null;
+        }
+
+        public static char[] readPassword() {
+            assert consoleIsAvailable();
+            if (c1 != null) {
+                return c1.readPassword();
+            } else {
+                try {
+                    return SharedSecrets.getJavaIOAccess()
+                            .readPasswordNoNewLine(c2);
+                } finally {
+                    System.err.println();
+                }
             }
         }
-        byte[] ba = new byte[(int)(enc.maxBytesPerChar() * pass.length)];
-        ByteBuffer bb = ByteBuffer.wrap(ba);
-        synchronized (enc) {
-            enc.reset().encode(CharBuffer.wrap(pass), bb, true);
+
+        /**
+         * Convert a password read from console into its original bytes.
+         *
+         * @param pass a char[]
+         * @return its byte[] format, equivalent to new String(pass).getBytes()
+         *      but String is immutable and cannot be cleaned up.
+         */
+        public static byte[] convertToBytes(char[] pass) {
+            assert consoleIsAvailable();
+            byte[] ba = new byte[(int) (enc.maxBytesPerChar() * pass.length)];
+            ByteBuffer bb = ByteBuffer.wrap(ba);
+            synchronized (enc) {
+                enc.reset().encode(CharBuffer.wrap(pass), bb, true);
+            }
+            if (bb.remaining() > 0) {
+                bb.put((byte)'\n'); // will be recognized as a stop sign
+            }
+            return ba;
         }
-        if (bb.position() < ba.length) {
-            ba[bb.position()] = '\n';
-        }
-        return ba;
     }
-    private static volatile CharsetEncoder enc;
 }

--- a/src/java.base/share/classes/sun/security/util/Resources.java
+++ b/src/java.base/share/classes/sun/security/util/Resources.java
@@ -150,6 +150,10 @@ public class Resources extends java.util.ListResourceBundle {
         // sun.security.pkcs11.SunPKCS11
         {"PKCS11.Token.providerName.Password.",
                 "PKCS11 Token [{0}] Password: "},
+
+        // sun.security.util.Password
+        {"warning.input.may.be.visible.on.screen",
+                "[WARNING: Input may be visible on screen]\u0020"},
     };
 
 

--- a/src/java.base/unix/native/libjava/Console_md.c
+++ b/src/java.base/unix/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,21 @@
 #include <unistd.h>
 #include <termios.h>
 
-JNIEXPORT jboolean JNICALL
-Java_java_io_Console_istty(JNIEnv *env, jclass cls)
+JNIEXPORT jint JNICALL
+Java_java_io_Console_ttyStatus(JNIEnv *env, jclass cls)
 {
-    return isatty(fileno(stdin)) && isatty(fileno(stdout));
+    jint ret = 0;
+
+    if (isatty(fileno(stdin))) {
+        ret |= java_io_Console_TTY_STDIN_MASK;
+    }
+    if (isatty(fileno(stdout))) {
+        ret |= java_io_Console_TTY_STDOUT_MASK;
+    }
+    if (isatty(fileno(stderr))) {
+        ret |= java_io_Console_TTY_STDERR_MASK;
+    }
+    return ret;
 }
 
 JNIEXPORT jstring JNICALL

--- a/src/java.base/windows/native/libjava/Console_md.c
+++ b/src/java.base/windows/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,23 +31,30 @@
 #include <stdlib.h>
 #include <Wincon.h>
 
-static HANDLE hStdOut = INVALID_HANDLE_VALUE;
-static HANDLE hStdIn = INVALID_HANDLE_VALUE;
-JNIEXPORT jboolean JNICALL
-Java_java_io_Console_istty(JNIEnv *env, jclass cls)
+JNIEXPORT jint JNICALL
+Java_java_io_Console_ttyStatus(JNIEnv *env, jclass cls)
 {
-    if (hStdIn == INVALID_HANDLE_VALUE &&
-        (hStdIn = GetStdHandle(STD_INPUT_HANDLE)) == INVALID_HANDLE_VALUE) {
-        return JNI_FALSE;
+    jint ret = 0;
+    HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
+    HANDLE hStdErr = GetStdHandle(STD_ERROR_HANDLE);
+
+    if (hStdIn != INVALID_HANDLE_VALUE &&
+        GetFileType(hStdIn) == FILE_TYPE_CHAR) {
+        ret |= java_io_Console_TTY_STDIN_MASK;
     }
-    if (hStdOut == INVALID_HANDLE_VALUE &&
-        (hStdOut = GetStdHandle(STD_OUTPUT_HANDLE)) == INVALID_HANDLE_VALUE) {
-        return JNI_FALSE;
+
+    if (hStdOut != INVALID_HANDLE_VALUE &&
+        GetFileType(hStdOut) == FILE_TYPE_CHAR) {
+        ret |= java_io_Console_TTY_STDOUT_MASK;
     }
-    if (GetFileType(hStdIn) != FILE_TYPE_CHAR ||
-        GetFileType(hStdOut) != FILE_TYPE_CHAR)
-        return JNI_FALSE;
-    return JNI_TRUE;
+
+    if (hStdErr != INVALID_HANDLE_VALUE &&
+        GetFileType(hStdErr) == FILE_TYPE_CHAR) {
+        ret |= java_io_Console_TTY_STDERR_MASK;
+    }
+
+    return ret;
 }
 
 JNIEXPORT jstring JNICALL
@@ -67,6 +74,7 @@ Java_java_io_Console_echo(JNIEnv *env, jclass cls, jboolean on)
 {
     DWORD fdwMode;
     jboolean old;
+    HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
     if (! GetConsoleMode(hStdIn, &fdwMode)) {
         JNU_ThrowIOExceptionWithLastError(env, "GetConsoleMode failed");
         return !on;

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354469
+ * @summary keytool password does not echo in multiple cases
+ * @library /java/awt/regtesthelpers
+ * @modules java.base/jdk.internal.util
+ * @build PassFailJFrame
+ * @compile -encoding UTF-8 EchoPassword.java
+ * @run main/manual/othervm EchoPassword
+ */
+
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
+import javax.swing.event.HyperlinkEvent;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.io.File;
+import java.nio.file.Path;
+
+public class EchoPassword {
+
+    static JLabel label;
+
+    public static void main(String[] args) throws Exception {
+
+        var ks1 = "\"" + Path.of("8354469.ks1").toAbsolutePath() + "\"";
+        var ks2 = "\"" + Path.of("8354469.ks2").toAbsolutePath() + "\"";
+        var ks3 = "\"" + Path.of("8354469.ks3").toAbsolutePath() + "\"";
+
+        final String keytool = "\"" + System.getProperty("java.home")
+                + File.separator + "bin" + File.separator + "keytool\"";
+        final String nonASCII = "äöäöäöäö";
+
+        final String[][] commands = {
+                // Input password from real Console
+                {"First command", keytool + " -keystore " + ks1
+                        + " -genkeypair -keyalg ec -dname cn=a -alias first"},
+                // Input password from limited Console (when stdout is redirected)
+                {"Second command", keytool + " -keystore " + ks2
+                        + " -genkeypair -keyalg ec -dname cn=b -alias second | sort"},
+                // Input password from System.in stream
+                {"Third command", "echo changeit| " + keytool + " -keystore " + ks1
+                        + " -genkeypair -keyalg ec -dname cn=c -alias third"},
+                // Ensure limited Console does not write a newline to System.out
+                {"Fourth command", keytool + " -keystore " + ks1
+                        + " -exportcert -alias first | "
+                        + keytool + " -printcert -rfc"},
+                {"The password", nonASCII}
+        };
+
+        final String message = String.format("""
+                <html>Open a terminal or Windows Command Prompt window, perform
+                the following steps, and record the final result. Each time you
+                click a link to copy something, make sure the status line at the
+                bottom shows the link has been successfully clicked.
+                <h3>Part I: Password Echoing Tests</h3>
+                <ol>
+                <li>Click <a href='c0'>Copy First Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. When prompted
+                again, enter "changeit" again and press Enter. Verify that the
+                two password prompts show up on different lines, both
+                passwords are hidden, and a key pair is generated successfully.
+
+                <li>Click <a href='c1'>Copy Second Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. When prompted
+                again, enter "changeit" again and press Enter. Verify that the
+                two password prompts show up on different lines, both
+                passwords are hidden, and a key pair is generated successfully.
+
+                <li>Click <a href='c2'>Copy Third Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                You will see a prompt but you don't need to enter anything.
+                Verify that the password "changeit" is not shown in the command
+                output and a key pair is generated successfully.
+
+                <li>Click <a href='c3'>Copy Fourth Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. Verify that the
+                password is hidden and a PEM certificate is correctly shown.
+                </ol>
+                Press "pass" if the behavior matches expectations;
+                otherwise, press "fail".
+                """, commands[0][1], commands[1][1], commands[2][1], commands[3][1],
+                commands[4][1]);
+
+        PassFailJFrame.builder()
+                .instructions(message)
+                .rows(40).columns(100)
+                .hyperlinkListener(e -> {
+                    if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                        int pos = Integer.parseInt(e.getDescription().substring(1));
+                        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(
+                                new StringSelection(commands[pos][1]), null);
+                        label.setText(commands[pos][0] + " copied");
+                        if (e.getSource() instanceof JEditorPane ep) {
+                            ep.getCaret().setVisible(false);
+                        }
+                    }
+                })
+                .splitUIBottom(() -> {
+                    label = new JLabel("Status");
+                    return label;
+                })
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -72,57 +72,57 @@ public class EchoPassword {
                 {"The password", nonASCII}
         };
 
-        final String message = String.format("""
-                <html>Open a terminal or Windows Command Prompt window, perform
-                the following steps, and record the final result. Each time you
-                click a link to copy something, make sure the status line at the
-                bottom shows the link has been successfully clicked.
-                <h3>Part I: Password Echoing Tests</h3>
-                <ol>
-                <li>Click <a href='c0'>Copy First Command</a> to copy the
-                following command into the system clipboard. Paste it into the
-                terminal window and execute the command.
-                <p><code>
-                %s
-                </code><p>
-                When prompted, enter "changeit" and press Enter. When prompted
-                again, enter "changeit" again and press Enter. Verify that the
-                two password prompts show up on different lines, both
-                passwords are hidden, and a key pair is generated successfully.
-
-                <li>Click <a href='c1'>Copy Second Command</a> to copy the
-                following command into the system clipboard. Paste it into the
-                terminal window and execute the command.
-                <p><code>
-                %s
-                </code><p>
-                When prompted, enter "changeit" and press Enter. When prompted
-                again, enter "changeit" again and press Enter. Verify that the
-                two password prompts show up on different lines, both
-                passwords are hidden, and a key pair is generated successfully.
-
-                <li>Click <a href='c2'>Copy Third Command</a> to copy the
-                following command into the system clipboard. Paste it into the
-                terminal window and execute the command.
-                <p><code>
-                %s
-                </code><p>
-                You will see a prompt but you don't need to enter anything.
-                Verify that the password "changeit" is not shown in the command
-                output and a key pair is generated successfully.
-
-                <li>Click <a href='c3'>Copy Fourth Command</a> to copy the
-                following command into the system clipboard. Paste it into the
-                terminal window and execute the command.
-                <p><code>
-                %s
-                </code><p>
-                When prompted, enter "changeit" and press Enter. Verify that the
-                password is hidden and a PEM certificate is correctly shown.
-                </ol>
-                Press "pass" if the behavior matches expectations;
-                otherwise, press "fail".
-                """, commands[0][1], commands[1][1], commands[2][1], commands[3][1],
+        final String message = String.format(
+                "<html>Open a terminal or Windows Command Prompt window, perform" +
+                "the following steps, and record the final result. Each time you" +
+                "click a link to copy something, make sure the status line at the" +
+                "bottom shows the link has been successfully clicked." +
+                "<h3>Part I: Password Echoing Tests</h3>" +
+                "<ol>" +
+                "<li>Click <a href='c0'>Copy First Command</a> to copy the" +
+                "following command into the system clipboard. Paste it into the" +
+                "terminal window and execute the command." +
+                "<p><code>" +
+                "%s" +
+                "</code><p>" +
+                "When prompted, enter \"changeit\" and press Enter. When prompted" +
+                "again, enter \"changeit\" again and press Enter. Verify that the" +
+                "two password prompts show up on different lines, both" +
+                "passwords are hidden, and a key pair is generated successfully." +
+                "" +
+                "<li>Click <a href='c1'>Copy Second Command</a> to copy the" +
+                "following command into the system clipboard. Paste it into the" +
+                "terminal window and execute the command." +
+                "<p><code>" +
+                "%s" +
+                "</code><p>" +
+                "When prompted, enter \"changeit\" and press Enter. When prompted" +
+                "again, enter \"changeit\" again and press Enter. Verify that the" +
+                "two password prompts show up on different lines, both" +
+                "passwords are hidden, and a key pair is generated successfully." +
+                "" +
+                "<li>Click <a href='c2'>Copy Third Command</a> to copy the" +
+                "following command into the system clipboard. Paste it into the" +
+                "terminal window and execute the command." +
+                "<p><code>" +
+                "%s" +
+                "</code><p>" +
+                "You will see a prompt but you don't need to enter anything." +
+                "Verify that the password \"changeit\" is not shown in the command" +
+                "output and a key pair is generated successfully." +
+                "" +
+                "<li>Click <a href='c3'>Copy Fourth Command</a> to copy the" +
+                "following command into the system clipboard. Paste it into the" +
+                "terminal window and execute the command." +
+                "<p><code>" +
+                "%s" +
+                "</code><p>" +
+                "When prompted, enter \"changeit\" and press Enter. Verify that the" +
+                "password is hidden and a PEM certificate is correctly shown." +
+                "</ol>" +
+                "Press \"pass\" if the behavior matches expectations;" +
+                "otherwise, press \"fail\".",
+                commands[0][1], commands[1][1], commands[2][1], commands[3][1],
                 commands[4][1]);
 
         PassFailJFrame.builder()

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -33,7 +33,6 @@
  */
 
 import javax.swing.JEditorPane;
-import javax.swing.JLabel;
 import javax.swing.event.HyperlinkEvent;
 
 import java.awt.Toolkit;
@@ -42,8 +41,6 @@ import java.io.File;
 import java.nio.file.Path;
 
 public class EchoPassword {
-
-    static JLabel label;
 
     public static void main(String[] args) throws Exception {
 
@@ -126,10 +123,6 @@ public class EchoPassword {
         PassFailJFrame.builder()
                 .instructions(message)
                 .rows(40).columns(100)
-                .splitUIBottom(() -> {
-                    label = new JLabel("Status");
-                    return label;
-                })
                 .build()
                 .awaitAndCheck();
     }

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -74,54 +74,52 @@ public class EchoPassword {
 
         final String message = String.format(
                 "<html>Open a terminal or Windows Command Prompt window, perform" +
-                "the following steps, and record the final result. Each time you" +
-                "click a link to copy something, make sure the status line at the" +
-                "bottom shows the link has been successfully clicked." +
+                " the following steps, and record the final result." +
                 "<h3>Part I: Password Echoing Tests</h3>" +
                 "<ol>" +
-                "<li>Click <a href='c0'>Copy First Command</a> to copy the" +
-                "following command into the system clipboard. Paste it into the" +
-                "terminal window and execute the command." +
+                "<li>Copy the" +
+                " following command into the system clipboard. Paste it into the" +
+                " terminal window and execute the command." +
                 "<p><code>" +
                 "%s" +
                 "</code><p>" +
                 "When prompted, enter \"changeit\" and press Enter. When prompted" +
-                "again, enter \"changeit\" again and press Enter. Verify that the" +
-                "two password prompts show up on different lines, both" +
-                "passwords are hidden, and a key pair is generated successfully." +
+                " again, enter \"changeit\" again and press Enter. Verify that the" +
+                " two password prompts show up on different lines, both" +
+                " passwords are hidden, and a key pair is generated successfully." +
                 "" +
-                "<li>Click <a href='c1'>Copy Second Command</a> to copy the" +
-                "following command into the system clipboard. Paste it into the" +
-                "terminal window and execute the command." +
+                "<li>Copy the" +
+                " following command into the system clipboard. Paste it into the" +
+                " terminal window and execute the command." +
                 "<p><code>" +
                 "%s" +
                 "</code><p>" +
                 "When prompted, enter \"changeit\" and press Enter. When prompted" +
-                "again, enter \"changeit\" again and press Enter. Verify that the" +
-                "two password prompts show up on different lines, both" +
-                "passwords are hidden, and a key pair is generated successfully." +
+                " again, enter \"changeit\" again and press Enter. Verify that the" +
+                " two password prompts show up on different lines, both" +
+                " passwords are hidden, and a key pair is generated successfully." +
                 "" +
-                "<li>Click <a href='c2'>Copy Third Command</a> to copy the" +
-                "following command into the system clipboard. Paste it into the" +
-                "terminal window and execute the command." +
+                "<li>Copy the" +
+                " following command into the system clipboard. Paste it into the" +
+                " terminal window and execute the command." +
                 "<p><code>" +
                 "%s" +
                 "</code><p>" +
                 "You will see a prompt but you don't need to enter anything." +
-                "Verify that the password \"changeit\" is not shown in the command" +
-                "output and a key pair is generated successfully." +
+                " Verify that the password \"changeit\" is not shown in the command" +
+                " output and a key pair is generated successfully." +
                 "" +
-                "<li>Click <a href='c3'>Copy Fourth Command</a> to copy the" +
-                "following command into the system clipboard. Paste it into the" +
-                "terminal window and execute the command." +
+                "<li>Copy the" +
+                " following command into the system clipboard. Paste it into the" +
+                " terminal window and execute the command." +
                 "<p><code>" +
                 "%s" +
                 "</code><p>" +
                 "When prompted, enter \"changeit\" and press Enter. Verify that the" +
-                "password is hidden and a PEM certificate is correctly shown." +
+                " password is hidden and a PEM certificate is correctly shown." +
                 "</ol>" +
                 "Press \"pass\" if the behavior matches expectations;" +
-                "otherwise, press \"fail\".",
+                " otherwise, press \"fail\".",
                 commands[0][1], commands[1][1], commands[2][1], commands[3][1],
                 commands[4][1]);
 

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -128,17 +128,6 @@ public class EchoPassword {
         PassFailJFrame.builder()
                 .instructions(message)
                 .rows(40).columns(100)
-                .hyperlinkListener(e -> {
-                    if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-                        int pos = Integer.parseInt(e.getDescription().substring(1));
-                        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(
-                                new StringSelection(commands[pos][1]), null);
-                        label.setText(commands[pos][0] + " copied");
-                        if (e.getSource() instanceof JEditorPane ep) {
-                            ep.getCaret().setVisible(false);
-                        }
-                    }
-                })
                 .splitUIBottom(() -> {
                     label = new JLabel("Status");
                     return label;

--- a/test/jdk/sun/security/tools/keytool/SetInPassword.java
+++ b/test/jdk/sun/security/tools/keytool/SetInPassword.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354469
+ * @summary ensure password can be read from user's System.in
+ * @library /test/lib
+ * @modules java.base/sun.security.tools.keytool
+ */
+
+import jdk.test.lib.SecurityTools;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class SetInPassword {
+    public static void main(String[] args) throws Exception {
+        SecurityTools.keytool("-keystore ks -storepass changeit -genkeypair -alias a -dname CN=A -keyalg EC")
+                .shouldHaveExitValue(0);
+        System.setIn(new ByteArrayInputStream("changeit".getBytes(StandardCharsets.UTF_8)));
+        sun.security.tools.keytool.Main.main("-keystore ks -alias a -certreq".split(" "));
+    }
+}


### PR DESCRIPTION
This pull request backports:

`8354469: Keytool exposes the password in plain text when command is piped using | grep`

It depends on pull request #3232 which backports:

`8366261: Provide utility methods for sun.security.util.Password`

Starting from the backport of 8354469 to 17, I made the following adjustments:

Console.java:

- Its change applied with a minor line offset, looks fine.

Password.java:

- Adjust copyright year

- 17 renamed "misc" to "access" in "import jdk.internal.access.SharedSecrets;" as part of:

  8211122: Reduce the number of internal classes made accessible to jdk.unsupported

  so skip that.

- 17 then removed "import jdk.internal.access.SharedSecrets;" and called "System.console().charset()" directly instead of via SharedSecrets as part of:

  8264208: Console charset API

  which was never backported, so skip that and continue using SharedSecrets.

- 17 re-added "import jdk.internal.access.SharedSecrets;" as part of:

  8354469: Keytool exposes the password in plain text when command is piped using | grep

  to be able to call passwordConsole and readPasswordNoNewLine, so again, I just keep "import jdk.internal.misc.SharedSecrets;" constant in 11

- 11 does not have Console.charset, so modify the JavaIOAccess interface to accept a Console argument which returns the value of the passed console's private charset (`cs`) field.

SetInPassword.java:

- Fine as-is, passes.

EchoPassword.java:

- Change to use traditional multiline-string syntax since 11 does not support `"""` multiline strings; update message whitespace

- Remove support for the convenience "Copy Command" hyperlinks since hyperlinkListener support is not available in 11; update message accordingly

  I did briefly try to maintain these links and status label, but it would have required first backporting:

  `8367348: Enhance PassFailJFrame to support links in HTML`

  which did not apply cleanly to 11, so I decided to simplify the test instead.

- Remove the now-unused status label

Usages.java:

- Drop test/jdk/sun/security/util/Resources/Usages.java changes since
  that file does not exist in 11

The new `SetInPassword.java` test passes and with the modifications herein, the `EchoPassword.java` also passes.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8354469](https://bugs.openjdk.org/browse/JDK-8354469) needs maintainer approval

### Issue
 * [JDK-8354469](https://bugs.openjdk.org/browse/JDK-8354469): Keytool exposes the password in plain text when command is piped using | grep (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3233/head:pull/3233` \
`$ git checkout pull/3233`

Update a local copy of the PR: \
`$ git checkout pull/3233` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3233`

View PR using the GUI difftool: \
`$ git pr show -t 3233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3233.diff">https://git.openjdk.org/jdk11u-dev/pull/3233.diff</a>

</details>
