### PR TITLE
8305481: gtest is_first_C_frame failing on ARM

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -347,7 +347,7 @@ TEST_VM(os, jio_snprintf) {
 }
 
 TEST_VM(os, is_first_C_frame) {
-#if !defined(_WIN32) && !defined(ZERO)
+#if !defined(_WIN32) && !defined(ZERO) && !defined(__thumb__)
   frame invalid_frame;
   EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values
 


### PR DESCRIPTION
Backporting "JDK-8305481: gtest is_first_C_frame failing on ARM". Skipping failing test for armv7 as done with newer major versions. Patch is clean and fairly trivial. Ran gtest suite and GHA for testing.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8305481](https://bugs.openjdk.org/browse/JDK-8305481) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8305481: gtest is_first_C_frame failing on ARM`

### Issue
 * [JDK-8305481](https://bugs.openjdk.org/browse/JDK-8305481): gtest is_first_C_frame failing on ARM (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3239/head:pull/3239` \
`$ git checkout pull/3239`

Update a local copy of the PR: \
`$ git checkout pull/3239` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3239`

View PR using the GUI difftool: \
`$ git pr show -t 3239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3239.diff">https://git.openjdk.org/jdk11u-dev/pull/3239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3239#issuecomment-4938031912)
</details>
