### PR TITLE
Documentation update for Windows Compiler minimum requirements.

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -201,7 +201,7 @@
 <p>The double version numbers for Linux, Solaris and macOS is due to the hybrid model used at Oracle, where header files and external libraries from an older version are used when building on a more modern version of the OS.</p>
 <p>The Build Group has a wiki page with <a href="https://wiki.openjdk.java.net/display/Build/Supported+Build+Platforms">Supported Build Platforms</a>. From time to time, this is updated by contributors to list successes or failures of building on different platforms.</p>
 <h3 id="windows">Windows</h3>
-<p>Windows XP is not a supported platform, but all newer Windows should be able to build the JDK.</p>
+<p>Windows 7 Service Pack 1, Windows Server 2008 R2 Service Pack 1, and all newer Windows versions are supported. Keeping the system fully updated is recommended.</p>
 <p>On Windows, it is important that you pay attention to the instructions in the <a href="#special-considerations">Special Considerations</a>.</p>
 <p>Windows is the only non-POSIX OS supported by the JDK, and as such, requires some extra care. A POSIX support layer is required to build on Windows. Currently, the only supported such layers are Cygwin and MSYS2. (MSYS is no longer supported due to an outdated bash; While OpenJDK can be built with MSYS2, support for it is still experimental, so build failures and unusual errors are not uncommon.)</p>
 <p>Internally in the build system, all paths are represented as Unix-style paths, e.g. <code>/cygdrive/c/git/jdk/Makefile</code> rather than <code>C:\git\jdk\Makefile</code>. This rule also applies to input to the build system, e.g. in arguments to <code>configure</code>. So, use <code>--with-msvcr-dll=/cygdrive/c/msvcr100.dll</code> rather than <code>--with-msvcr-dll=c:\msvcr100.dll</code>. For details on this conversion, see the section on <a href="#fixpath">Fixpath</a>.</p>
@@ -376,9 +376,8 @@ cc: Sun C 5.13 SunOS_i386 2014/10/20
 $ CC -V
 CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <h3 id="microsoft-visual-studio">Microsoft Visual Studio</h3>
-<p>The minimum accepted version of Visual Studio is 2010. Older versions will not be accepted by <code>configure</code>. The maximum accepted version of Visual Studio is 2019. Versions older than 2017 are unlikely to continue working for long.</p>
-<p>If you have multiple versions of Visual Studio installed, <code>configure</code> will by default pick the latest. You can request a specific version to be used by setting <code>--with-toolchain-version</code>, e.g. <code>--with-toolchain-version=2015</code>.</p>
-<p>If you get <code>LINK: fatal error LNK1123: failure during conversion to COFF: file invalid</code> when building using Visual Studio 2010, you have encountered <a href="http://support.microsoft.com/kb/2757355">KB2757355</a>, a bug triggered by a specific installation order. However, the solution suggested by the KB article does not always resolve the problem. See <a href="https://stackoverflow.com/questions/10888391">this stackoverflow discussion</a> for other suggestions.</p>
+<p>The minimum accepted version of Visual Studio is 2017 (version 15.8). Older versions will not be accepted by <code>configure</code>. The maximum accepted version of Visual Studio is 2022. Versions older than 2017 are unlikely to continue working for long.</p>
+<p>If you have multiple versions of Visual Studio installed, <code>configure</code> will by default pick the latest. You can request a specific version to be used by setting <code>--with-toolchain-version</code>, e.g. <code>--with-toolchain-version=2017</code>.</p>
 <p>If you have Visual Studio installed but <code>configure</code> fails to detect it, it may be because of <a href="#spaces-in-path">spaces in path</a>.</p>
 <h3 id="ibm-xl-cc">IBM XL C/C++</h3>
 <p>The regular builds by SAP is using version 12.1, described as <code>IBM XL C/C++ for AIX, V12.1 (5765-J02, 5725-C72) Version: 12.01.0000.0017</code>.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -169,8 +169,10 @@ building on different platforms.
 
 ### Windows
 
-Windows XP is not a supported platform, but all newer Windows should be able to
-build the JDK.
+Windows 7 Service Pack 1, Windows Server 2008 R2 Service Pack 1, and all newer 
+Windows versions are supported. However, the minimum required Windows version 
+is usually determined by the compiler toolchain being used. Keeping the system 
+fully updated is recommended.
 
 On Windows, it is important that you pay attention to the instructions in the
 [Special Considerations](#special-considerations).
@@ -392,20 +394,14 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30
 
 ### Microsoft Visual Studio
 
-The minimum accepted version of Visual Studio is 2010. Older versions will not
-be accepted by `configure`. The maximum accepted version of Visual Studio is
-2019. Versions older than 2017 are unlikely to continue working for long.
+The minimum accepted version of Visual Studio is 2017 (version 15.8). 
+Older versions will not be accepted by `configure` or build successfully. 
+The maximum accepted version of Visual Studio is 2022. Versions older than 
+2017 are unlikely to continue working for long.
 
 If you have multiple versions of Visual Studio installed, `configure` will by
 default pick the latest. You can request a specific version to be used by
-setting `--with-toolchain-version`, e.g. `--with-toolchain-version=2015`.
-
-If you get `LINK: fatal error LNK1123: failure during conversion to COFF: file
-invalid` when building using Visual Studio 2010, you have encountered
-[KB2757355](http://support.microsoft.com/kb/2757355), a bug triggered by a
-specific installation order. However, the solution suggested by the KB article
-does not always resolve the problem. See [this stackoverflow discussion](
-https://stackoverflow.com/questions/10888391) for other suggestions.
+setting `--with-toolchain-version`, e.g. `--with-toolchain-version=2017`.
 
 If you have Visual Studio installed but `configure` fails to detect it, it may
 be because of [spaces in path](#spaces-in-path).


### PR DESCRIPTION
Hi, this is the backport of 12ef1bf016feedde349fb5c0cb7b5ea402a72afb

The latest jdk11-update with tag `jdk-11.0.32-ga` code failed to compile with Visual Studio 2010, Visual Studio 2012, Visual Studio 2013, Visual Studio 2015, Visual Studio 2017 (version 15.0-15.7), The minimum accepted version now is Visual Studio 2017 (version 15.8).

And due to this change for compiler, for Windows building, the minimum for Windows Build is Windows 7 Service Pack 1, or Windows Server 2008 R2 Service Pack 1. Due to the Visual Studio Complier needs at least IE 11 and the later Visual Studio 2017.

Here is the detail build failure for these version.

- for Visual Studio 2010, Visual Studio 2012, it reports that it lacks the <inttypes.h> header.
- for Visual Studio 2013, Visual Studio 2015(Bundled with Windows SDK 8.1), it reports that the macro lacks `IMAGE_FILE_MACHINE_ARM64`, `PROCESSOR_ARCHITECTURE_ARM64`, these macros actually introduces with Windows SDK 10.0.
- for Visual Studio 2017, version 15.0-15.4, it reports with that nothing generated ..... and exit.
- for Visual Studio 2017, version 15.5-15.7, it reports that 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'....

> full build failure for Visual Studio 2015 (with Windows SDK 10.0), Visual Studio 2017, version 15.0-15.4:
```txt
=== Output from failing command(s) repeated here ===
* For target hotspot_variant-server_libjvm_objs_BUILD_LIBJVM_pch.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
BUILD_LIBJVM_pch.cpp
c:\progra~2\micros~1\2017\buildt~1\vc\tools\msvc\1411~1.255\include\type_traits(2342): error C2220: warning treated as error - no 'object' file generated
c:\progra~2\micros~1\2017\buildt~1\vc\tools\msvc\1411~1.255\include\type_traits(2342): warning C4577: 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc
   ... (rest of output omitted)

* All command lines available in /cygdrive/c/jdk11u/build/windows-x86_64-normal-server-release/make-support/failure-logs.
```

> full build failure for Visual Studio 2017 15.5.0-15.7.0: 
```text
ERROR: Build failed for target 'jdk-image' in configuration 'windows-x86_64-normal-server-release' (exit code 2)
Stopping sjavac server

=== Output from failing command(s) repeated here ===
* For target support_native_java.desktop_libfontmanager_VARC.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
VARC.cc
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(93): note: see declaration of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(183): note: see reference to class template instantiation 'hb_vector_t<hb_ot_map_t::stage_map_t,false>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_builder_t::stage_info_t'
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-aat-layout.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
hb-aat-layout.cc
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(93): note: see declaration of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(183): note: see reference to class template instantiation 'hb_vector_t<hb_ot_map_t::stage_map_t,false>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_builder_t::stage_info_t'
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-aat-map.obj:
hb-aat-map.cc
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_aat_map_t::range_flags_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-aat-map.hh(39): note: see declaration of 'hb_aat_map_t::range_flags_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(49): note: see reference to class template instantiation 'hb_vector_t<hb_aat_map_t::range_flags_t,true>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-aat-map.hh(46): note: see reference to class template instantiation 'hb_vector_t<hb_vector_t<hb_aat_map_t::range_flags_t,true>,false>' being compiled
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-blob.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
hb-blob.cc
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-buffer-serialize.obj:
hb-buffer-serialize.cc
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-buffer-verify.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
hb-buffer-verify.cc
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2825: 'Type': must be a class or namespace when followed by '::'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-buffer-verify.cc(405): note: see reference to class template instantiation 'hb_vector_t<char,false>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2510: 'Type': left of '::' must be a class/struct/union
   ... (rest of output omitted)
* For target support_native_java.desktop_libfontmanager_hb-buffer.obj:
cl : Command line warning D9002 : ignoring unknown option '-pathmap:c:\jdk11u=s'
cl : Command line warning D9002 : ignoring unknown option '-experimental:deterministic'
hb-buffer.cc
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(162): note: see declaration of 'hb_user_data_array_t::hb_user_data_item_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(48): note: see reference to class template instantiation 'hb_vector_t<item_t,false>' being compiled
        with
        [
            item_t=hb_user_data_array_t::hb_user_data_item_t
        ]
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-object.hh(174): note: see reference to class template instantiation 'hb_lockable_set_t<hb_user_data_array_t::hb_user_data_item_t,hb_mutex_t>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(93): note: see declaration of 'hb_ot_map_t::stage_map_t'
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-ot-map.hh(183): note: see reference to class template instantiation 'hb_vector_t<hb_ot_map_t::stage_map_t,false>' being compiled
c:\jdk11u\src\java.desktop\share\native\libharfbuzz\hb-vector.hh(674): error C2039: 'cmp': is not a member of 'hb_ot_map_builder_t::stage_info_t'
   ... (rest of output omitted)

* All command lines available in /cygdrive/c/jdk11u/build/windows-x86_64-normal-server-release/make-support/failure-logs.
```




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3245/head:pull/3245` \
`$ git checkout pull/3245`

Update a local copy of the PR: \
`$ git checkout pull/3245` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3245`

View PR using the GUI difftool: \
`$ git pr show -t 3245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3245.diff">https://git.openjdk.org/jdk11u-dev/pull/3245.diff</a>

</details>
