### PR TITLE
8357561: BootstrapLoggerTest does not work on Ubuntu 24 with LANG de_DE.UTF-8

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -376,10 +376,10 @@ public class BootstrapLoggerTest {
                 LogStream.err.println("Not checking executor termination for " + test);
             }
         } finally {
+            Locale.setDefault(savedLocale);
             SimplePolicy.allowAll.set(Boolean.FALSE);
         }
         LogStream.err.println(test.name() + ": PASSED");
-        Locale.setDefault(savedLocale);
     }
 
     final static class SimplePolicy extends Policy {

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -88,6 +89,8 @@ public class BootstrapLoggerTest {
     }
 
     public static void main(String[] args) throws Exception {
+        Locale savedLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
         if (args == null || args.length == 0) {
             args = new String[] { TestCase.SECURE_AND_WAIT.name() };
         }
@@ -376,6 +379,7 @@ public class BootstrapLoggerTest {
             SimplePolicy.allowAll.set(Boolean.FALSE);
         }
         LogStream.err.println(test.name() + ": PASSED");
+        Locale.setDefault(savedLocale);
     }
 
     final static class SimplePolicy extends Policy {

--- a/test/jdk/java/util/logging/LocalizedLevelName.java
+++ b/test/jdk/java/util/logging/LocalizedLevelName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ public class LocalizedLevelName {
     public static void main(String args[]) throws Exception {
         Locale defaultLocale = Locale.getDefault();
         for (int i=0; i<namesMap.length; i += 4) {
+            Locale.setDefault(Locale.US);
             final String key = (String) namesMap[i];
             final Locale locale = (Locale) namesMap[i+1];
             final String expectedTranslation = (String) namesMap[i+2];

--- a/test/jdk/java/util/logging/SimpleFormatterFormat.java
+++ b/test/jdk/java/util/logging/SimpleFormatterFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  */
 
 import java.io.*;
+import java.util.Locale;
 import java.util.logging.*;
 import java.util.regex.*;
 
@@ -38,6 +39,8 @@ public class SimpleFormatterFormat {
     private static final String origFormat = System.getProperty(key);
     private static final PrintStream err = System.err;
     public static void main(String[] args) throws Exception {
+        Locale savedLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
         try {
             File dir = new File(System.getProperty("user.dir", "."));
             File log = new File(dir, "simpleformat.txt");
@@ -53,7 +56,8 @@ public class SimpleFormatterFormat {
                 System.setProperty(key, origFormat);
             }
             System.setErr(err);
-       }
+        }
+        Locale.setDefault(savedLocale);
     }
 
     private static String[] loggers = new String[] {

--- a/test/jdk/sun/util/logging/SourceClassName.java
+++ b/test/jdk/sun/util/logging/SourceClassName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,17 +33,21 @@
  * @run main/othervm SourceClassName
  */
 
+import java.util.Locale;
 import java.util.logging.*;
 import java.io.*;
 import sun.util.logging.PlatformLogger;
 
 public class SourceClassName {
     public static void main(String[] args) throws Exception {
+        Locale savedLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
         File dir = new File(System.getProperty("user.dir", "."));
         File log = new File(dir, "testlog.txt");
         PrintStream logps = new PrintStream(log);
         writeLogRecords(logps);
         checkLogRecords(log);
+        Locale.setDefault(savedLocale);
     }
 
     private static void writeLogRecords(PrintStream logps) throws Exception {


### PR DESCRIPTION
I backport this for parity with 11.0.30-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8357561](https://bugs.openjdk.org/browse/JDK-8357561) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8357561](https://bugs.openjdk.org/browse/JDK-8357561): BootstrapLoggerTest does not work on Ubuntu 24 with LANG de_DE.UTF-8 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3247/head:pull/3247` \
`$ git checkout pull/3247`

Update a local copy of the PR: \
`$ git checkout pull/3247` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3247`

View PR using the GUI difftool: \
`$ git pr show -t 3247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3247.diff">https://git.openjdk.org/jdk11u-dev/pull/3247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3247#issuecomment-5425907635)
</details>
