### PR TITLE
8365861: test/jdk/sun/security/pkcs11/Provider/ tests skipped without SkippedException

### DIFF
--- a/test/jdk/sun/security/pkcs11/Provider/Absolute.java
+++ b/test/jdk/sun/security/pkcs11/Provider/Absolute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  * @summary load DLLs and launch executables using fully qualified path
  */
 
+import jtreg.SkippedException;
+
 import java.security.InvalidParameterException;
 import java.security.Provider;
 
@@ -40,12 +42,11 @@ public class Absolute {
         try {
             Provider p = PKCS11Test.getSunPKCS11(config);
             if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
+                throw new SkippedException("Skipping test - no PKCS11 provider available");
             }
         } catch (InvalidParameterException ipe) {
             Throwable ex = ipe.getCause();
-            if (ex.getMessage().indexOf(
-                    "Absolute path required for library value:") != -1) {
+            if (ex.getMessage().contains("Absolute path required for library value:")) {
                 System.out.println("Test Passed: expected exception thrown");
             } else {
                 // rethrow

--- a/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
+++ b/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
@@ -52,7 +52,7 @@ public class ConfigShortPath {
             // re-try w/ SunPKCS11-Solaris
             p = Security.getProvider("SunPKCS11-Solaris");
             if (p == null) {
-				throw new SkippedException("Skipping test - no PKCS11 provider available");
+                throw new SkippedException("Skipping test - no PKCS11 provider available");
             }
         }
 

--- a/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
+++ b/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,17 @@
  * @bug 6581254 6986789 7196009 8062170
  * @summary Allow '~', '+', and quoted paths in config file
  * @author Valerie Peng
+ * @library /test/lib
  */
 
-import java.security.*;
-import java.io.*;
-import java.lang.reflect.*;
+import jtreg.SkippedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.security.Provider;
+import java.security.ProviderException;
+import java.security.Security;
 
 public class ConfigShortPath {
 
@@ -46,8 +52,7 @@ public class ConfigShortPath {
             // re-try w/ SunPKCS11-Solaris
             p = Security.getProvider("SunPKCS11-Solaris");
             if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
-                return;
+				throw new SkippedException("Skipping test - no PKCS11 provider available");
             }
         }
 
@@ -69,7 +74,7 @@ public class ConfigShortPath {
                 if (cause.getClass().getName().equals
                         ("sun.security.pkcs11.ConfigurationException")) {
                     // Error occurred during parsing
-                    if (cause.getMessage().indexOf("Unexpected") != -1) {
+                    if (cause.getMessage().contains("Unexpected")) {
                         throw (ProviderException) cause;
                     }
                 }

--- a/test/jdk/sun/security/pkcs11/Provider/LoginISE.java
+++ b/test/jdk/sun/security/pkcs11/Provider/LoginISE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,16 +21,22 @@
  * questions.
  */
 
-import java.io.*;
-import java.util.*;
-import java.security.*;
-import javax.security.auth.callback.*;
+import jtreg.SkippedException;
+
+import java.io.IOException;
+import java.security.AuthProvider;
+import java.security.Provider;
+import java.security.Security;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * @test
  * @bug 8130648
  * @summary make sure IllegalStateException is thrown for uninitialized
  * SunPKCS11 provider instance
+ * @library /test/lib
  */
 public class LoginISE {
 
@@ -38,8 +44,7 @@ public class LoginISE {
 
         Provider p = Security.getProvider("SunPKCS11");
         if (p == null) {
-            System.out.println("No un-initialized PKCS11 provider available; skip");
-            return;
+            throw new SkippedException("No un-initialized PKCS11 provider available; skip");
         }
         if (!(p instanceof AuthProvider)) {
             throw new RuntimeException("Error: expect AuthProvider!");


### PR DESCRIPTION
Hi all,

I will backport DK-8365861 from JDK 26 to JDK 11 to address an issue where, when a SunPKCS11 provider is not available, tests would print a skipping message and return. This caused jtreg to misleadingly mark them as "Passed" because no explicit failure occurred. In other words, when PKCS#11 functionality was unavailable, the tests exited normally and were counted the same as successful tests, even though they did not actually verify any functionality.

This backport is mostly clean from JDK 17, but some manual fixes are required.

Unclean Backport
The backport of JDK-8365861 to JDK 11 is not straightforward because ConfigShortPath.java differs from the version targeted by the original fix. In particular, JDK 11 still contains Solaris-related code that was later removed in JDK 15 as part of JDK-8244224. Since that removal is not planned for backporting to JDK 11 or earlier releases, the affected sections of ConfigShortPath.java do not align cleanly with the upstream patch and require manual edits.

There are additional, similar PKCS#11 test improvements in newer releases, but we plan to backport those to JDK 11 separately and in due course.

Thank you.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] [JDK-8365861](https://bugs.openjdk.org/browse/JDK-8365861) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365861](https://bugs.openjdk.org/browse/JDK-8365861): test/jdk/sun/security/pkcs11/Provider/ tests skipped without SkippedException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3238/head:pull/3238` \
`$ git checkout pull/3238`

Update a local copy of the PR: \
`$ git checkout pull/3238` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3238`

View PR using the GUI difftool: \
`$ git pr show -t 3238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3238.diff">https://git.openjdk.org/jdk11u-dev/pull/3238.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3238#issuecomment-4925154876)
</details>
