### PR TITLE
8241091: AArch64: "bad AD file" with VM option "-XX:-UsePopCountInstruction"

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -324,6 +324,11 @@ void VM_Version::initialize() {
   }
 
   if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
+    FLAG_SET_DEFAULT(UsePopCountInstruction, true);
+  }
+
+  if (!UsePopCountInstruction) {
+    warning("UsePopCountInstruction is always enabled on this CPU");
     UsePopCountInstruction = true;
   }
 


### PR DESCRIPTION
Clean backport.  Fix AArch64: "bad AD file" with VM option "-XX:-UsePopCountInstruction". Force the flag to be true on AArch64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8241091](https://bugs.openjdk.org/browse/JDK-8241091) needs maintainer approval

### Issue
 * [JDK-8241091](https://bugs.openjdk.org/browse/JDK-8241091): AArch64: "bad AD file" with VM option "-XX:-UsePopCountInstruction" (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3250/head:pull/3250` \
`$ git checkout pull/3250`

Update a local copy of the PR: \
`$ git checkout pull/3250` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3250`

View PR using the GUI difftool: \
`$ git pr show -t 3250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3250.diff">https://git.openjdk.org/jdk11u-dev/pull/3250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3250#issuecomment-5395597977)
</details>
