### PR TITLE
8380223: Refactor test/jdk/sun/util/resources TestNG tests to JUnit

### DIFF
--- a/test/jdk/sun/util/resources/TimeZone/Bug8139107.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug8139107.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,12 @@
  * @summary Test that date parsing with DateTimeFormatter pattern
  *   that contains timezone field doesn't trigger NPE. All supported
  *   locales are tested.
- * @run testng/othervm -Djava.locale.providers=JRE,SPI Bug8139107
+ * @run junit/othervm -Djava.locale.providers=JRE,SPI Bug8139107
  */
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import org.testng.annotations.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class Bug8139107 {
 

--- a/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
+++ b/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8275721
  * @modules jdk.localedata
  * @summary Checks Chinese time zone names for `UTC` using CLDR are consistent
- * @run testng/othervm -Djava.locale.providers=CLDR,COMPAT ChineseTimeZoneNameTest
- * @run testng/othervm -Djava.locale.providers=CLDR ChineseTimeZoneNameTest
+ * @run junit/othervm -Djava.locale.providers=CLDR,COMPAT ChineseTimeZoneNameTest
+ * @run junit/othervm -Djava.locale.providers=CLDR ChineseTimeZoneNameTest
  */
 
 import java.time.Instant;
@@ -36,11 +36,10 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Test
 public class ChineseTimeZoneNameTest {
 
     private static final Locale SIMPLIFIED_CHINESE = Locale.forLanguageTag("zh-Hans");
@@ -48,8 +47,7 @@ public class ChineseTimeZoneNameTest {
     private static final ZonedDateTime EPOCH_UTC =
         ZonedDateTime.ofInstant(Instant.ofEpochSecond (0), ZoneId.of ("UTC"));
 
-    @DataProvider(name="locales")
-    Object[][] data() {
+    private static Object[][] data() {
         return new Object[][] {
             {Locale.CHINESE,                        SIMPLIFIED_CHINESE},
             {Locale.SIMPLIFIED_CHINESE,             SIMPLIFIED_CHINESE},
@@ -62,11 +60,12 @@ public class ChineseTimeZoneNameTest {
         };
     }
 
-    @Test(dataProvider="locales")
+    @ParameterizedTest
+    @MethodSource("data")
     public void test_ChineseTimeZoneNames(Locale testLoc, Locale resourceLoc) {
-        assertEquals(DateTimeFormatter.ofPattern("z", testLoc).format(EPOCH_UTC),
-                DateTimeFormatter.ofPattern("z", resourceLoc).format(EPOCH_UTC));
-        assertEquals(DateTimeFormatter.ofPattern("zzzz", testLoc).format(EPOCH_UTC),
-                DateTimeFormatter.ofPattern("zzzz", resourceLoc).format(EPOCH_UTC));
+        assertEquals(DateTimeFormatter.ofPattern("z", resourceLoc).format(EPOCH_UTC),
+            DateTimeFormatter.ofPattern("z", testLoc).format(EPOCH_UTC));
+        assertEquals(DateTimeFormatter.ofPattern("zzzz", resourceLoc).format(EPOCH_UTC),
+            DateTimeFormatter.ofPattern("zzzz", testLoc).format(EPOCH_UTC));
     }
 }

--- a/test/jdk/sun/util/resources/cldr/Bug8202764.java
+++ b/test/jdk/sun/util/resources/cldr/Bug8202764.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,13 @@
 
  /*
  * @test
- * @bug 8202764
+ * @bug 8202764 8347841
  * @modules jdk.localedata
  * @summary Checks time zone names are consistent with aliased ids,
  *      between DateFormatSymbols.getZoneStrings() and getDisplayName()
  *      of TimeZone/ZoneId classes
- * @run testng/othervm Bug8202764
+ * @run junit/othervm Bug8202764
  */
-
-import static org.testng.Assert.assertEquals;
 
 import java.time.ZoneId;
 import java.time.format.TextStyle;
@@ -41,7 +39,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bug8202764 {
 
@@ -49,18 +48,19 @@ public class Bug8202764 {
     public void testAliasedTZs() {
         Set<String> zoneIds = ZoneId.getAvailableZoneIds();
         Arrays.stream(DateFormatSymbols.getInstance(Locale.US).getZoneStrings())
+            .filter(zone -> !ZoneId.SHORT_IDS.containsKey(zone[0]))
             .forEach(zone -> {
                 System.out.println(zone[0]);
                 TimeZone tz = TimeZone.getTimeZone(zone[0]);
-                assertEquals(zone[1], tz.getDisplayName(false, TimeZone.LONG, Locale.US));
-                assertEquals(zone[2], tz.getDisplayName(false, TimeZone.SHORT, Locale.US));
-                assertEquals(zone[3], tz.getDisplayName(true, TimeZone.LONG, Locale.US));
-                assertEquals(zone[4], tz.getDisplayName(true, TimeZone.SHORT, Locale.US));
+                assertEquals(tz.getDisplayName(false, TimeZone.LONG, Locale.US), zone[1]);
+                assertEquals(tz.getDisplayName(false, TimeZone.SHORT, Locale.US), zone[2]);
+                assertEquals(tz.getDisplayName(true, TimeZone.LONG, Locale.US), zone[3]);
+                assertEquals(tz.getDisplayName(true, TimeZone.SHORT, Locale.US), zone[4]);
                 if (zoneIds.contains(zone[0])) {
                     // Some of the ids, e.g. three-letter ids are not supported in ZoneId
                     ZoneId zi = tz.toZoneId();
-                    assertEquals(zone[5], zi.getDisplayName(TextStyle.FULL, Locale.US));
-                    assertEquals(zone[6], zi.getDisplayName(TextStyle.SHORT, Locale.US));
+                    assertEquals(zi.getDisplayName(TextStyle.FULL, Locale.US), zone[5]);
+                    assertEquals(zi.getDisplayName(TextStyle.SHORT, Locale.US), zone[6]);
                 }
             });
     }

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8181157 8202537 8234347 8236548  8261279 8293834
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
- * @run testng/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
+ * @run junit/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
  */
 
 import java.text.DateFormatSymbols;
@@ -37,16 +37,15 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.TimeZone;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@Test
 public class TimeZoneNamesTest {
 
-    @DataProvider(name="noResourceTZs")
-    Object[][] data() {
+    private static Object[][] data() {
         return new Object[][] {
             // tzid, locale, style, expected
 
@@ -196,19 +195,20 @@ public class TimeZoneNamesTest {
     }
 
 
-    @Test(dataProvider="noResourceTZs")
+    @ParameterizedTest
+    @MethodSource("data")
     public void test_tzNames(String tzid, Locale locale, String lstd, String sstd, String ldst, String sdst, String lgen, String sgen) {
         // Standard time
-        assertEquals(TimeZone.getTimeZone(tzid).getDisplayName(false, TimeZone.LONG, locale), lstd);
-        assertEquals(TimeZone.getTimeZone(tzid).getDisplayName(false, TimeZone.SHORT, locale), sstd);
+        assertEquals(lstd, TimeZone.getTimeZone(tzid).getDisplayName(false, TimeZone.LONG, locale));
+        assertEquals(sstd, TimeZone.getTimeZone(tzid).getDisplayName(false, TimeZone.SHORT, locale));
 
         // daylight saving time
-        assertEquals(TimeZone.getTimeZone(tzid).getDisplayName(true, TimeZone.LONG, locale), ldst);
-        assertEquals(TimeZone.getTimeZone(tzid).getDisplayName(true, TimeZone.SHORT, locale), sdst);
+        assertEquals(ldst, TimeZone.getTimeZone(tzid).getDisplayName(true, TimeZone.LONG, locale));
+        assertEquals(sdst, TimeZone.getTimeZone(tzid).getDisplayName(true, TimeZone.SHORT, locale));
 
         // generic name
-        assertEquals(ZoneId.of(tzid).getDisplayName(TextStyle.FULL, locale), lgen);
-        assertEquals(ZoneId.of(tzid).getDisplayName(TextStyle.SHORT, locale), sgen);
+        assertEquals(lgen, ZoneId.of(tzid).getDisplayName(TextStyle.FULL, locale));
+        assertEquals(sgen, ZoneId.of(tzid).getDisplayName(TextStyle.SHORT, locale));
     }
 
     // Make sure getZoneStrings() returns non-empty string array


### PR DESCRIPTION
Backporting from https://github.com/openjdk/jdk17u/commit/cb30cb3acfd935b637e7c0eb061f1415440b0436

Trivial merge conflict in copyright year.
Otherwise clean cherry-pick.

This is required for the next backport 8381379 as this updates the tests and makes the remaining tzdata2026c backports a little easier.

#### Testing
* `make images`
* `make run-test JVM_TEST_IMAGE_TARGETS= \
  TEST="\
test/jdk/sun/util/resources/TimeZone/Bug8139107.java \
test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java \
test/jdk/sun/util/resources/cldr/Bug8202764.java \
test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8380223](https://bugs.openjdk.org/browse/JDK-8380223) needs maintainer approval

### Issue
 * [JDK-8380223](https://bugs.openjdk.org/browse/JDK-8380223): Refactor test/jdk/sun/util/resources TestNG tests to JUnit (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3252/head:pull/3252` \
`$ git checkout pull/3252`

Update a local copy of the PR: \
`$ git checkout pull/3252` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3252`

View PR using the GUI difftool: \
`$ git pr show -t 3252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3252.diff">https://git.openjdk.org/jdk11u-dev/pull/3252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3252#issuecomment-5546942275)
</details>
