### PR TITLE
8334502: gtest/GTestWrapper.java fails on armhf due to LogDecorations.iso8601_utctime_test

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -188,9 +188,9 @@ char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
     abs_local_to_UTC = -(abs_local_to_UTC);
   }
   // Convert time zone offset seconds to hours and minutes.
-  const time_t zone_hours = (abs_local_to_UTC / seconds_per_hour);
-  const time_t zone_min =
-    ((abs_local_to_UTC % seconds_per_hour) / seconds_per_minute);
+  const int zone_hours = static_cast<int>(abs_local_to_UTC / seconds_per_hour);
+  const int zone_min =
+    static_cast<int>((abs_local_to_UTC % seconds_per_hour) / seconds_per_minute);
 
   // Print an ISO 8601 date and time stamp into the buffer
   const int year = 1900 + time_struct.tm_year;


### PR DESCRIPTION
Backporting JDK-8334502: gtest/GTestWrapper.java fails on armhf due to LogDecorations.iso8601_utctime_test. Adjusts casting from time_t to int. Ran GHA Sanity Checks and previously failing gtest test (and full suite). Ran tier 1 and tier 2 tests. Patch is clean.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8334502](https://bugs.openjdk.org/browse/JDK-8334502) needs maintainer approval

### Issue
 * [JDK-8334502](https://bugs.openjdk.org/browse/JDK-8334502): gtest/GTestWrapper.java fails on armhf due to LogDecorations.iso8601_utctime_test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3236/head:pull/3236` \
`$ git checkout pull/3236`

Update a local copy of the PR: \
`$ git checkout pull/3236` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3236`

View PR using the GUI difftool: \
`$ git pr show -t 3236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3236.diff">https://git.openjdk.org/jdk11u-dev/pull/3236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3236#issuecomment-4907299083)
</details>
