### PR TITLE
8283562: JDK-8282306 breaks gtests on zero

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -347,7 +347,7 @@ TEST_VM(os, jio_snprintf) {
 }
 
 TEST_VM(os, is_first_C_frame) {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(ZERO)
   frame invalid_frame;
   EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values
 


### PR DESCRIPTION
Backporting JDK-8283562: JDK-8282306 breaks gtests on zero. Fixes test by skipping on platforms where we expect/know os::current_frame() will be zero (such as armv7). Trivial backport, only touches test code and adds additional disabling condition.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8283562](https://bugs.openjdk.org/browse/JDK-8283562) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8283562](https://bugs.openjdk.org/browse/JDK-8283562): JDK-8282306 breaks gtests on zero (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3237/head:pull/3237` \
`$ git checkout pull/3237`

Update a local copy of the PR: \
`$ git checkout pull/3237` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3237`

View PR using the GUI difftool: \
`$ git pr show -t 3237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3237.diff">https://git.openjdk.org/jdk11u-dev/pull/3237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3237#issuecomment-4907432332)
</details>
