### PR TITLE
8322135: Printing JTable in Windows L&F throws InternalError: HTHEME is null

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,19 +107,28 @@ public final class ThemeReader {
         return xpStyleEnabled;
     }
 
-    private static Long openThemeImpl(String widget, int dpi) {
-       Long theme;
+    private static long openThemeImpl(String widget, int dpi) {
+       long theme;
        int i = widget.indexOf("::");
        if (i > 0) {
            // We're using the syntax "subAppName::controlName" here, as used by msstyles.
            // See documentation for SetWindowTheme on MSDN.
            setWindowTheme(widget.substring(0, i));
-           theme = openTheme(widget.substring(i + 2), dpi);
+           theme = getOpenThemeValue(widget.substring(i + 2), dpi);
            setWindowTheme(null);
        } else {
-           theme = openTheme(widget, dpi);
+           theme = getOpenThemeValue(widget, dpi);
        }
        return theme;
+    }
+
+    private static long getOpenThemeValue(String widget, int dpi) {
+        long theme;
+        theme = openTheme(widget, dpi);
+        if (theme == 0) {
+            theme = openTheme(widget, defaultDPI);
+        }
+        return theme;
     }
 
     // this should be called only with writeLock held


### PR DESCRIPTION
This is the backport of "JDK-8322135: Printing JTable in Windows L&F throws InternalError: HTHEME is null" to jdk11u-dev.

Backporting this as jdk11 is affected as well.

Backport is almost clean: 
- resolved a conflict with copyright year
- test files don't exist in jdk11, so I skipped the test files changes, as there were no functional changes there, only a bug number update

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8322135](https://bugs.openjdk.org/browse/JDK-8322135) needs maintainer approval

### Issue
 * [JDK-8322135](https://bugs.openjdk.org/browse/JDK-8322135): Printing JTable in Windows L&amp;F throws InternalError: HTHEME is null (**Bug** - P3 - Approved)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3246/head:pull/3246` \
`$ git checkout pull/3246`

Update a local copy of the PR: \
`$ git checkout pull/3246` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3246`

View PR using the GUI difftool: \
`$ git pr show -t 3246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3246.diff">https://git.openjdk.org/jdk11u-dev/pull/3246.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3246#issuecomment-5254708079)
</details>
