### PR TITLE
8375367: vmTestbase tests reported variable uninitialized by clang23

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d99ce15f](https://github.com/openjdk/jdk17u-dev/commit/d99ce15ff0b003dca9216f1f898c0c68d7817496) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Sergey Bylokhov on 8 Sep 2026 and had no reviewers.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8375367](https://bugs.openjdk.org/browse/JDK-8375367) needs maintainer approval

### Issue
 * [JDK-8375367](https://bugs.openjdk.org/browse/JDK-8375367): vmTestbase tests reported variable uninitialized by clang23 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3254/head:pull/3254` \
`$ git checkout pull/3254`

Update a local copy of the PR: \
`$ git checkout pull/3254` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3254`

View PR using the GUI difftool: \
`$ git pr show -t 3254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3254.diff">https://git.openjdk.org/jdk11u-dev/pull/3254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3254#issuecomment-5593453865)
</details>
