### PR TITLE
8357105: C2: compilation fails with "assert(false) failed: empty program detected during loop optimization"

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -1000,12 +1000,21 @@ bool StringConcat::validate_control_flow() {
         continue;
       }
 
-      // A test which leads to an uncommon trap which should be safe.
-      // Later this trap will be converted into a trap that restarts
+      // A test which leads to an uncommon trap. It is safe to convert the trap
+      // into a trap that restarts at the beginning as long as its test does not
+      // depend on intermediate results of the candidate chain.
       // at the beginning.
       if (otherproj->outcnt() == 1) {
         CallStaticJavaNode* call = otherproj->unique_out()->isa_CallStaticJava();
         if (call != NULL && call->_name != NULL && strcmp(call->_name, "uncommon_trap") == 0) {
+          // First check for dependency on a toString that is going away during stacked concats.
+          if (_multiple &&
+              ((v1->is_Proj() && is_SB_toString(v1->in(0)) && ctrl_path.member(v1->in(0))) ||
+               (v2->is_Proj() && is_SB_toString(v2->in(0)) && ctrl_path.member(v2->in(0))))) {
+            // iftrue -> if -> bool -> cmpp -> resproj -> tostring
+            fail = true;
+            break;
+          }
           // control flow leads to uct so should be ok
           _uncommon_traps.push(call);
           ctrl_path.push(call);

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsAppendUncommonTrap.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsAppendUncommonTrap.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8357105
+ * @summary Test stacked string concatenations where the toString result
+ *          of the first StringBuilder chain is wired into an uncommon trap
+ *          located in the second one.
+ * @run main/othervm compiler.stringopts.TestStackedConcatsAppendUncommonTrap
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsAppendUncommonTrap::*
+ *                   compiler.stringopts.TestStackedConcatsAppendUncommonTrap
+ */
+
+package compiler.stringopts;
+
+public class TestStackedConcatsAppendUncommonTrap {
+
+    public static void main (String... args) {
+        for (int i = 0; i < 10000; i++) {
+            String s = f(" ");
+            if (!s.equals("    ")) {
+                throw new RuntimeException("wrong result.");
+            }
+        }
+    }
+
+    static String f(String c) {
+        String s = " ";
+        s = new StringBuilder().append(s).append(s).toString();
+        s = new StringBuilder().append(s).append(s == c ? s : "  ").toString();
+        return s;
+    }
+}


### PR DESCRIPTION
Mostly clean backport of [JDK-8357105](https://bugs.openjdk.org/browse/JDK-8357105). Backport is not clean because JDK11 C++ uses `NULL`  instead of `nulllptr`.

(Reopens pr #3071 on top of latest `master, re-tested)

Tested on Linux with:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsAppendUncommonTrap.java
                                                         1     1     0     0   
==============================
TEST SUCCESS
```

And `gtest`:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   gtest:all/server                                    507   507     0     0   
==============================
TEST SUCCESS
```

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8357105](https://bugs.openjdk.org/browse/JDK-8357105) needs maintainer approval

### Issue
 * [JDK-8357105](https://bugs.openjdk.org/browse/JDK-8357105): C2: compilation fails with "assert(false) failed: empty program detected during loop optimization" (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/3258/head:pull/3258` \
`$ git checkout pull/3258`

Update a local copy of the PR: \
`$ git checkout pull/3258` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/3258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3258`

View PR using the GUI difftool: \
`$ git pr show -t 3258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/3258.diff">https://git.openjdk.org/jdk11u-dev/pull/3258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/3258#issuecomment-5638370800)
</details>
